### PR TITLE
OS X: Fix StringStream::Seekg signature

### DIFF
--- a/src/core/util/Filesystem.h
+++ b/src/core/util/Filesystem.h
@@ -44,7 +44,7 @@ namespace util {
 namespace filesystem {
 
 /// @class StringStream
-/// @details A wrapper for casting and and strongly-typed classes
+/// @details A wrapper for casting and strongly-typed classes
 /// @param String to be treated as stream
 class StringStream {
  public:
@@ -52,18 +52,18 @@ class StringStream {
     m_Stream.str(stream);
   }
 
-  template<typename SizeCast = std::size_t, typename Buffer, typename Size>
+  template <typename SizeCast = std::size_t, typename Buffer, typename Size>
   void Read(Buffer& buf, Size&& size) {
     m_Stream.read(
         reinterpret_cast<char *>(&buf),
         static_cast<SizeCast>(std::forward<Size>(size)));
   }
 
-  template<typename SizeCast = std::size_t, typename Offset, typename Position>
-  void Seekg(Offset&& off, Position& pos) {
+  template <typename SizeCast = std::size_t, typename Offset>
+  void Seekg(Offset&& off, std::ios_base::seekdir way) {
     m_Stream.seekg(
       static_cast<SizeCast>(std::forward<Offset>(off)),
-      pos);
+      way);
   }
 
   std::size_t Tellg() {


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
- I am not basing this pull-request on branch ```master```
- I am sending this pull-request to branch ```development```

*Place an X inside the bracket (or click the box in preview) to confirm*
- [x] I confirm.

---

There's no need to be too general
with perfect forwarding of integral types.
Specifying the type directly and taking by copy can do the job.
This fix is needed for clang on OS X.
https://travis-ci.org/rakhimov/kovri/builds/145718362

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/monero-project/kovri/244)
<!-- Reviewable:end -->
