### PR TITLE
SSUSession: resolve #65 + document payload types.

### DIFF
--- a/src/core/transport/SSUSession.cpp
+++ b/src/core/transport/SSUSession.cpp
@@ -622,10 +622,12 @@ void SSUSession::SendSessionConfirmed(
   htobe32buf(payload, signedOnTime);  // signed on time
   payload += 4;
   auto signatureLen = i2p::context.GetIdentity().GetSignatureLen();
+  // Add N bytes padding, currently uninterpreted
   size_t paddingSize = ((payload - buf) + signatureLen)%16;
-  if (paddingSize > 0)
+  if (paddingSize > 0) {
     paddingSize = 16 - paddingSize;
-  // TODO(unassigned): fill padding
+    i2p::crypto::RandBytes(payload, paddingSize);
+  }
   payload += paddingSize;  // padding size
   // signature
   // x,y, our IP, our port, remote IP, remote port,

--- a/src/core/transport/SSUSession.h
+++ b/src/core/transport/SSUSession.h
@@ -89,57 +89,57 @@ struct SSUSessionPacket {
         bodyptr(nullptr),
         bodylen(0) {}
 
-  // How many bytes long is the header (includes Extended options)
-  // @return n bytes denoting size of header
+  /// @brief How many bytes long is the header (includes Extended options)
+  /// @return n bytes denoting size of header
   size_t ComputeHeaderSize() const;
 
-  // Do we have extended options?
-  // @return true if we have extended options
+  /// @brief Do we have extended options?
+  /// @return true if we have extended options
   bool HasExtendedOptions() const;
 
-  // Extract the extended options from the SSUHeader
-  // @return true if successful otherwise false
+  /// @brief Extract the extended options from the SSUHeader
+  /// @return true if successful otherwise false
   bool ExtractExtendedOptions(SSUExtendedOptions & opts) const;
 
-  // Obtain the SSU payload type
-  // @return what type of ssu packet are we?
+  /// @brief Obtain the SSU payload type
+  /// @return what type of ssu packet are we?
   uint8_t GetPayloadType() const;
 
-  // @return true if the rekey flag is set
+  /// @return true if the rekey flag is set
   bool Rekey() const;
 
-  // Used for rekey and extended options
+  /// @brief Used for rekey and extended options
   uint8_t Flag() const;
 
-  // Set flag byte
+  /// @brief Sets flag byte
   void PutFlag(
       uint8_t f) const;
 
-  // Packet timestamp
-  // @return a four byte sending timestamp (seconds since the unix epoch).
+  /// @brief Packet timestamp
+  /// @return a four byte sending timestamp (seconds since the unix epoch).
   uint32_t Time() const;
 
-  // Put timestamp into packet header
+  /// @brief Puts timestamp into packet header
   void PutTime(uint32_t t) const;
 
-  // Get pointer to MAC
+  /// @brief Gets pointer to MAC
   uint8_t* MAC() const;
 
-  // Get pointer to begining of encrypted section
+  /// @brief Gets pointer to begining of encrypted section
   uint8_t* Encrypted() const;
 
-  // Get pointer to IV
+  /// @brief Gets pointer to IV
   uint8_t* IV() const;
 
-  // Parse SSU header
-  // @return true if valid header format otherwise false
+  /// @brief Parses SSU header
+  /// @return true if valid header format otherwise false
   bool ParseHeader();
 };
 
 const int SSU_CONNECT_TIMEOUT = 5;  // 5 seconds
 const int SSU_TERMINATION_TIMEOUT = 330;  // 5.5 minutes
 
-// payload types (4 bits)
+// Messages (payload types) (4 bits)
 const uint8_t PAYLOAD_TYPE_SESSION_REQUEST = 0;
 const uint8_t PAYLOAD_TYPE_SESSION_CREATED = 1;
 const uint8_t PAYLOAD_TYPE_SESSION_CONFIRMED = 2;
@@ -243,11 +243,13 @@ class SSUSession
   void PostI2NPMessages(
       std::vector<std::shared_ptr<I2NPMessage> > msgs);
 
-  // call for established session
+  /// @brief Call for established session
   void ProcessDecryptedMessage(
       uint8_t* buf,
       size_t len,
       const boost::asio::ip::udp::endpoint& senderEndpoint);
+
+  // Payload type 0: SessionRequest
 
   void ProcessSessionRequest(
       SSUSessionPacket& pkt,
@@ -255,15 +257,15 @@ class SSUSession
 
   void SendSessionRequest();
 
-  void SendRelayRequest(
-      uint32_t iTag,
-      const uint8_t* iKey);
+  // Payload type 1: SessionCreated
 
   void ProcessSessionCreated(
       SSUSessionPacket& pkt);
 
   void SendSessionCreated(
       const uint8_t* x);
+
+  // Payload type 2: SessionConfirmed
 
   void ProcessSessionConfirmed(
       SSUSessionPacket& pkt);
@@ -273,9 +275,20 @@ class SSUSession
       const uint8_t* ourAddress,
       size_t ourAddressLen);
 
+  // Payload type 3: RelayRequest
+
   void ProcessRelayRequest(
       SSUSessionPacket& pkt,
       const boost::asio::ip::udp::endpoint& from);
+
+  void SendRelayRequest(
+      uint32_t iTag,
+      const uint8_t* iKey);
+
+  // Payload type 4: RelayResponse
+
+  void ProcessRelayResponse(
+      SSUSessionPacket& pkt);
 
   void SendRelayResponse(
       uint32_t nonce,
@@ -283,24 +296,21 @@ class SSUSession
       const uint8_t* introKey,
       const boost::asio::ip::udp::endpoint& to);
 
+  // Payload type 5: RelayIntro
+
+  void ProcessRelayIntro(
+      SSUSessionPacket& pkt);
+
   void SendRelayIntro(
       SSUSession* session,
       const boost::asio::ip::udp::endpoint& from);
 
-  void ProcessRelayResponse(
-      SSUSessionPacket & pkt);
+  // Payload type 6: Data
 
-  void ProcessRelayIntro(
-      SSUSessionPacket & pkt);
+  void ProcessData(
+      SSUSessionPacket& pkt);
 
-  void Established();
-
-  void Failed();
-
-  void ScheduleConnectTimer();
-
-  void HandleConnectTimer(
-      const boost::system::error_code& ecode);
+  // Payload type 7: PeerTest
 
   void ProcessPeerTest(
       SSUSessionPacket& pkt,
@@ -314,15 +324,26 @@ class SSUSession
       bool toAddress = true,
       bool sendAddress = true);
 
-  void ProcessData(
-      SSUSessionPacket & pkt);
+  // Payload type 8: SessionDestroyed
 
   void SendSesionDestroyed();
+
+  // End payload types
+
+  void Established();
+
+  void Failed();
+
+  void ScheduleConnectTimer();
+
+  void HandleConnectTimer(
+      const boost::system::error_code& ecode);
 
   void Send(
       const uint8_t* buf,
       size_t size);
-  // with session key
+
+  // With session key
   void Send(
       uint8_t type,
       const uint8_t* payload,
@@ -335,7 +356,8 @@ class SSUSession
       const uint8_t* aesKey,
       const uint8_t* iv,
       const uint8_t* macKey);
-  // with session key
+
+  // With session key
   void FillHeaderAndEncrypt(
       uint8_t payloadType,
       uint8_t* buf,


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull request may be closed by the will of the maintainer.
- I give this submission freely and claim no ownership to its content.

*Place an X inside the bracket to confirm*
- [X] I confirm.

---

SSUSession: fill padding in SendSessionConfirmed.
* Resolves #65 

SSUSession: document SSU payload types. Refactor.
* Refactoring consisted of re-ordering function layout and fixing a few trivial style issues.
