### PR TITLE
Add .codedocs file and CodeDocs badge to README.md

### DIFF
--- a/.codedocs
+++ b/.codedocs
@@ -1,0 +1,46 @@
+# CodeDocs.xyz Configuration File
+
+# Optional project name, if left empty the GitHub repository name will be used.
+PROJECT_NAME = "The Kovri I2P Router Project"
+
+# One or more directories and files that contain example code to be included.
+EXAMPLE_PATH =
+
+# One or more directories and files to exclude from documentation generation.
+# Use relative paths with respect to the repository root directory.
+EXCLUDE = pkg build
+
+# One or more wildcard patterns to exclude files and directories from document
+# generation.
+EXCLUDE_PATTERNS =
+
+# One or more symbols to exclude from document generation. Symbols can be
+# namespaces, classes, or functions.
+EXCLUDE_SYMBOLS =
+
+# Override the default parser (language) used for each file extension.
+EXTENSION_MAPPING =
+
+# Set the wildcard patterns used to filter out the source-files.
+# If left blank the default is:
+# *.c, *.cc, *.cxx, *.cpp, *.c++, *.java, *.ii, *.ixx, *.ipp, *.i++, *.inl,
+# *.idl, *.ddl, *.odl, *.h, *.hh, *.hxx, *.hpp, *.h++, *.cs, *.d, *.php,
+# *.php4, *.php5, *.phtml, *.inc, *.m, *.markdown, *.md, *.mm, *.dox, *.py,
+# *.f90, *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf, *.qsf, *.as and *.js.
+FILE_PATTERNS          = *.c \
+                         *.cpp \
+                         *.h \
+                         *.py \
+                         *.md
+
+# Hide undocumented class members.
+HIDE_UNDOC_MEMBERS =
+
+# Hide undocumented classes.
+HIDE_UNDOC_CLASSES =
+
+# Specify a markdown page whose contents should be used as the main page
+# (index.html). This will override a page marked as \mainpage. For example, a
+# README.md file usually serves as a useful main page.
+USE_MDFILE_AS_MAINPAGE = README.md
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 2. The secure, private, untraceable C++ [I2P router](https://geti2p.net), forked from [i2pd](https://github.com/PurpleI2P/i2pd/tree/master).
 
 [![Build Status](https://travis-ci.org/monero-project/kovri.svg?branch=master)](https://travis-ci.org/monero-project/kovri)
+[![Documentation](https://codedocs.xyz/monero-project/kovri.svg)](https://codedocs.xyz/monero-project/kovri/)
 
 ## Disclaimer
 - Currently pre-alpha software; under heavy overhaul and development! Stick to branch ```master``` for stability.


### PR DESCRIPTION
Use the CodeDocs.xyz GitHub integration to automatically build the
doxygen documentation.

Fixes monero-project/kovri#69