### PR TITLE
Fix compilation with Clang 3.8

### DIFF
--- a/src/client/I2PControl/I2PControl.cpp
+++ b/src/client/I2PControl/I2PControl.cpp
@@ -317,7 +317,7 @@ I2PControlSession::Response I2PControlSession::HandleRequest(
     }
     // Call the appropriate handler
     (this->*(it->second))(params, response);
-  } catch (const boost::property_tree::ptree_error& error) {
+  } catch (const boost::property_tree::ptree_error&) {
     response.SetError(ErrorCode::e_ParseError);
   } catch (...) {
     response.SetError(ErrorCode::e_InternalError);
@@ -340,7 +340,7 @@ bool I2PControlSession::Authenticate(
       response.SetError(ErrorCode::e_ExpiredToken);
       return false;
     }
-  } catch (const boost::property_tree::ptree_error& error) {
+  } catch (const boost::property_tree::ptree_error&) {
     response.SetError(ErrorCode::e_NoToken);
     return false;
   }

--- a/src/client/I2PControl/I2PControl.h
+++ b/src/client/I2PControl/I2PControl.h
@@ -321,6 +321,7 @@ class I2PControlSession
                                         m_RouterManagerHandlers,
                                         m_NetworkSettingHandlers;
 
+  /// @todo Unused private field. Why?
   boost::asio::io_service& m_Service;
   boost::asio::deadline_timer m_ShutdownTimer,
                               m_ExpireTokensTimer;

--- a/src/client/I2PService.h
+++ b/src/client/I2PService.h
@@ -95,7 +95,7 @@ class I2PService {
   virtual void Stop() = 0;
 
   // everyone must override this
-  virtual std::string GetName() = 0;
+  virtual std::string GetName() const = 0;
 
  private:
   std::shared_ptr<ClientDestination> m_LocalDestination;
@@ -199,9 +199,7 @@ class TCPIPAcceptor : public I2PService {
   virtual std::shared_ptr<I2PServiceHandler> CreateHandler(
       std::shared_ptr<boost::asio::ip::tcp::socket> socket) = 0;
 
-  virtual std::string GetName() {
-    return "generic TCP/IP accepting daemon";
-  }
+  std::string GetName() const { return "generic TCP/IP accepting daemon"; }
 
  protected:
   std::string m_Address;

--- a/src/client/I2PTunnel/I2PTunnel.cpp
+++ b/src/client/I2PTunnel/I2PTunnel.cpp
@@ -384,9 +384,7 @@ std::unique_ptr<const i2p::data::IdentHash> I2PClientTunnel::GetIdentHash() {
   return std::move(m_DestinationIdentHash);
 }
 
-std::string I2PClientTunnel::GetName() {
-  return m_TunnelName;
-}
+std::string I2PClientTunnel::GetName() const { return m_TunnelName; }
 
 std::shared_ptr<I2PServiceHandler> I2PClientTunnel::CreateHandler(
     std::shared_ptr<boost::asio::ip::tcp::socket> socket) {
@@ -582,9 +580,7 @@ void I2PServerTunnel::CreateI2PConnection(
   conn->Connect();
 }
 
-std::string I2PServerTunnel::GetName() {
-  return m_TunnelName;
-}
+std::string I2PServerTunnel::GetName() const { return m_TunnelName; }
 
 I2PServerTunnelHTTP::I2PServerTunnelHTTP(
     const std::string& name,

--- a/src/client/I2PTunnel/I2PTunnel.h
+++ b/src/client/I2PTunnel/I2PTunnel.h
@@ -162,7 +162,7 @@ class I2PClientTunnel : public TCPIPAcceptor {
 
   void Start();
   void Stop();
-  std::string GetName();
+  std::string GetName() const;
 
  private:
   std::unique_ptr<const i2p::data::IdentHash> GetIdentHash();
@@ -216,7 +216,7 @@ class I2PServerTunnel : public I2PService {
     return m_Endpoint;
   }
 
-  std::string GetName();
+  std::string GetName() const;
 
  private:
   void HandleResolve(

--- a/src/client/I2PTunnel/SOCKS.h
+++ b/src/client/I2PTunnel/SOCKS.h
@@ -58,9 +58,7 @@ class SOCKSServer : public i2p::client::TCPIPAcceptor {
   std::shared_ptr<i2p::client::I2PServiceHandler> CreateHandler(
       std::shared_ptr<boost::asio::ip::tcp::socket> socket);
 
-  std::string GetName() const {
-    return "SOCKS";
-  }
+  std::string GetName() const { return "SOCKS"; }
 };
 
 typedef SOCKSServer SOCKSProxy;

--- a/src/core/Profiling.cpp
+++ b/src/core/Profiling.cpp
@@ -153,7 +153,7 @@ void RouterProfile::Load() {
           m_NumTunnelsNonReplied = participations.get(
               PEER_PROFILE_PARTICIPATION_NON_REPLIED,
               0);
-        } catch (boost::property_tree::ptree_bad_path& ex) {
+        } catch (boost::property_tree::ptree_bad_path&) {
           LogPrint(eLogWarn,
               "RouterProfile: Missing section ",
               PEER_PROFILE_SECTION_PARTICIPATION);
@@ -163,7 +163,7 @@ void RouterProfile::Load() {
           auto usage = pt.get_child(PEER_PROFILE_SECTION_USAGE);
           m_NumTimesTaken = usage.get(PEER_PROFILE_USAGE_TAKEN, 0);
           m_NumTimesRejected = usage.get(PEER_PROFILE_USAGE_REJECTED, 0);
-        } catch (boost::property_tree::ptree_bad_path& ex) {
+        } catch (boost::property_tree::ptree_bad_path&) {
           LogPrint(eLogWarn,
               "RouterProfile: missing section ", PEER_PROFILE_SECTION_USAGE);
         }

--- a/src/core/util/Filesystem.h
+++ b/src/core/util/Filesystem.h
@@ -57,26 +57,26 @@ class StringStream {
     m_Stream.read(
         reinterpret_cast<char *>(&buf),
         static_cast<SizeCast>(std::forward<Size>(size)));
-  };
+  }
 
   template<typename SizeCast = std::size_t, typename Offset, typename Position>
   void Seekg(Offset&& off, Position& pos) {
     m_Stream.seekg(
       static_cast<SizeCast>(std::forward<Offset>(off)),
       pos);
-  };
+  }
 
   std::size_t Tellg() {
     return m_Stream.tellg();
-  };
+  }
 
   bool EndOfFile() {
     return m_Stream.eof() ? true : false;
-  };
+  }
 
   std::string Str() {
     return m_Stream.str();
-  };
+  }
 
  private:
   std::stringstream m_Stream;

--- a/src/core/util/HTTP.cpp
+++ b/src/core/util/HTTP.cpp
@@ -104,7 +104,7 @@ void URI::Parse(
     m_Host.assign(m_Host.begin(), port_i);
     try {
       m_Port = boost::lexical_cast<decltype(m_Port)>(m_PortString);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       // Keep the default port
     }
   }

--- a/src/core/util/ZIP.h
+++ b/src/core/util/ZIP.h
@@ -63,7 +63,8 @@ class ZIP {
   ZIP(const std::string& zip,
       std::size_t len,
       std::size_t pos = 0)
-      : m_Stream(zip),
+      : Descriptor(),
+        m_Stream(zip),
         m_Data(std::make_unique<Data>()) {
           m_Data->content_length = len;
           m_Data->content_position = pos;


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
- I am not basing this pull-request on branch ```master```
- I am sending this pull-request to branch ```development```

*Place an X inside the bracket (or click the box in preview) to confirm*
- [x] I confirm.

---

Verified compilation with Clang 3.8 on Ubuntu 16.04;
however, no linking due to binary incompatibility of libstdc++.
The compilation needs further testing on Mac or FreeBSD.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/monero-project/kovri/237)
<!-- Reviewable:end -->
