### PR TITLE
Crypto: use constant-time comparison in ed25519.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -99,7 +99,8 @@ set(EDDSA_SRC
   "${EDDSA_DIR}/ed25519/open.cpp"
   "${EDDSA_DIR}/ed25519/sc_muladd.cpp"
   "${EDDSA_DIR}/ed25519/sc_reduce.cpp"
-  "${EDDSA_DIR}/ed25519/sign.cpp")
+  "${EDDSA_DIR}/ed25519/sign.cpp"
+  "${EDDSA_DIR}/ed25519/verify.cpp")
 
 # Library building
 if(WITH_LIBRARY)

--- a/src/core/crypto/pimpl/supercop/ed25519/crypto_verify_32.h
+++ b/src/core/crypto/pimpl/supercop/ed25519/crypto_verify_32.h
@@ -1,3 +1,1 @@
-#include <cstring>
-
-#define crypto_verify_32(a,b) (!!std::memcmp((a), (b), 32))
+int crypto_verify_32(const unsigned char *x,const unsigned char *y);

--- a/src/core/crypto/pimpl/supercop/ed25519/verify.cpp
+++ b/src/core/crypto/pimpl/supercop/ed25519/verify.cpp
@@ -1,0 +1,40 @@
+#include "crypto_verify_32.h"
+
+int crypto_verify_32(const unsigned char *x,const unsigned char *y)
+{
+  unsigned int differentbits = 0;
+#define F(i) differentbits |= x[i] ^ y[i];
+  F(0)
+  F(1)
+  F(2)
+  F(3)
+  F(4)
+  F(5)
+  F(6)
+  F(7)
+  F(8)
+  F(9)
+  F(10)
+  F(11)
+  F(12)
+  F(13)
+  F(14)
+  F(15)
+  F(16)
+  F(17)
+  F(18)
+  F(19)
+  F(20)
+  F(21)
+  F(22)
+  F(23)
+  F(24)
+  F(25)
+  F(26)
+  F(27)
+  F(28)
+  F(29)
+  F(30)
+  F(31)
+  return (1 & ((differentbits - 1) >> 8)) - 1;
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull request may be closed by the will of the maintainer.
- I give this submission freely and claim no ownership to its content.

*Place an X inside the bracket to confirm*
- [X] I confirm.

---

* Implements ```supercop-20141124/crypto_verify/32/ref/verify.c```
* Fixes #153