### PR TITLE
Coverity: Remove unnecessary certificate fetch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,12 @@ env:
   - secure: J4o/q57D7PAqV+hG5VUhwGJLH4ryFWy8YGVAlAOyrRVv9UxfbiihhyE5Yh68tjukdFqLt3WcHB3hoPz0VfbxWGdLQ9OR0r7xxYPetA0qVYcttpumcVSBra17CCRBYOcyRCfbgUY/LVRbKlr8zgkubRUW0skUcAgELyZJA6k/k+3pd1oDjdBLMLp+TeQvQnUtekw7eEzBl31bgpku3vHQEiYxMRY6FhBC0vojNJSjT56pqYzA/bOVrPNDATxHqDAxuEWfNiNQym4P2T+LmkC2utCWlwLBSqTauy54z4nKM6+0xEmRq2hmBWZeSv1tYuKJi8rmtAH5OozyVGSaXpuelcaWE4YrNCGEXOJZQvuD+IEuFVSkqXItoUIjlE1kP/zIDAZERMaISzXkp2xpPQFes8NLE3lNdcvMYYUjVfyUpYN0qE5/XX6Opii6Y8Sj6wQaz1Y5n3g1Lp5TMlQIVmmTUPAWoCq3U2BTPn+Ub8O8Z7Y/9Zr1xdz3gBEJaYv1CuxrSb3z3lQ9BjodBL1u+l5me+16dBe4RbpPwoWvLramJAvKEuDHMx93UnYU+PWs9B9UyIwEh/FxpvRyu8iyI6pfNWIsrc1jJ2nzf1YrnXOHb0C0CdwHH6p6Nzy/bOfaBOihiwc6o9r80AHq0RBbkH7euPOGFAo4iUgYTaS7R9Pw6Rk=
 sudo: required
 dist: trusty
-before_install:
-- echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-certificates.crt
 language: cpp
 compiler:
 - gcc
 addons:
   apt:
     packages:
-    - ca-certificates
     - gcc-5
     - g++-5
     - libboost-all-dev


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
- I am not basing this pull-request on branch ```master```
- I am sending this pull-request to branch ```development```

*Place an X inside the bracket (or click the box in preview) to confirm*
- [x] I confirm.

---

Travis folks fixed the outdated certificate issues.

It would be best to separate coverity-specific Travis configurations into ``coverity_scan`` branch
for cleaner config files especially with multi-os builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/monero-project/kovri/246)
<!-- Reviewable:end -->
