### PR TITLE
Garlic: fix uninitialized padding in ElGamalBlock.

### DIFF
--- a/src/core/Garlic.h
+++ b/src/core/Garlic.h
@@ -46,6 +46,7 @@
 #include "Identity.h"
 #include "LeaseSet.h"
 #include "crypto/AES.h"
+#include "crypto/Rand.h"
 #include "util/Queue.h"
 
 namespace i2p {
@@ -60,9 +61,12 @@ enum GarlicDeliveryType {
 
 #pragma pack(1)
 struct ElGamalBlock {
+  ElGamalBlock() {
+    // Spec defines padding as CSPRNG radomized
+    i2p::crypto::RandBytes(padding.data(), padding.size());
+  }
   std::array<std::uint8_t, 32> session_key;
   std::array<std::uint8_t, 32> pre_IV;
-  // TODO(unassigned): review spec, how should padding be initialized/treated?
   std::array<std::uint8_t, 158> padding;
 };
 #pragma pack()


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull request may be closed by the will of the maintainer.
- I give this submission freely and claim no ownership to its content.

*Place an X inside the bracket to confirm*
- [X] I confirm.

---