### PR TITLE
Transports: fixes, refactor, improve logging.

### DIFF
--- a/src/client/I2PTunnel/I2PTunnel.cpp
+++ b/src/client/I2PTunnel/I2PTunnel.cpp
@@ -328,7 +328,7 @@ void I2PClientTunnelHandler::HandleStreamRequestComplete(
   } else {
     LogPrint(eLogError,
         "I2PClientTunnelHandler: ",
-        "I2P Client Tunnel Issue when creating the stream.",
+        "I2P Client Tunnel Issue when creating the stream. ",
         "Check the previous warnings for details.");
     Terminate();
   }

--- a/src/core/transport/NTCP.cpp
+++ b/src/core/transport/NTCP.cpp
@@ -32,6 +32,10 @@
 
 #include "NTCP.h"
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "NTCPSession.h"
 #include "NetworkDatabase.h"
 #include "RouterContext.h"
@@ -42,77 +46,64 @@
 namespace i2p {
 namespace transport {
 
-NTCPServer::NTCPServer(int)
+NTCPServer::NTCPServer(
+    std::size_t /*port*/)
     : m_IsRunning(false),
       m_Thread(nullptr),
       m_Work(m_Service),
       m_NTCPAcceptor(nullptr),
-      m_NTCPV6Acceptor(nullptr) {}
+      m_NTCPV6Acceptor(nullptr) {
+  LogPrint(eLogDebug, "NTCPServer: initializing");
+}
 
 NTCPServer::~NTCPServer() {
+  LogPrint(eLogDebug, "NTCPServer: destroying");
   Stop();
 }
 
 void NTCPServer::Start() {
   if (!m_IsRunning) {
+    LogPrint(eLogDebug, "NTCPServer: starting");
     m_IsRunning = true;
-    m_Thread = new std::thread(std::bind(&NTCPServer::Run, this));
-    // create acceptors
+    m_Thread = std::make_unique<std::thread>(std::bind(&NTCPServer::Run, this));
+    // Create acceptors
     auto addresses = context.GetRouterInfo().GetAddresses();
     for (auto& address : addresses) {
       if (address.transportStyle ==
-          i2p::data::RouterInfo::eTransportNTCP &&
-          address.host.is_v4()) {
-        m_NTCPAcceptor = new boost::asio::ip::tcp::acceptor(
-            m_Service,
-            boost::asio::ip::tcp::endpoint(
-              boost::asio::ip::tcp::v4(),
-              address.port));
-        LogPrint(eLogInfo, "NTCPServer: listening on port ", address.port);
+          i2p::data::RouterInfo::eTransportNTCP && address.host.is_v4()) {
+        m_NTCPAcceptor =
+          std::make_unique<boost::asio::ip::tcp::acceptor>(
+              m_Service,
+              boost::asio::ip::tcp::endpoint(
+                  boost::asio::ip::tcp::v4(),
+                  address.port));
         auto conn = std::make_shared<NTCPSession>(*this);
         m_NTCPAcceptor->async_accept(
             conn->GetSocket(),
             std::bind(
-              &NTCPServer::HandleAccept,
-              this,
-              conn,
-              std::placeholders::_1));
+                &NTCPServer::HandleAccept,
+                this,
+                conn,
+                std::placeholders::_1));
         if (context.SupportsV6()) {
-          m_NTCPV6Acceptor = new boost::asio::ip::tcp::acceptor(m_Service);
+          m_NTCPV6Acceptor =
+            std::make_unique<boost::asio::ip::tcp::acceptor>(m_Service);
           m_NTCPV6Acceptor->open(boost::asio::ip::tcp::v6());
           m_NTCPV6Acceptor->set_option(boost::asio::ip::v6_only(true));
           m_NTCPV6Acceptor->bind(boost::asio::ip::tcp::endpoint(
                 boost::asio::ip::tcp::v6(),
                 address.port));
           m_NTCPV6Acceptor->listen();
-          LogPrint(eLogInfo, "NTCPServer: listening V6 on port ", address.port);
-          auto conn = std::make_shared<NTCPSession> (*this);
+          auto conn = std::make_shared<NTCPSession>(*this);
           m_NTCPV6Acceptor->async_accept(
               conn->GetSocket(),
               std::bind(
-                &NTCPServer::HandleAcceptV6,
-                this,
-                conn,
-                std::placeholders::_1));
+                  &NTCPServer::HandleAcceptV6,
+                  this,
+                  conn,
+                  std::placeholders::_1));
         }
       }
-    }
-  }
-}
-
-void NTCPServer::Stop() {
-  m_NTCPSessions.clear();
-  if (m_IsRunning) {
-    m_IsRunning = false;
-    delete m_NTCPAcceptor;
-    m_NTCPAcceptor = nullptr;
-    delete m_NTCPV6Acceptor;
-    m_NTCPV6Acceptor = nullptr;
-    m_Service.stop();
-    if (m_Thread) {
-      m_Thread->join();
-      delete m_Thread;
-      m_Thread = nullptr;
     }
   }
 }
@@ -120,42 +111,20 @@ void NTCPServer::Stop() {
 void NTCPServer::Run() {
   while (m_IsRunning) {
     try {
+      LogPrint(eLogDebug, "NTCPServer: running ioservice");
       m_Service.run();
     } catch (std::exception& ex) {
-      LogPrint("NTCPServer: Run(): ", ex.what());
+      LogPrint(eLogError,
+          "NTCPServer: ioservice error: '", ex.what(), "'");
     }
   }
 }
 
-void NTCPServer::AddNTCPSession(
-    std::shared_ptr<NTCPSession> session) {
-  if (session) {
-    std::unique_lock<std::mutex> l(m_NTCPSessionsMutex);
-    m_NTCPSessions[session->GetRemoteIdentity().GetIdentHash()] = session;
-  }
-}
-
-void NTCPServer::RemoveNTCPSession(
-    std::shared_ptr<NTCPSession> session) {
-  if (session) {
-    std::unique_lock<std::mutex> l(m_NTCPSessionsMutex);
-    m_NTCPSessions.erase(session->GetRemoteIdentity().GetIdentHash());
-  }
-}
-
-std::shared_ptr<NTCPSession> NTCPServer::FindNTCPSession(
-    const i2p::data::IdentHash& ident) {
-  std::unique_lock<std::mutex> l(m_NTCPSessionsMutex);
-  auto it = m_NTCPSessions.find(ident);
-  if (it != m_NTCPSessions.end())
-    return it->second;
-  return nullptr;
-}
-
 void NTCPServer::HandleAccept(
     std::shared_ptr<NTCPSession> conn,
-    const boost::system::error_code& error) {
-  if (!error) {
+    const boost::system::error_code& ecode) {
+  if (!ecode) {
+    LogPrint(eLogDebug, "NTCPServer: handling accepted connection");
     boost::system::error_code ec;
     auto ep = conn->GetSocket().remote_endpoint(ec);
     if (!ec) {
@@ -176,25 +145,29 @@ void NTCPServer::HandleAccept(
         conn->ServerLogin();
     } else {
       LogPrint(eLogError,
-          "NTCPServer: HandleAccept(): ", ec.message());
+          "NTCPServer: HandleAccept() remote endpoint: ", ec.message());
     }
+  } else {
+    LogPrint(eLogError,
+        "NTCPServer: HandleAccept(): '", ecode.message(), "'");
   }
-  if (error != boost::asio::error::operation_aborted) {
-    conn = std::make_shared<NTCPSession> (*this);
+  if (ecode != boost::asio::error::operation_aborted) {
+    conn = std::make_shared<NTCPSession>(*this);
     m_NTCPAcceptor->async_accept(
         conn->GetSocket(),
         std::bind(
-          &NTCPServer::HandleAccept,
-          this,
-          conn,
-          std::placeholders::_1));
+            &NTCPServer::HandleAccept,
+            this,
+            conn,
+            std::placeholders::_1));
   }
 }
 
 void NTCPServer::HandleAcceptV6(
     std::shared_ptr<NTCPSession> conn,
-    const boost::system::error_code& error) {
-  if (!error) {
+    const boost::system::error_code& ecode) {
+  if (!ecode) {
+    LogPrint(eLogDebug, "NTCPServer: handling V6 accepted connection");
     boost::system::error_code ec;
     auto ep = conn->GetSocket().remote_endpoint(ec);
     if (!ec) {
@@ -215,46 +188,55 @@ void NTCPServer::HandleAcceptV6(
       if (conn)
         conn->ServerLogin();
     } else {
-      LogPrint(eLogError, "NTCPServer: HandleAcceptV6(): ", ec.message());
+      LogPrint(eLogError,
+          "NTCPServer: HandleAcceptV6() remote endpoint: ", ec.message());
     }
+  } else {
+    LogPrint(eLogError,
+        "NTCPServer: HandleAcceptV6(): '", ecode.message(), "'");
   }
-  if (error != boost::asio::error::operation_aborted) {
-    conn = std::make_shared<NTCPSession> (*this);
+  if (ecode != boost::asio::error::operation_aborted) {
+    conn = std::make_shared<NTCPSession>(*this);
     m_NTCPV6Acceptor->async_accept(
         conn->GetSocket(),
         std::bind(
-          &NTCPServer::HandleAcceptV6,
-          this,
-          conn,
-          std::placeholders::_1));
+            &NTCPServer::HandleAcceptV6,
+            this,
+            conn,
+            std::placeholders::_1));
   }
 }
 
 void NTCPServer::Connect(
     const boost::asio::ip::address& address,
-    int port,
+    std::size_t port,
     std::shared_ptr<NTCPSession> conn) {
   LogPrint(eLogInfo,
-      "NTCPServer: connecting to ", address , ":",  port);
+      "NTCPServer: connecting to [",
+      context.GetRouterInfo().GetIdentHashAbbreviation(), "] ",
+      address , ":",  port);
+
   m_Service.post([conn, this]() {
       this->AddNTCPSession(conn);
-    });
+  });
   conn->GetSocket().async_connect(
       boost::asio::ip::tcp::endpoint(
-        address,
-        port),
+          address,
+          port),
       std::bind(
-        &NTCPServer::HandleConnect,
-        this,
-        std::placeholders::_1,
-        conn));
+          &NTCPServer::HandleConnect,
+          this,
+          conn,
+          std::placeholders::_1));
 }
 
 void NTCPServer::HandleConnect(
-    const boost::system::error_code& ecode,
-    std::shared_ptr<NTCPSession> conn) {
+    std::shared_ptr<NTCPSession> conn,
+    const boost::system::error_code& ecode) {
   if (ecode) {
-    LogPrint(eLogError, "NTCPServer: connect error: ", ecode.message());
+    LogPrint(eLogError,
+        "NTCPServer: ", conn->GetSocket().remote_endpoint(),
+        " connect error '", ecode.message(), "'");
     if (ecode != boost::asio::error::operation_aborted)
       i2p::data::netdb.SetUnreachable(
           conn->GetRemoteIdentity().GetIdentHash(),
@@ -262,8 +244,8 @@ void NTCPServer::HandleConnect(
     conn->Terminate();
   } else {
     LogPrint(eLogInfo,
-        "NTCPServer: connected to ",  conn->GetSocket().remote_endpoint());
-    if (conn->GetSocket().local_endpoint().protocol () ==
+        "NTCPServer: connected to ", conn->GetSocket().remote_endpoint());
+    if (conn->GetSocket().local_endpoint().protocol() ==
         boost::asio::ip::tcp::v6())  // ipv6
       context.UpdateNTCPV6Address(
           conn->GetSocket().local_endpoint().address());
@@ -271,13 +253,61 @@ void NTCPServer::HandleConnect(
   }
 }
 
+void NTCPServer::AddNTCPSession(
+    std::shared_ptr<NTCPSession> session) {
+  if (session) {
+    LogPrint(eLogDebug,
+        "NTCPServer: ", session->GetSocket().remote_endpoint(),
+        ", adding NTCP session");
+    std::unique_lock<std::mutex> l(m_NTCPSessionsMutex);
+    m_NTCPSessions[session->GetRemoteIdentity().GetIdentHash()] = session;
+  }
+}
+
+void NTCPServer::RemoveNTCPSession(
+    std::shared_ptr<NTCPSession> session) {
+  if (session) {
+    LogPrint(eLogDebug,
+        "NTCPServer: ", session->GetSocket().remote_endpoint(),
+        ", removing NTCP session");
+    std::unique_lock<std::mutex> l(m_NTCPSessionsMutex);
+    m_NTCPSessions.erase(session->GetRemoteIdentity().GetIdentHash());
+  }
+}
+
+std::shared_ptr<NTCPSession> NTCPServer::FindNTCPSession(
+    const i2p::data::IdentHash& ident) {
+  LogPrint(eLogDebug, "NTCPServer: finding NTCP session");
+  std::unique_lock<std::mutex> l(m_NTCPSessionsMutex);
+  auto it = m_NTCPSessions.find(ident);
+  if (it != m_NTCPSessions.end())
+    return it->second;
+  return nullptr;
+}
+
 void NTCPServer::Ban(
-    const boost::asio::ip::address& addr) {
+    const std::shared_ptr<NTCPSession>& session) {
   uint32_t ts = i2p::util::GetSecondsSinceEpoch();
-  m_BanList[addr] = ts + NTCP_BAN_EXPIRATION_TIMEOUT;
+  m_BanList[session->GetRemoteEndpoint().address()] =
+    ts + static_cast<std::size_t>(NTCPTimeoutLength::ban_expiration);
   LogPrint(eLogInfo,
-      "NTCPServer: ", addr, " has been banned for ",
-      NTCP_BAN_EXPIRATION_TIMEOUT, " seconds");
+      "NTCPServer:", session->GetFormattedSessionInfo(), "has been banned for ",
+      static_cast<std::size_t>(NTCPTimeoutLength::ban_expiration), " seconds");
+}
+
+void NTCPServer::Stop() {
+  LogPrint(eLogDebug, "NTCPServer: stopping");
+  m_NTCPSessions.clear();
+  if (m_IsRunning) {
+    m_IsRunning = false;
+    m_NTCPAcceptor.reset(nullptr);
+    m_NTCPV6Acceptor.reset(nullptr);
+    m_Service.stop();
+    if (m_Thread) {
+      m_Thread->join();
+      m_Thread.reset(nullptr);
+    }
+  }
 }
 
 }  // namespace transport

--- a/src/core/transport/NTCP.h
+++ b/src/core/transport/NTCP.h
@@ -105,6 +105,7 @@ class NTCPServer {
   boost::asio::io_service m_Service;
   boost::asio::io_service::work m_Work;
 
+  boost::asio::ip::tcp::endpoint m_NTCPEndpoint, m_NTCPEndpointV6;
   std::unique_ptr<boost::asio::ip::tcp::acceptor> m_NTCPAcceptor, m_NTCPV6Acceptor;
 
   std::mutex m_NTCPSessionsMutex;

--- a/src/core/transport/NTCP.h
+++ b/src/core/transport/NTCP.h
@@ -35,9 +35,11 @@
 
 #include <boost/asio.hpp>
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -51,8 +53,9 @@ namespace transport {
 
 class NTCPServer {
  public:
-  NTCPServer(
-      int port);
+  explicit NTCPServer(
+      std::size_t port);
+
   ~NTCPServer();
 
   void Start();
@@ -70,7 +73,7 @@ class NTCPServer {
 
   void Connect(
       const boost::asio::ip::address& address,
-      int port,
+      std::size_t port,
       std::shared_ptr<NTCPSession> conn);
 
   boost::asio::io_service& GetService() {
@@ -78,37 +81,40 @@ class NTCPServer {
   }
 
   void Ban(
-      const boost::asio::ip::address& addr);
+      const std::shared_ptr<NTCPSession>& session);
 
  private:
   void Run();
 
   void HandleAccept(
       std::shared_ptr<NTCPSession> conn,
-      const boost::system::error_code& error);
+      const boost::system::error_code& ecode);
 
   void HandleAcceptV6(
       std::shared_ptr<NTCPSession> conn,
-      const boost::system::error_code& error);
+      const boost::system::error_code& ecode);
 
   void HandleConnect(
-      const boost::system::error_code& ecode,
-      std::shared_ptr<NTCPSession> conn);
+      std::shared_ptr<NTCPSession> conn,
+      const boost::system::error_code& ecode);
 
  private:
   bool m_IsRunning;
-  std::thread* m_Thread;
+  std::unique_ptr<std::thread> m_Thread;
+
   boost::asio::io_service m_Service;
   boost::asio::io_service::work m_Work;
-  boost::asio::ip::tcp::acceptor* m_NTCPAcceptor,
-                                  *m_NTCPV6Acceptor;
+
+  std::unique_ptr<boost::asio::ip::tcp::acceptor> m_NTCPAcceptor, m_NTCPV6Acceptor;
+
   std::mutex m_NTCPSessionsMutex;
-  std::map<i2p::data::IdentHash, std::shared_ptr<NTCPSession> > m_NTCPSessions;
+  std::map<i2p::data::IdentHash, std::shared_ptr<NTCPSession>> m_NTCPSessions;
+
   // IP -> ban expiration time in seconds
   std::map<boost::asio::ip::address, uint32_t> m_BanList;
 
  public:
-  // for HTTP/I2PControl
+  // for I2PControl
   const decltype(m_NTCPSessions)& GetNTCPSessions() const {
     return m_NTCPSessions;
   }

--- a/src/core/transport/SSU.cpp
+++ b/src/core/transport/SSU.cpp
@@ -686,7 +686,7 @@ void SSUServer::SchedulePeerTestsCleanupTimer() {
 
 void SSUServer::HandlePeerTestsCleanupTimer(
     const boost::system::error_code& ecode) {
-  LogPrint(eLogDebug, "SSUServer: handling PeerTests cleanup timer()");
+  LogPrint(eLogDebug, "SSUServer: handling PeerTests cleanup timer");
   if (ecode != boost::asio::error::operation_aborted) {
     int numDeleted = 0;
     uint64_t ts = i2p::util::GetMillisecondsSinceEpoch();

--- a/src/core/transport/SSU.cpp
+++ b/src/core/transport/SSU.cpp
@@ -36,10 +36,13 @@
 
 #include <string.h>
 
+#include <cstdint>
 #include <list>
-#include <vector>
+#include <memory>
 #include <set>
+#include <vector>
 
+#include "SSU.h"
 #include "crypto/Rand.h"
 #include "NetworkDatabase.h"
 #include "RouterContext.h"
@@ -49,7 +52,8 @@
 namespace i2p {
 namespace transport {
 
-SSUServer::SSUServer(int port)
+SSUServer::SSUServer(
+    std::size_t port)
     : m_Thread(nullptr),
       m_ThreadV6(nullptr),
       m_ReceiversThread(nullptr),
@@ -62,6 +66,7 @@ SSUServer::SSUServer(int port)
       m_SocketV6(m_ReceiversService),
       m_IntroducersUpdateTimer(m_Service),
       m_PeerTestsCleanupTimer(m_Service) {
+  LogPrint(eLogDebug, "SSUServer: initializing");
   m_Socket.set_option(boost::asio::socket_base::receive_buffer_size(65535));
   m_Socket.set_option(boost::asio::socket_base::send_buffer_size(65535));
   if (context.SupportsV6()) {
@@ -73,34 +78,37 @@ SSUServer::SSUServer(int port)
   }
 }
 
-SSUServer::~SSUServer() {}
+SSUServer::~SSUServer() {
+  LogPrint(eLogDebug, "SSUServer: destroying");
+}
 
 void SSUServer::Start() {
+  LogPrint(eLogDebug, "SSUServer: starting");
   m_IsRunning = true;
   m_ReceiversThread =
-    new std::thread(
-      std::bind(
-        &SSUServer::RunReceivers,
-        this));
+    std::make_unique<std::thread>(
+        std::bind(
+          &SSUServer::RunReceivers,
+          this));
   m_Thread =
-    new std::thread(
-      std::bind(
-        &SSUServer::Run,
-        this));
+    std::make_unique<std::thread>(
+        std::bind(
+            &SSUServer::Run,
+            this));
   m_ReceiversService.post(
       std::bind(
-        &SSUServer::Receive,
-        this));
+          &SSUServer::Receive,
+          this));
   if (context.SupportsV6()) {
     m_ThreadV6 =
-      new std::thread(
+      std::make_unique<std::thread>(
           std::bind(
-            &SSUServer::RunV6,
-            this));
+              &SSUServer::RunV6,
+              this));
     m_ReceiversService.post(
         std::bind(
-          &SSUServer::ReceiveV6,
-          this));
+            &SSUServer::ReceiveV6,
+            this));
   }
   SchedulePeerTestsCleanupTimer();
   // wait for 30 seconds and decide if we need introducers
@@ -108,6 +116,7 @@ void SSUServer::Start() {
 }
 
 void SSUServer::Stop() {
+  LogPrint(eLogDebug, "SSUServer: stopping");
   DeleteAllSessions();
   m_IsRunning = false;
   m_Service.stop();
@@ -117,28 +126,27 @@ void SSUServer::Stop() {
   m_ReceiversService.stop();
   if (m_ReceiversThread) {
     m_ReceiversThread->join();
-    delete m_ReceiversThread;
-    m_ReceiversThread = nullptr;
+    m_ReceiversThread.reset(nullptr);
   }
   if (m_Thread) {
     m_Thread->join();
-    delete m_Thread;
-    m_Thread = nullptr;
+    m_Thread.reset(nullptr);
   }
   if (m_ThreadV6) {
     m_ThreadV6->join();
-    delete m_ThreadV6;
-    m_ThreadV6 = nullptr;
+    m_ThreadV6.reset(nullptr);
   }
 }
 
 void SSUServer::Run() {
   while (m_IsRunning) {
     try {
+      LogPrint(eLogDebug, "SSUServer: running ioservice");
       m_Service.run();
     }
     catch (std::exception& ex) {
-      LogPrint(eLogError, "SSUServer::Run(): ", ex.what());
+      LogPrint(eLogError,
+          "SSUServer: Run() ioservice error: '", ex.what(), "'");
     }
   }
 }
@@ -146,10 +154,12 @@ void SSUServer::Run() {
 void SSUServer::RunV6() {
   while (m_IsRunning) {
     try {
+      LogPrint(eLogDebug, "SSUServer: running V6 ioservice");
       m_ServiceV6.run();
     }
     catch (std::exception& ex) {
-      LogPrint(eLogError, "SSUServer::RunV6(): ", ex.what());
+      LogPrint(eLogError,
+          "SSUServer: RunV6() ioservice error: '", ex.what(), "'");
     }
   }
 }
@@ -157,10 +167,12 @@ void SSUServer::RunV6() {
 void SSUServer::RunReceivers() {
   while (m_IsRunning) {
     try {
+      LogPrint(eLogDebug, "SSUServer: running receivers ioservice");
       m_ReceiversService.run();
     }
     catch (std::exception& ex) {
-      LogPrint(eLogError, "SSUServer:RunReceivers(): ", ex.what());
+      LogPrint(eLogError,
+          "SSUServer: RunReceivers() ioservice error: '", ex.what(), "'");
     }
   }
 }
@@ -168,11 +180,13 @@ void SSUServer::RunReceivers() {
 void SSUServer::AddRelay(
     uint32_t tag,
     const boost::asio::ip::udp::endpoint& relay) {
+  LogPrint(eLogDebug, "SSUServer: adding relay");
   m_Relays[tag] = relay;
 }
 
 std::shared_ptr<SSUSession> SSUServer::FindRelaySession(
     uint32_t tag) {
+  LogPrint(eLogDebug, "SSUServer: finding relay session");
   auto it = m_Relays.find(tag);
   if (it != m_Relays.end())
     return FindSession(it->second);
@@ -183,63 +197,67 @@ void SSUServer::Send(
     const uint8_t* buf,
     size_t len,
     const boost::asio::ip::udp::endpoint& to) {
+  LogPrint(eLogDebug, "SSUServer: sending data");
   if (to.protocol() == boost::asio::ip::udp::v4()) {
     try {
       m_Socket.send_to(
           boost::asio::buffer(
-            buf,
-            len),
+              buf,
+              len),
           to);
     } catch (const std::exception& ex) {
-      LogPrint(eLogError, "SSUServer: send error: ", ex.what());
+      LogPrint(eLogError, "SSUServer: send error: '", ex.what(), "'");
     }
   } else {
       try {
         m_SocketV6.send_to(
             boost::asio::buffer(
-              buf,
-              len),
+                buf,
+                len),
             to);
       } catch (const std::exception& ex) {
-        LogPrint(eLogError, "SSUServer: V6 send error: ", ex.what());
+        LogPrint(eLogError, "SSUServer: V6 send error: '", ex.what(), "'");
       }
     }
 }
 
 void SSUServer::Receive() {
+  LogPrint(eLogDebug, "SSUServer: receiving data");
   SSUPacket* packet = new SSUPacket();
   m_Socket.async_receive_from(
       boost::asio::buffer(
-        packet->buf,
-        SSU_MTU_V4),
+          packet->buf,
+          SSU_MTU_V4),
       packet->from,
       std::bind(
-        &SSUServer::HandleReceivedFrom,
-        this,
-        std::placeholders::_1,
-        std::placeholders::_2,
-        packet));
+          &SSUServer::HandleReceivedFrom,
+          this,
+          std::placeholders::_1,
+          std::placeholders::_2,
+          packet));
 }
 
 void SSUServer::ReceiveV6() {
+  LogPrint(eLogDebug, "SSUServer: V6: receiving data");
   SSUPacket* packet = new SSUPacket();
   m_SocketV6.async_receive_from(
       boost::asio::buffer(
-        packet->buf,
-        SSU_MTU_V6),
+          packet->buf,
+          SSU_MTU_V6),
       packet->from,
       std::bind(
-        &SSUServer::HandleReceivedFromV6,
-        this,
-        std::placeholders::_1,
-        std::placeholders::_2,
-        packet));
+          &SSUServer::HandleReceivedFromV6,
+          this,
+          std::placeholders::_1,
+          std::placeholders::_2,
+          packet));
 }
 
 void SSUServer::HandleReceivedFrom(
     const boost::system::error_code& ecode,
     std::size_t bytes_transferred,
     SSUPacket* packet) {
+  LogPrint(eLogDebug, "SSUServer: handling received data");
   if (!ecode) {
     packet->len = bytes_transferred;
     std::vector<SSUPacket *> packets;
@@ -250,17 +268,17 @@ void SSUServer::HandleReceivedFrom(
       packet = new SSUPacket();
       packet->len = m_Socket.receive_from(
           boost::asio::buffer(
-            packet->buf,
-            SSU_MTU_V4),
+              packet->buf,
+              SSU_MTU_V4),
           packet->from);
       packets.push_back(packet);
       moreBytes = m_Socket.available();
     }
     m_Service.post(
         std::bind(
-          &SSUServer::HandleReceivedPackets,
-          this,
-          packets));
+            &SSUServer::HandleReceivedPackets,
+            this,
+            packets));
     Receive();
   } else {
     LogPrint("SSUServer: receive error: ", ecode.message());
@@ -272,6 +290,7 @@ void SSUServer::HandleReceivedFromV6(
     const boost::system::error_code& ecode,
     std::size_t bytes_transferred,
     SSUPacket* packet) {
+  LogPrint(eLogDebug, "SSUServer: V6: handling received data");
   if (!ecode) {
     packet->len = bytes_transferred;
     std::vector<SSUPacket *> packets;
@@ -281,17 +300,17 @@ void SSUServer::HandleReceivedFromV6(
       packet = new SSUPacket();
       packet->len = m_SocketV6.receive_from(
           boost::asio::buffer(
-            packet->buf,
-            SSU_MTU_V6),
+              packet->buf,
+              SSU_MTU_V6),
           packet->from);
       packets.push_back(packet);
       moreBytes = m_SocketV6.available();
     }
     m_ServiceV6.post(
         std::bind(
-          &SSUServer::HandleReceivedPackets,
-          this,
-          packets));
+            &SSUServer::HandleReceivedPackets,
+            this,
+            packets));
     ReceiveV6();
   } else {
     LogPrint("SSUServer: V6 receive error: ", ecode.message());
@@ -301,30 +320,33 @@ void SSUServer::HandleReceivedFromV6(
 
 void SSUServer::HandleReceivedPackets(
     std::vector<SSUPacket *> packets) {
+  LogPrint(eLogDebug, "SSUServer: handling received packets");
   std::shared_ptr<SSUSession> session;
-  for (auto it1 : packets) {
-    auto packet = it1;
+  for (auto packets_it : packets) {
+    auto packet = packets_it;
     try {
       // we received packet for other session than previous
       if (!session || session->GetRemoteEndpoint() != packet->from) {
-        if (session) session->FlushData();
-        auto it = m_Sessions.find(packet->from);
-        if (it != m_Sessions.end())
-          session = it->second;
+        if (session)
+          session->FlushData();
+        auto session_it = m_Sessions.find(packet->from);
+        if (session_it != m_Sessions.end())
+          session = session_it->second;
         if (!session) {
-          session = std::make_shared<SSUSession> (*this, packet->from);
+          session = std::make_shared<SSUSession>(*this, packet->from);
           session->WaitForConnect(); {
             std::unique_lock<std::mutex> l(m_SessionsMutex);
             m_Sessions[packet->from] = session;
           }
           LogPrint(eLogInfo,
-              "SSUServer: new SSU session from ", packet->from.address().to_string(),
-              ":", packet->from.port(), " created");
+              "SSUServer: created new SSU session from ",
+              session->GetRemoteEndpoint());
         }
       }
       session->ProcessNextMessage(packet->buf, packet->len, packet->from);
     } catch (std::exception& ex) {
-      LogPrint(eLogError, "SSUServer::HandleReceivedPackets(): ", ex.what());
+      LogPrint(eLogError,
+          "SSUServer: HandleReceivedPackets(): '", ex.what(), "'");
       if (session)
         session->FlushData();
       session = nullptr;
@@ -337,6 +359,7 @@ void SSUServer::HandleReceivedPackets(
 
 std::shared_ptr<SSUSession> SSUServer::FindSession(
     std::shared_ptr<const i2p::data::RouterInfo> router) const {
+  LogPrint(eLogDebug, "SSUServer: finding session from RI");
   if (!router)
     return nullptr;
   auto address = router->GetSSUAddress(true);  // v4 only
@@ -344,8 +367,8 @@ std::shared_ptr<SSUSession> SSUServer::FindSession(
     return nullptr;
   auto session = FindSession(
       boost::asio::ip::udp::endpoint(
-        address->host,
-        address->port));
+          address->host,
+          address->port));
   if (session || !context.SupportsV6())
     return session;
   // try v6
@@ -354,13 +377,15 @@ std::shared_ptr<SSUSession> SSUServer::FindSession(
     return nullptr;
   return FindSession(
       boost::asio::ip::udp::endpoint(
-        address->host,
-        address->port));
+          address->host,
+          address->port));
 }
 
 std::shared_ptr<SSUSession> SSUServer::FindSession(
-    const boost::asio::ip::udp::endpoint& e) const {
-  auto it = m_Sessions.find(e);
+    const boost::asio::ip::udp::endpoint& ep) const {
+  LogPrint(eLogDebug,
+      "SSUServer: finding session from endpoint)");
+  auto it = m_Sessions.find(ep);
   if (it != m_Sessions.end())
     return it->second;
   else
@@ -370,6 +395,7 @@ std::shared_ptr<SSUSession> SSUServer::FindSession(
 std::shared_ptr<SSUSession> SSUServer::GetSession(
     std::shared_ptr<const i2p::data::RouterInfo> router,
     bool peerTest) {
+  LogPrint(eLogDebug, "SSUServer: getting session");
   std::shared_ptr<SSUSession> session;
   if (router) {
     auto address = router->GetSSUAddress(!context.SupportsV6());
@@ -382,7 +408,7 @@ std::shared_ptr<SSUSession> SSUServer::GetSession(
         session = it->second;
       } else {
         // otherwise create new session
-        session = std::make_shared<SSUSession> (
+        session = std::make_shared<SSUSession>(
             *this,
             remoteEndpoint,
             router,
@@ -390,12 +416,12 @@ std::shared_ptr<SSUSession> SSUServer::GetSession(
           std::unique_lock<std::mutex> l(m_SessionsMutex);
           m_Sessions[remoteEndpoint] = session;
         }
+        session->SetRemoteIdentHashAbbreviation();
         if (!router->UsesIntroducer()) {
           // connect directly
-          LogPrint("SSUServer: creating new SSU session to [",
-              router->GetIdentHashAbbreviation(), "] ",
-              remoteEndpoint.address().to_string(), ":",
-              remoteEndpoint.port());
+          LogPrint(eLogInfo,
+              "SSUServer: creating new session to",
+              session->GetFormattedSessionInfo());
           session->Connect();
         } else {
           // connect through introducer
@@ -408,22 +434,25 @@ std::shared_ptr<SSUSession> SSUServer::GetSession(
               introducer = &(address->introducers[i]);
               it = m_Sessions.find(
                   boost::asio::ip::udp::endpoint(
-                    introducer->iHost,
-                    introducer->iPort));
+                      introducer->iHost,
+                      introducer->iPort));
               if (it != m_Sessions.end()) {
                 introducerSession = it->second;
                 break;
               }
             }
             if (introducerSession) {  // session found
-              LogPrint("SSUServer: session to introducer already exists");
+              LogPrint(eLogInfo,
+                  "SSUServer: ", introducer->iHost, ":", introducer->iPort,
+                  "session to introducer already exists");
             } else {  // create new
-              LogPrint("SSUServer: creating new session to introducer");
+              LogPrint(eLogInfo,
+                  "SSUServer: creating new session to introducer");
               introducer = &(address->introducers[0]);  // TODO(unassigned): ???
               boost::asio::ip::udp::endpoint introducerEndpoint(
                   introducer->iHost,
                   introducer->iPort);
-              introducerSession = std::make_shared<SSUSession> (
+              introducerSession = std::make_shared<SSUSession>(
                   *this,
                   introducerEndpoint,
                   router);
@@ -432,7 +461,8 @@ std::shared_ptr<SSUSession> SSUServer::GetSession(
             }
             // introduce
             LogPrint("SSUServer: introducing new SSU session to [",
-                router->GetIdentHashAbbreviation(), "] through introducer ",
+                router->GetIdentHashAbbreviation(), "] through introducer [",
+                introducerSession->GetRemoteIdentHashAbbreviation(), "] ",
                 introducer->iHost, ":",
                 introducer->iPort);
             session->WaitForIntroduction();
@@ -463,6 +493,7 @@ std::shared_ptr<SSUSession> SSUServer::GetSession(
 
 void SSUServer::DeleteSession(
     std::shared_ptr<SSUSession> session) {
+  LogPrint(eLogDebug, "SSUServer: deleting session");
   if (session) {
     session->Close();
     std::unique_lock<std::mutex> l(m_SessionsMutex);
@@ -471,6 +502,7 @@ void SSUServer::DeleteSession(
 }
 
 void SSUServer::DeleteAllSessions() {
+  LogPrint(eLogDebug, "SSUServer: deleting all sessions");
   std::unique_lock<std::mutex> l(m_SessionsMutex);
   for (auto it : m_Sessions)
     it.second->Close();
@@ -480,16 +512,15 @@ void SSUServer::DeleteAllSessions() {
 template<typename Filter>
 std::shared_ptr<SSUSession> SSUServer::GetRandomSession(
     Filter filter) {
-  std::vector<std::shared_ptr<SSUSession> > filteredSessions;
+  LogPrint(eLogDebug, "SSUServer: getting random session");
+  std::vector<std::shared_ptr<SSUSession>> filteredSessions;
   for (auto s : m_Sessions)
     if (filter (s.second))
       filteredSessions.push_back(s.second);
   if (filteredSessions.size() > 0) {
     size_t s = filteredSessions.size();
     size_t ind =
-      i2p::crypto::RandInRange<size_t>(
-          size_t{0},
-          s - 1);
+      i2p::crypto::RandInRange<size_t>(0, s - 1);
     return filteredSessions[ind];
   }
   return nullptr;
@@ -497,6 +528,7 @@ std::shared_ptr<SSUSession> SSUServer::GetRandomSession(
 
 std::shared_ptr<SSUSession> SSUServer::GetRandomEstablishedSession(
     std::shared_ptr<const SSUSession> excluded) {
+  LogPrint(eLogDebug, "SSUServer: getting random established session");
   return GetRandomSession(
       [excluded](std::shared_ptr<SSUSession> session)->bool {
       return session->GetState() == eSessionStateEstablished &&
@@ -507,6 +539,7 @@ std::shared_ptr<SSUSession> SSUServer::GetRandomEstablishedSession(
 
 std::set<SSUSession *> SSUServer::FindIntroducers(
     int maxNumIntroducers) {
+  LogPrint(eLogDebug, "SSUServer: finding introducers");
   uint32_t ts = i2p::util::GetSecondsSinceEpoch();
   std::set<SSUSession *> ret;
   for (int i = 0; i < maxNumIntroducers; i++) {
@@ -527,18 +560,21 @@ std::set<SSUSession *> SSUServer::FindIntroducers(
 }
 
 void SSUServer::ScheduleIntroducersUpdateTimer() {
+  LogPrint(eLogDebug, "SSUServer: scheduling introducers update timer");
   m_IntroducersUpdateTimer.expires_from_now(
       boost::posix_time::seconds(
-        SSU_KEEP_ALIVE_INTERVAL));
+          SSU_KEEP_ALIVE_INTERVAL));
   m_IntroducersUpdateTimer.async_wait(
       std::bind(
-        &SSUServer::HandleIntroducersUpdateTimer,
-        this,
-        std::placeholders::_1));
+          &SSUServer::HandleIntroducersUpdateTimer,
+          this,
+          std::placeholders::_1));
 }
 
 void SSUServer::HandleIntroducersUpdateTimer(
     const boost::system::error_code& ecode) {
+  LogPrint(eLogDebug,
+      "SSUServer: handling introducers update timer");
   if (ecode != boost::asio::error::operation_aborted) {
     // timeout expired
     if (i2p::context.GetStatus() == eRouterStatusTesting) {
@@ -593,6 +629,7 @@ void SSUServer::NewPeerTest(
     uint32_t nonce,
     PeerTestParticipant role,
     std::shared_ptr<SSUSession> session) {
+  LogPrint(eLogDebug, "SSUServer: new peer test");
   m_PeerTests[nonce] = {
     i2p::util::GetMillisecondsSinceEpoch(),
     role,
@@ -602,6 +639,7 @@ void SSUServer::NewPeerTest(
 
 PeerTestParticipant SSUServer::GetPeerTestParticipant(
     uint32_t nonce) {
+  LogPrint(eLogDebug, "SSUServer: getting PeerTest participant");
   auto it = m_PeerTests.find(nonce);
   if (it != m_PeerTests.end())
     return it->second.role;
@@ -611,6 +649,7 @@ PeerTestParticipant SSUServer::GetPeerTestParticipant(
 
 std::shared_ptr<SSUSession> SSUServer::GetPeerTestSession(
     uint32_t nonce) {
+  LogPrint(eLogDebug, "SSUServer: getting PeerTest session");
   auto it = m_PeerTests.find(nonce);
   if (it != m_PeerTests.end())
     return it->second.session;
@@ -621,6 +660,7 @@ std::shared_ptr<SSUSession> SSUServer::GetPeerTestSession(
 void SSUServer::UpdatePeerTest(
     uint32_t nonce,
     PeerTestParticipant role) {
+  LogPrint(eLogDebug, "SSUServer: updating PeerTest");
   auto it = m_PeerTests.find(nonce);
   if (it != m_PeerTests.end())
     it->second.role = role;
@@ -628,22 +668,25 @@ void SSUServer::UpdatePeerTest(
 
 void SSUServer::RemovePeerTest(
     uint32_t nonce) {
+  LogPrint(eLogDebug, "SSUServer: removing PeerTest");
   m_PeerTests.erase(nonce);
 }
 
 void SSUServer::SchedulePeerTestsCleanupTimer() {
+  LogPrint(eLogDebug, "SSUServer: scheduling PeerTests cleanup timer");
   m_PeerTestsCleanupTimer.expires_from_now(
       boost::posix_time::seconds(
-        SSU_PEER_TEST_TIMEOUT));
+          SSU_PEER_TEST_TIMEOUT));
   m_PeerTestsCleanupTimer.async_wait(
       std::bind(
-        &SSUServer::HandlePeerTestsCleanupTimer,
-        this,
-        std::placeholders::_1));
+          &SSUServer::HandlePeerTestsCleanupTimer,
+          this,
+          std::placeholders::_1));
 }
 
 void SSUServer::HandlePeerTestsCleanupTimer(
     const boost::system::error_code& ecode) {
+  LogPrint(eLogDebug, "SSUServer: handling PeerTests cleanup timer()");
   if (ecode != boost::asio::error::operation_aborted) {
     int numDeleted = 0;
     uint64_t ts = i2p::util::GetMillisecondsSinceEpoch();

--- a/src/core/transport/SSUSession.h
+++ b/src/core/transport/SSUSession.h
@@ -36,7 +36,9 @@
 #include <inttypes.h>
 
 #include <memory>
+#include <ostream>
 #include <set>
+#include <string>
 #include <vector>
 
 #include "I2NPProtocol.h"
@@ -197,16 +199,12 @@ class SSUSession
 
   void Done();
 
-  boost::asio::ip::udp::endpoint& GetRemoteEndpoint() {
-    return m_RemoteEndpoint;
-  }
-
   bool IsV6() const {
     return m_RemoteEndpoint.address().is_v6();
   }
 
   void SendI2NPMessages(
-      const std::vector<std::shared_ptr<I2NPMessage> >& msgs);
+      const std::vector<std::shared_ptr<I2NPMessage>>& msgs);
 
   void SendPeerTest();  // Alice
 
@@ -232,6 +230,36 @@ class SSUSession
     return m_CreationTime;
   }
 
+  /// @brief Sets peer abbreviated ident hash
+  void SetRemoteIdentHashAbbreviation() {
+    m_RemoteIdentHashAbbreviation =
+      GetRemoteRouter()->GetIdentHashAbbreviation();
+  }
+
+  /// @brief Set current session's endpoint address/port
+  void SetRemoteEndpoint(
+      const boost::asio::ip::udp::endpoint& ep) {
+    m_RemoteEndpoint = ep;
+  }
+
+  /// @return Log-formatted string of session info
+  const std::string GetFormattedSessionInfo() {
+    std::ostringstream info;
+    info << " [" << GetRemoteIdentHashAbbreviation() << "] "
+         << GetRemoteEndpoint() << " ";
+    return info.str();
+  }
+
+  /// @return Current session's peer's ident hash
+  const std::string& GetRemoteIdentHashAbbreviation() {
+    return m_RemoteIdentHashAbbreviation;
+  }
+
+  /// @return Current session's endpoint address/port
+  const boost::asio::ip::udp::endpoint& GetRemoteEndpoint() {
+    return m_RemoteEndpoint;
+  }
+
   void FlushData();
 
  private:
@@ -241,7 +269,7 @@ class SSUSession
       const uint8_t* pubKey);
 
   void PostI2NPMessages(
-      std::vector<std::shared_ptr<I2NPMessage> > msgs);
+      std::vector<std::shared_ptr<I2NPMessage>> msgs);
 
   /// @brief Call for established session
   void ProcessDecryptedMessage(
@@ -386,6 +414,7 @@ class SSUSession
 
  private:
   friend class SSUData;  // TODO(unassigned): change in later
+  std::string m_RemoteIdentHashAbbreviation;
   SSUServer& m_Server;
   boost::asio::ip::udp::endpoint m_RemoteEndpoint;
   boost::asio::deadline_timer m_Timer;

--- a/src/core/transport/TransportSession.h
+++ b/src/core/transport/TransportSession.h
@@ -62,7 +62,7 @@ class SignedData {
   void Insert(
       const std::uint8_t* buf,
       std::size_t len) {
-    m_Stream.write(reinterpret_cast<char *>(&buf), len);
+    m_Stream.write(reinterpret_cast<const char *>(buf), len);
   }
   template<typename T>
   void Insert(

--- a/src/core/transport/TransportSession.h
+++ b/src/core/transport/TransportSession.h
@@ -33,10 +33,10 @@
 #ifndef SRC_CORE_TRANSPORT_TRANSPORTSESSION_H_
 #define SRC_CORE_TRANSPORT_TRANSPORTSESSION_H_
 
-#include <inttypes.h>
-
+#include <cstdint>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <vector>
 
 #include "I2NPProtocol.h"
@@ -47,8 +47,8 @@ namespace i2p {
 namespace transport {
 
 struct DHKeysPair {  // transient keys for transport sessions
-  uint8_t publicKey[256];
-  uint8_t privateKey[256];
+  std::array<std::uint8_t, 256> public_key;
+  std::array<std::uint8_t, 256> private_key;
 };
 
 class SignedData {
@@ -60,30 +60,30 @@ class SignedData {
   }
 
   void Insert(
-      const uint8_t* buf,
-      size_t len) {
-    m_Stream.write((char *)buf, len);
+      const std::uint8_t* buf,
+      std::size_t len) {
+    m_Stream.write(reinterpret_cast<char *>(&buf), len);
   }
   template<typename T>
   void Insert(
-      T t) {
-    m_Stream.write((char *)&t, sizeof(T));
+      T type) {
+    m_Stream.write(reinterpret_cast<char *>(&type), sizeof(T));
   }
 
   bool Verify(
       const i2p::data::IdentityEx& ident,
-      const uint8_t* signature) const {
+      const std::uint8_t* signature) const {
     return ident.Verify(
-        (const uint8_t *)m_Stream.str().c_str(),
+        (const std::uint8_t *)m_Stream.str().c_str(),
         m_Stream.str().size(),
         signature);
   }
 
   void Sign(
       const i2p::data::PrivateKeys& keys,
-      uint8_t* signature) const {
+      std::uint8_t* signature) const {
     keys.Sign(
-        (const uint8_t *)m_Stream.str().c_str(),
+        (const std::uint8_t *)m_Stream.str().c_str(),
         m_Stream.str().size(),
         signature);
   }
@@ -119,11 +119,11 @@ class TransportSession {
     return m_RemoteIdentity;
   }
 
-  size_t GetNumSentBytes() const {
+  std::size_t GetNumSentBytes() const {
     return m_NumSentBytes;
   }
 
-  size_t GetNumReceivedBytes() const {
+  std::size_t GetNumReceivedBytes() const {
     return m_NumReceivedBytes;
   }
 
@@ -138,8 +138,7 @@ class TransportSession {
   std::shared_ptr<const i2p::data::RouterInfo> m_RemoteRouter;
   i2p::data::IdentityEx m_RemoteIdentity;
   DHKeysPair* m_DHKeysPair;  // X - for client and Y - for server
-  size_t m_NumSentBytes,
-         m_NumReceivedBytes;
+  std::size_t m_NumSentBytes, m_NumReceivedBytes;
   bool m_IsOutbound;
 };
 

--- a/src/core/transport/Transports.cpp
+++ b/src/core/transport/Transports.cpp
@@ -33,6 +33,8 @@
 #include "Transports.h"
 
 #include <algorithm>
+#include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -47,37 +49,40 @@ namespace i2p {
 namespace transport {
 
 DHKeysPairSupplier::DHKeysPairSupplier(
-    int size)
+    std::size_t size)
     : m_QueueSize(size),
       m_IsRunning(false),
       m_Thread(nullptr) {}
 
 DHKeysPairSupplier::~DHKeysPairSupplier() {
+  LogPrint(eLogDebug, "DHKeysPairSupplier: destroying");
   Stop();
 }
 
 void DHKeysPairSupplier::Start() {
+  LogPrint(eLogDebug, "DHKeysPairSupplier: starting");
   m_IsRunning = true;
   m_Thread =
-    new std::thread(
+    std::make_unique<std::thread>(
         std::bind(
-          &DHKeysPairSupplier::Run,
-          this));
+            &DHKeysPairSupplier::Run,
+            this));
 }
 
 void DHKeysPairSupplier::Stop() {
+  LogPrint(eLogDebug, "DHKeysPairSupplier: stopping");
   m_IsRunning = false;
   m_Acquired.notify_one();
   if (m_Thread) {
     m_Thread->join();
-    delete m_Thread;
-    m_Thread = 0;
+    m_Thread.reset(nullptr);
   }
 }
 
 void DHKeysPairSupplier::Run() {
+  LogPrint(eLogDebug, "DHKeysPairSupplier: running");
   while (m_IsRunning) {
-    int num;
+    std::size_t num;
     while ((num = m_QueueSize - m_Queue.size ()) > 0)
       CreateDHKeysPairs(num);
     std::unique_lock<std::mutex> l(m_AcquiredMutex);
@@ -86,14 +91,14 @@ void DHKeysPairSupplier::Run() {
 }
 
 void DHKeysPairSupplier::CreateDHKeysPairs(
-    int num) {
+    std::size_t num) {
+  LogPrint(eLogDebug, "DHKeysPairSupplier: creating");
   if (num > 0) {
-    for (int i = 0; i < num; i++) {
-      i2p::transport::DHKeysPair* pair =
-        new i2p::transport::DHKeysPair();
+    for (std::size_t i = 0; i < num; i++) {
+      i2p::transport::DHKeysPair* pair = new i2p::transport::DHKeysPair();
       i2p::crypto::DiffieHellman().GenerateKeyPair(
-          pair->privateKey,
-          pair->publicKey);
+          pair->private_key.data(),
+          pair->public_key.data());
       std::unique_lock<std::mutex>  l(m_AcquiredMutex);
       m_Queue.push(pair);
     }
@@ -101,6 +106,7 @@ void DHKeysPairSupplier::CreateDHKeysPairs(
 }
 
 DHKeysPair* DHKeysPairSupplier::Acquire() {
+  LogPrint(eLogDebug, "DHKeysPairSupplier: acquiring");
   std::unique_lock<std::mutex> l(m_AcquiredMutex);
   if (!m_Queue.empty()) {
     auto pair = m_Queue.front();
@@ -109,18 +115,18 @@ DHKeysPair* DHKeysPairSupplier::Acquire() {
     return pair;
   }
   l.unlock();
-
   // queue is empty, create new key pair
   DHKeysPair* pair = new DHKeysPair();
   i2p::crypto::DiffieHellman().GenerateKeyPair(
-      pair->privateKey,
-      pair->publicKey);
+      pair->private_key.data(),
+      pair->public_key.data());
   return pair;
 }
 
 void DHKeysPairSupplier::Return(
     DHKeysPair* pair) {
-  std::unique_lock<std::mutex>  l(m_AcquiredMutex);
+  LogPrint(eLogDebug, "DHKeysPairSupplier: returning");
+  std::unique_lock<std::mutex> l(m_AcquiredMutex);
   m_Queue.push(pair);
 }
 
@@ -143,52 +149,54 @@ Transports::Transports()
       m_LastBandwidthUpdateTime(0) {}
 
 Transports::~Transports() {
+  LogPrint(eLogDebug, "Transports: destroying");
   Stop();
 }
 
 void Transports::Start() {
+  LogPrint(eLogDebug, "Transports: starting");
 #ifdef USE_UPNP
   m_UPnP.Start();
   LogPrint(eLogInfo, "Transports: UPnP started");
 #endif
   m_DHKeysPairSupplier.Start();
   m_IsRunning = true;
-  m_Thread =
-    new std::thread(
-      std::bind(
-        &Transports::Run,
-        this));
+  m_Thread = std::make_unique<std::thread>(std::bind(&Transports::Run, this));
   // create acceptors
   auto addresses = context.GetRouterInfo().GetAddresses();
   for (auto& address : addresses) {
+    LogPrint("Transports: creating servers for address ", address.host);
     if (!m_NTCPServer) {
-      m_NTCPServer = new NTCPServer(address.port);
+      LogPrint(eLogInfo, "Transports: TCP listening on port ", address.port);
+      m_NTCPServer = std::make_unique<NTCPServer>(address.port);
       m_NTCPServer->Start();
+    } else {
+      LogPrint(eLogError, "Transports: TCP server already exists");
     }
     if (address.transportStyle ==
-        i2p::data::RouterInfo::eTransportSSU &&
-        address.host.is_v4()) {
+        i2p::data::RouterInfo::eTransportSSU && address.host.is_v4()) {
       if (!m_SSUServer) {
-        m_SSUServer = new SSUServer(address.port);
-        LogPrint("Transports: UDP listening on port ", address.port);
+        LogPrint(eLogInfo, "Transports: UDP listening on port ", address.port);
+        m_SSUServer = std::make_unique<SSUServer>(address.port);
         m_SSUServer->Start();
         DetectExternalIP();
       } else {
-        LogPrint("Transports: SSU server already exists");
+        LogPrint(eLogError, "Transports: SSU server already exists");
       }
     }
   }
   m_PeerCleanupTimer.expires_from_now(
       boost::posix_time::seconds(
-        5 * SESSION_CREATION_TIMEOUT));
+          5 * SESSION_CREATION_TIMEOUT));   // TODO(unassigned): why 5 seconds
   m_PeerCleanupTimer.async_wait(
       std::bind(
-        &Transports::HandlePeerCleanupTimer,
-        this,
-        std::placeholders::_1));
+          &Transports::HandlePeerCleanupTimer,
+          this,
+          std::placeholders::_1));
 }
 
 void Transports::Stop() {
+  LogPrint(eLogDebug, "Transports: stopping");
 #ifdef USE_UPNP
   m_UPnP.Stop();
   LogPrint(eLogInfo, "Transports: UPnP stopped");
@@ -197,35 +205,34 @@ void Transports::Stop() {
   m_Peers.clear();
   if (m_SSUServer) {
     m_SSUServer->Stop();
-    delete m_SSUServer;
-    m_SSUServer = nullptr;
+    m_SSUServer.reset(nullptr);
   }
   if (m_NTCPServer) {
     m_NTCPServer->Stop();
-    delete m_NTCPServer;
-    m_NTCPServer = nullptr;
+    m_NTCPServer.reset(nullptr);
   }
   m_DHKeysPairSupplier.Stop();
   m_IsRunning = false;
   m_Service.stop();
   if (m_Thread) {
     m_Thread->join();
-    delete m_Thread;
-    m_Thread = nullptr;
+    m_Thread.reset(nullptr);
   }
 }
 
 void Transports::Run() {
+  LogPrint(eLogDebug, "Transports: running");
   while (m_IsRunning) {
     try {
       m_Service.run();
     } catch (std::exception& ex) {
-      LogPrint("Transports::Run(): ", ex.what());
+      LogPrint("Transports: Run(): '", ex.what(), "'");
     }
   }
 }
 
 void Transports::UpdateBandwidth() {
+  LogPrint(eLogDebug, "Transports: updating bandwidth");
   uint64_t ts = i2p::util::GetMillisecondsSinceEpoch();
   if (m_LastBandwidthUpdateTime > 0) {
     auto delta = ts - m_LastBandwidthUpdateTime;
@@ -242,57 +249,65 @@ void Transports::UpdateBandwidth() {
 }
 
 bool Transports::IsBandwidthExceeded() const {
+  if (std::max(m_InBandwidth, m_OutBandwidth) > LOW_BANDWIDTH_LIMIT) {
+    LogPrint(eLogDebug, "Transports: bandwidth has been exceeded");
+    return true;
+  }
   if (i2p::context.GetRouterInfo().IsHighBandwidth())
-    return false;
-  return std::max(m_InBandwidth, m_OutBandwidth) > LOW_BANDWIDTH_LIMIT;
+    LogPrint(eLogDebug, "Transports: bandwidth has not been exceeded");
+  return false;
 }
 
 void Transports::SendMessage(
     const i2p::data::IdentHash& ident,
     std::shared_ptr<i2p::I2NPMessage> msg) {
-  SendMessages(ident, std::vector<std::shared_ptr<i2p::I2NPMessage> > {msg});
+  LogPrint(eLogDebug, "Transports: sending messages");
+  SendMessages(
+      ident,
+      std::vector<std::shared_ptr<i2p::I2NPMessage>> {msg});
 }
 
 void Transports::SendMessages(
     const i2p::data::IdentHash& ident,
-    const std::vector<std::shared_ptr<i2p::I2NPMessage> >& msgs) {
+    const std::vector<std::shared_ptr<i2p::I2NPMessage>>& msgs) {
   m_Service.post(
       std::bind(
-        &Transports::PostMessages,
-        this,
-        ident,
-        msgs));
+          &Transports::PostMessages,
+          this,
+          ident,
+          msgs));
 }
 
 void Transports::PostMessages(
     i2p::data::IdentHash ident,
-    std::vector<std::shared_ptr<i2p::I2NPMessage> > msgs) {
+    std::vector<std::shared_ptr<i2p::I2NPMessage>> msgs) {
+  LogPrint(eLogDebug, "Transports: posting messages");
   if (ident == i2p::context.GetRouterInfo().GetIdentHash()) {
     // we send it to ourself
-    for (auto it : msgs)
-      i2p::HandleI2NPMessage(it);
+    for (auto msg : msgs)
+      i2p::HandleI2NPMessage(msg);
     return;
   }
   auto it = m_Peers.find(ident);
   if (it == m_Peers.end()) {
     bool connected = false;
     try {
-      auto r = i2p::data::netdb.FindRouter(ident);
+      auto router = i2p::data::netdb.FindRouter(ident);
       it = m_Peers.insert(
           std::make_pair(
-            ident,
-            Peer{ 0, r, {}, i2p::util::GetSecondsSinceEpoch(), {} })).first;
+              ident,
+              Peer{ 0, router, {}, i2p::util::GetSecondsSinceEpoch(), {} })).first;
       connected = ConnectToPeer(ident, it->second);
     } catch (std::exception& ex) {
-      LogPrint(eLogError, "Transports::PostMessages() ", ex.what());
+      LogPrint(eLogError, "Transports: PostMessages(): '", ex.what(), "'");
     }
     if (!connected) return;
   }
   if (!it->second.sessions.empty()) {
     it->second.sessions.front()->SendI2NPMessages(msgs);
   } else {
-    for (auto it1 : msgs)
-      it->second.delayedMessages.push_back(it1);
+    for (auto msg : msgs)
+      it->second.delayed_messages.push_back(msg);
   }
 }
 
@@ -301,9 +316,15 @@ bool Transports::ConnectToPeer(
     Peer& peer) {
   // we have RI already
   if (peer.router) {
+    LogPrint(eLogDebug,
+        "Transports: connecting to peer",
+        GetFormattedSessionInfo(peer.router));
     // NTCP
-    if (!peer.numAttempts) {
-      peer.numAttempts++;
+    if (!peer.num_attempts) {
+      LogPrint(eLogDebug,
+          "Transports: attempting NTCP for peer",
+          GetFormattedSessionInfo(peer.router));
+      peer.num_attempts++;
       auto address = peer.router->GetNTCPAddress(!context.SupportsV6());
       if (address) {
 #if BOOST_VERSION >= 104900
@@ -315,61 +336,69 @@ bool Transports::ConnectToPeer(
 #endif
         {
           if (!peer.router->UsesIntroducer() && !peer.router->IsUnreachable()) {
-            auto s = std::make_shared<NTCPSession> (*m_NTCPServer, peer.router);
+            auto s = std::make_shared<NTCPSession>(*m_NTCPServer, peer.router);
             m_NTCPServer->Connect(address->host, address->port, s);
             return true;
           }
         } else {  // we don't have address
           if (address->addressString.length() > 0) {  // trying to resolve
-            LogPrint(eLogInfo, "Transports: resolving ", address->addressString);
+            LogPrint(eLogInfo,
+                "Transports: NTCP resolving ", address->addressString);
             NTCPResolve(address->addressString, ident);
             return true;
           }
         }
       }
-    } else if (peer.numAttempts == 1) {  // SSU
-      peer.numAttempts++;
+    } else if (peer.num_attempts == 1) {  // SSU
+      LogPrint(eLogDebug,
+         "Transports: attempting SSU for peer",
+          GetFormattedSessionInfo(peer.router));
+      peer.num_attempts++;
       if (m_SSUServer) {
         if (m_SSUServer->GetSession(peer.router))
           return true;
       }
     }
-    LogPrint(eLogError, "Transports: no NTCP or SSU addresses available");
+    LogPrint(eLogError,
+        "Transports:", GetFormattedSessionInfo(peer.router),
+        "no NTCP/SSU address available");
     peer.Done();
     m_Peers.erase(ident);
     return false;
   } else {  // otherwise request RI
-    LogPrint("Transports: router not found, requesting");
+    LogPrint(eLogDebug, "Transports: RI not found, requesting");
     i2p::data::netdb.RequestDestination(
         ident,
         std::bind(
-          &Transports::RequestComplete,
-          this,
-          std::placeholders::_1,
-          ident));
+            &Transports::RequestComplete,
+            this,
+            std::placeholders::_1,
+            ident));
   }
   return true;
 }
 
 void Transports::RequestComplete(
-    std::shared_ptr<const i2p::data::RouterInfo> r,
+    std::shared_ptr<const i2p::data::RouterInfo> router,
     const i2p::data::IdentHash& ident) {
   m_Service.post(
       std::bind(
-        &Transports::HandleRequestComplete,
-        this,
-        r,
-        ident));
+          &Transports::HandleRequestComplete,
+          this,
+          router,
+          ident));
 }
 
 void Transports::HandleRequestComplete(
-    std::shared_ptr<const i2p::data::RouterInfo> r,
+    std::shared_ptr<const i2p::data::RouterInfo> router,
     const i2p::data::IdentHash& ident) {
   auto it = m_Peers.find(ident);
   if (it != m_Peers.end()) {
-    if (r) {
-      LogPrint("Transports: router found, trying to connect");
-      it->second.router = r;
+    if (router) {
+      LogPrint(eLogInfo,
+          "Transports: router ", router->GetIdentHashAbbreviation(),
+          " found, trying to connect");
+      it->second.router = router;
       ConnectToPeer(ident, it->second);
     } else {
       LogPrint("Transports: router not found, failed to send messages");
@@ -385,15 +414,15 @@ void Transports::NTCPResolve(
     std::make_shared<boost::asio::ip::tcp::resolver>(m_Service);
   resolver->async_resolve(
       boost::asio::ip::tcp::resolver::query(
-        addr,
-        ""),
+          addr,
+          ""),
       std::bind(
-        &Transports::HandleNTCPResolve,
-        this,
-        std::placeholders::_1,
-        std::placeholders::_2,
-        ident,
-        resolver));
+          &Transports::HandleNTCPResolve,
+          this,
+          std::placeholders::_1,
+          std::placeholders::_2,
+          ident,
+          resolver));
 }
 
 void Transports::HandleNTCPResolve(
@@ -426,11 +455,14 @@ void Transports::CloseSession(
     std::shared_ptr<const i2p::data::RouterInfo> router) {
   if (!router)
     return;
+  LogPrint(eLogDebug,
+      "Transports: closing session for [",
+      router->GetIdentHashAbbreviation(), "]");
   m_Service.post(
       std::bind(
-        &Transports::PostCloseSession,
-        this,
-        router));
+          &Transports::PostCloseSession,
+          this,
+          router));
 }
 
 void Transports::PostCloseSession(
@@ -440,12 +472,15 @@ void Transports::PostCloseSession(
   // try SSU first
   if (ssuSession) {
     m_SSUServer->DeleteSession(ssuSession);
-    LogPrint("Transports: SSU session closed");
+    LogPrint(eLogInfo,
+        "Transports: SSU session [",
+        router->GetIdentHashAbbreviation(), "] closed");
   }
   // TODO(unassigned): delete NTCP
 }
 
 void Transports::DetectExternalIP() {
+  LogPrint(eLogDebug, "Transports: detecting external IP");
   if (m_SSUServer) {
     i2p::context.SetStatus(eRouterStatusTesting);
     for (int i = 0; i < 5; i++) {
@@ -466,41 +501,47 @@ void Transports::DetectExternalIP() {
 }
 
 DHKeysPair* Transports::GetNextDHKeysPair() {
+  LogPrint(eLogDebug, "Transports: getting next DH keys pair");
   return m_DHKeysPairSupplier.Acquire();
 }
 
 void Transports::ReuseDHKeysPair(DHKeysPair* pair) {
+  LogPrint(eLogDebug, "Transports: reusing DH keys pair");
   m_DHKeysPairSupplier.Return(pair);
 }
 
 void Transports::PeerConnected(
     std::shared_ptr<TransportSession> session) {
+  auto router = session->GetRemoteRouter();
+  LogPrint(eLogDebug,
+      "Transports:", GetFormattedSessionInfo(router), "connecting");
   m_Service.post([session, this]() {
     auto ident = session->GetRemoteIdentity().GetIdentHash();
     auto it = m_Peers.find(ident);
     if (it != m_Peers.end()) {
       it->second.sessions.push_back(session);
-      session->SendI2NPMessages(it->second.delayedMessages);
-      it->second.delayedMessages.clear();
+      session->SendI2NPMessages(it->second.delayed_messages);
+      it->second.delayed_messages.clear();
     } else {  // incoming connection
       m_Peers.insert(
           std::make_pair(
-            ident,
-            Peer{ 0, nullptr, { session },
-            i2p::util::GetSecondsSinceEpoch(), {} }));
+              ident,
+              Peer{ 0, nullptr, { session },
+              i2p::util::GetSecondsSinceEpoch(), {} }));
     }
   });
 }
 
 void Transports::PeerDisconnected(
     std::shared_ptr<TransportSession> session) {
+  LogPrint(eLogDebug, "Transports: disconnecting peer");
   m_Service.post([session, this]() {
     auto ident = session->GetRemoteIdentity().GetIdentHash();
     auto it = m_Peers.find(ident);
     if (it != m_Peers.end()) {
       it->second.sessions.remove(session);
       if (it->second.sessions.empty()) {  // TODO(unassigned): why?
-        if (it->second.delayedMessages.size() > 0)
+        if (it->second.delayed_messages.size() > 0)
           ConnectToPeer(ident, it->second);
         else
           m_Peers.erase(it);
@@ -511,41 +552,50 @@ void Transports::PeerDisconnected(
 
 bool Transports::IsConnected(
     const i2p::data::IdentHash& ident) const {
+  LogPrint(eLogDebug, "Transports: testing if connected");
   auto it = m_Peers.find(ident);
-  return it != m_Peers.end();
+  if (it != m_Peers.end()) {
+    LogPrint(eLogDebug, "Transports: we are connected");
+    return true;
+  }
+  LogPrint(eLogDebug, "Transports: we are not connected");
+  return false;
 }
 
 void Transports::HandlePeerCleanupTimer(
     const boost::system::error_code& ecode) {
+  LogPrint(eLogDebug, "Transports: handling peer cleanup timer");
   if (ecode != boost::asio::error::operation_aborted) {
     auto ts = i2p::util::GetSecondsSinceEpoch();
     for (auto it = m_Peers.begin(); it != m_Peers.end();) {
-      if (it->second.sessions.empty () &&
-          ts > it->second.creationTime + SESSION_CREATION_TIMEOUT) {
+      if (it->second.sessions.empty() &&
+          ts > it->second.creation_time + SESSION_CREATION_TIMEOUT) {
         LogPrint(eLogError,
-            "Transports: session to peer ", it->first.ToBase64(),
-            " has not been created in ", SESSION_CREATION_TIMEOUT, " seconds");
+            "Transports: session to peer",
+            GetFormattedSessionInfo(it->second.router),
+            "has not been created in ", SESSION_CREATION_TIMEOUT, " seconds");
         it = m_Peers.erase(it);
       } else {
         it++;
       }
     }
     UpdateBandwidth();  // TODO(unassigned): use separate timer(s) for it
-    // if still testing,  repeat peer test
+    // if still testing, repeat peer test
     if (i2p::context.GetStatus() == eRouterStatusTesting)
       DetectExternalIP();
     m_PeerCleanupTimer.expires_from_now(
         boost::posix_time::seconds(
-          5 * SESSION_CREATION_TIMEOUT));
+            5 * SESSION_CREATION_TIMEOUT));
     m_PeerCleanupTimer.async_wait(
         std::bind(
-          &Transports::HandlePeerCleanupTimer,
-          this,
-          std::placeholders::_1));
+            &Transports::HandlePeerCleanupTimer,
+            this,
+            std::placeholders::_1));
   }
 }
 
 std::shared_ptr<const i2p::data::RouterInfo> Transports::GetRandomPeer() const {
+  LogPrint(eLogDebug, "Transports: getting random peer");
   if (m_Peers.empty())  // ensure m.Peers.size() >= 1
     return nullptr;
   size_t s = m_Peers.size();
@@ -553,7 +603,6 @@ std::shared_ptr<const i2p::data::RouterInfo> Transports::GetRandomPeer() const {
   std::advance(
       it,
       i2p::crypto::RandInRange<size_t>(0, s - 1));
-
   return it->second.router;
 }
 

--- a/src/core/transport/Transports.cpp
+++ b/src/core/transport/Transports.cpp
@@ -166,12 +166,15 @@ void Transports::Start() {
   auto addresses = context.GetRouterInfo().GetAddresses();
   for (auto& address : addresses) {
     LogPrint("Transports: creating servers for address ", address.host);
-    if (!m_NTCPServer) {
-      LogPrint(eLogInfo, "Transports: TCP listening on port ", address.port);
-      m_NTCPServer = std::make_unique<NTCPServer>(address.port);
-      m_NTCPServer->Start();
-    } else {
-      LogPrint(eLogError, "Transports: TCP server already exists");
+    if (address.transportStyle ==
+        i2p::data::RouterInfo::eTransportNTCP && address.host.is_v4()) {
+      if (!m_NTCPServer) {
+        LogPrint(eLogInfo, "Transports: TCP listening on port ", address.port);
+        m_NTCPServer = std::make_unique<NTCPServer>(address.port);
+        m_NTCPServer->Start();
+      } else {
+        LogPrint(eLogError, "Transports: TCP server already exists");
+      }
     }
     if (address.transportStyle ==
         i2p::data::RouterInfo::eTransportSSU && address.host.is_v4()) {
@@ -440,7 +443,7 @@ void Transports::HandleNTCPResolve(
           " has been resolved to ", address);
       auto addr = peer.router->GetNTCPAddress();
       if (addr) {
-        auto s = std::make_shared<NTCPSession> (*m_NTCPServer, peer.router);
+        auto s = std::make_shared<NTCPSession>(*m_NTCPServer, peer.router);
         m_NTCPServer->Connect(address, addr->port, s);
         return;
       }

--- a/src/core/transport/UPnP.cpp
+++ b/src/core/transport/UPnP.cpp
@@ -144,8 +144,7 @@ UPnP::UPnP()
 void UPnP::Stop() {
   if (m_Thread) {
     m_Thread->join();
-    delete m_Thread;
-    m_Thread = nullptr;
+    m_Thread.reset(nullptr);
   }
 }
 
@@ -197,10 +196,10 @@ void UPnP::Start() {
     }
   }
   m_Thread =
-    new std::thread(
+    std::make_unique<std::thread>(
         std::bind(
-          &UPnP::Run,
-          this));
+            &UPnP::Run,
+            this));
 }
 
 UPnP::~UPnP() {}

--- a/src/core/transport/UPnP.h
+++ b/src/core/transport/UPnP.h
@@ -42,6 +42,7 @@
 #include <miniupnpc/upnpcommands.h>
 #include <miniupnpc/upnperrors.h>
 
+#include <memory>
 #include <string>
 #include <thread>
 
@@ -75,7 +76,7 @@ class UPnP {
  private:
   void Run();
 
-  std::thread* m_Thread;
+  std::unique_ptr<std::thread> m_Thread;
   struct UPNPUrls m_upnpUrls;
   struct IGDdatas m_upnpData;
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull request may be closed by the will of the maintainer.
- I give this submission freely and claim no ownership to its content.

*Place an X inside the bracket to confirm*
- [X] I confirm.

---

* Effects Transports/TransportSession, NTCP/SSU, UPnP
  - SSU was left mostly alone because of #140
* Improve logging / add debugging output
  - Create new Get/Set session-info logging handlers
* NTCPSession: fix wrong phase1 handler call in ClientLogin()
* NTCPSession: refactor size constants into enum struct
* NTCPSession: Get functions for bytes sent/received and
  remote endpoint (like in SSU)
* NTCPSession: re-name/clarify payload-related functions
* NTCPSession: re-arrange function order layout into a
  linear fashion and then document phases
* NTCPServer: refactor peer banning handler
* NTCP: comment/point-out previously unfinished code
* C++11/14 refactor where appropriate. Refs #158
* Style refactor where appropriate
* Some function documentation
* Some trivial grammatical fixes (also in client/I2PTunnel)