### PR TITLE
Style: Clarify deviations from the GCSG

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,10 @@
 Language:        Cpp
 BasedOnStyle:  Google
+
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: true

--- a/doc/STYLE.md
+++ b/doc/STYLE.md
@@ -1,6 +1,34 @@
-## Style
+# Style
 We ardently adhere to (or are in the process of adhering to) [Google's C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
 Please run [cpplint](https://pypi.python.org/pypi/cpplint/) on any applicable work before contributing to Kovri and take no offense if your contribution ends up being style refactored.
+
+## Deviations from the Google C++ Style
+
+- The implementation file extension is ``cpp`` instead of ``cc``.
+- Enums are prefixed with ``e``/``e_`` instead of ``k``.
+- No more than one statement per line.
+  For example, one-liner ``if`` statement with its body is forbidden.
+- In the same manner, one-liner function definitions are forbidden.
+- Avoid inline functions.
+- Consider breaking on function parameters and arguments.
+  Consider providing comments for each parameter or argument.
+- Expressions can be broken before operators.
+
+```cpp
+if (expr1
+    && expr2
+    && expr3)
+  DoSomeThing();
+```
+
+- Bare if-else without brackets is allowed.
+
+```cpp
+if (expr1)
+  DoSomething();
+else
+  DoSomethingElse();
+```
 
 In addition to the aforementioned, please consider the following:
 


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
- I am not basing this pull-request on branch ```master```
- I am sending this pull-request to branch ```development```

*Place an X inside the bracket (or click the box in preview) to confirm*
- [x] I confirm.

---

Corresponding configurations for clang-format are provided.
These deviations are tentative
as observed from the current state of the codebase.

Note that the observed deviations are not
from the core, contributing developer or author,
so many deviations or implicit conventions may be missing.
It is best to get this information
from people who actually wrote the code.

This commit addresses issue #238.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/monero-project/kovri/245)
<!-- Reviewable:end -->
