### PR TITLE
Docs: change links to cpplint project

### DIFF
--- a/doc/STYLE.md
+++ b/doc/STYLE.md
@@ -1,12 +1,12 @@
 ## Style
 We ardently adhere to (or are in the process of adhering to) [Google's C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
-Please run [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint) on any applicable work before contributing to Kovri and take no offense if your contribution ends up being style refactored.
+Please run [cpplint](https://pypi.python.org/pypi/cpplint/) on any applicable work before contributing to Kovri and take no offense if your contribution ends up being style refactored.
 
 In addition to the aforementioned, please consider the following:
 
 - Please keep in line with codebase's present (vertical) style for consistency
 - If anonymity is a concern, try to blend in with a present contributor's style
-- Lines should be <=80 spaces unless impossible to do so (see [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint))
+- Lines should be <=80 spaces unless impossible to do so (see [cpplint](https://pypi.python.org/pypi/cpplint/))
 - Pointers: reference/dereference operators on the left (attached to datatype) when possible
 - Class member variables should be prepended with m_
 - If function args newline break, ensure that *every* indent is 4 spaces (and not 2).


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull request may be closed by the will of the maintainer.
- I give this submission freely under BSD-3 license.

*Place an X inside the bracket to confirm*
- [x] I confirm.

---

*Enter your pull request summary here*

Cpplint is now provided as a Python module with extra features
thanks to https://github.com/theandrewdavis/cpplint

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/monero-project/kovri/230)
<!-- Reviewable:end -->
