### PR TITLE
Transports: fix SIGSEGV from LogPrint placement.

### DIFF
--- a/src/core/transport/Transports.cpp
+++ b/src/core/transport/Transports.cpp
@@ -55,7 +55,6 @@ DHKeysPairSupplier::DHKeysPairSupplier(
       m_Thread(nullptr) {}
 
 DHKeysPairSupplier::~DHKeysPairSupplier() {
-  LogPrint(eLogDebug, "DHKeysPairSupplier: destroying");
   Stop();
 }
 
@@ -70,7 +69,6 @@ void DHKeysPairSupplier::Start() {
 }
 
 void DHKeysPairSupplier::Stop() {
-  LogPrint(eLogDebug, "DHKeysPairSupplier: stopping");
   m_IsRunning = false;
   m_Acquired.notify_one();
   if (m_Thread) {
@@ -149,7 +147,6 @@ Transports::Transports()
       m_LastBandwidthUpdateTime(0) {}
 
 Transports::~Transports() {
-  LogPrint(eLogDebug, "Transports: destroying");
   Stop();
 }
 
@@ -199,10 +196,8 @@ void Transports::Start() {
 }
 
 void Transports::Stop() {
-  LogPrint(eLogDebug, "Transports: stopping");
 #ifdef USE_UPNP
   m_UPnP.Stop();
-  LogPrint(eLogInfo, "Transports: UPnP stopped");
 #endif
   m_PeerCleanupTimer.cancel();
   m_Peers.clear();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull request may be closed by the will of the maintainer.
- I give this submission freely and claim no ownership to its content.

*Place an X inside the bracket to confirm*
- [X] I confirm.

---

Only noticeable when shutting down the router or when running ```./kovri -h```. This is a simple fix. A real fix requires a better logging implementation.