### PR TITLE
Reseed: do not rely on [a-z] catching all letters

### DIFF
--- a/src/core/Reseed.cpp
+++ b/src/core/Reseed.cpp
@@ -360,7 +360,9 @@ bool SU3::PrepareStream() {
     // Get signer ID
     m_Stream.Read(*m_Data->signer_id.data(), m_Data->signer_id_length);
     // Currently enforces signer ID as an email address (not spec-defined)
-    std::regex regex("([-a-z0-9+._']{1,254})@((?:[-a-z0-9]+.)+[a-z|(i2p)]{2,})");
+#define ALPHA "abcdefghijklmnopqrstuvwxyz"
+    std::regex regex("([-"ALPHA"0-9+._']{1,254})@((?:[-"ALPHA"0-9]+.)+["ALPHA"|(i2p)]{2,})");
+#undef ALPHA
     if (!std::regex_search(m_Data->signer_id.data(), regex)) {
       LogPrint(eLogError, "SU3: invalid signer ID");
       return false;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull request may be closed by the will of the maintainer.
- I give this submission freely and claim no ownership to its content.

*Place an X inside the bracket to confirm*
- [ ] I confirm.

---

*Enter your pull request summary here*

This will fail in some locales, the list of which I am totally
unable to list. At least one Turkish one, I believe.

Fixes tests and main binary on Fedora.