### PR TITLE
Add ClangFormat config for Google C++ Style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+Language:        Cpp
+BasedOnStyle:  Google


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
- I am not basing this pull-request on branch ```master```
- I am sending this pull-request to branch ```development```

*Place an X inside the bracket (or click the box in preview) to confirm*
- [x] I confirm.

---

It looks like the Kovri codebase is transitioning from one style to another
while also performing modernization of C++ code to C++14 standard.
Clang-Format is a great tool for such large scale endeavors.
Also, ``clang-modernize`` and ``clang-tidy`` are your friends.
You can get Vim/Emacs bindings for ``clang-format``,
which makes your life super-easy for tricky code (C++11 lambda expressions, templates, etc.),
and no more waste of time on style holy wars (clang-format is the ultimate last reference).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/monero-project/kovri/236)
<!-- Reviewable:end -->
