### PR TITLE
Doxygen: remove input filter + fix input & CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ addons:
             - libssl1.0.0
             - libminiupnpc-dev
             - doxygen
+            - graphviz
         sources:
             - ubuntu-toolchain-r-test
 
@@ -45,7 +46,6 @@ before_script:
     #- if [ "$CXX" = "clang++" ]; then export CXX=clang-${CLANG_VERSION}; fi
 
 script: make clean && make -j2 dependencies && make -j2 all-options && make -j2 tests && make doxygen && make install-resources
-
 
 notifications:
     email: false

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -9,7 +9,7 @@ PROJECT_NUMBER         = "@PROJECT_VERSION@"
 PROJECT_BRIEF          =
 PROJECT_LOGO           =
 OUTPUT_DIRECTORY       = "@DOXYFILE_OUTPUT_DIR@"
-CREATE_SUBDIRS         = NO
+CREATE_SUBDIRS         = YES
 ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
 BRIEF_MEMBER_DESC      = YES
@@ -36,7 +36,7 @@ QT_AUTOBRIEF           = NO
 MULTILINE_CPP_IS_BRIEF = NO
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
-TAB_SIZE               = 4
+TAB_SIZE               = 2
 ALIASES                =
 TCL_SUBST              =
 OPTIMIZE_OUTPUT_FOR_C  = NO
@@ -61,12 +61,12 @@ LOOKUP_CACHE_SIZE      = 0
 # Build related configuration options
 #---------------------------------------------------------------------------
 EXTRACT_ALL            = YES
-EXTRACT_PRIVATE        = NO
-EXTRACT_PACKAGE        = NO
-EXTRACT_STATIC         = NO
+EXTRACT_PRIVATE        = YES
+EXTRACT_PACKAGE        = YES
+EXTRACT_STATIC         = YES
 EXTRACT_LOCAL_CLASSES  = YES
 EXTRACT_LOCAL_METHODS  = NO
-EXTRACT_ANON_NSPACES   = NO
+EXTRACT_ANON_NSPACES   = YES
 HIDE_UNDOC_MEMBERS     = NO
 HIDE_UNDOC_CLASSES     = NO
 HIDE_FRIEND_COMPOUNDS  = NO
@@ -111,12 +111,11 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = @DOXYFILE_SOURCE_DIRS@
+INPUT                  = "@DOXYFILE_SOURCE_DIR@"
 INPUT_ENCODING         = UTF-8
-FILE_PATTERNS          = *.c \
-                         *.cpp \
+FILE_PATTERNS          = *.cc \
                          *.h \
-                         *.py \
+                         *.py
 RECURSIVE              = YES
 EXCLUDE                =
 EXCLUDE_SYMLINKS       = NO
@@ -126,7 +125,7 @@ EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO
 IMAGE_PATH             =
-INPUT_FILTER           = "sed -e 's/\/\/.*TODO/\/\/\/ \\todo/'"
+INPUT_FILTER           =
 FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
 FILTER_SOURCE_PATTERNS =
@@ -210,7 +209,7 @@ EXTRA_SEARCH_MAPPINGS  =
 #---------------------------------------------------------------------------
 # Configuration options related to the LaTeX output
 #---------------------------------------------------------------------------
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
@@ -273,7 +272,7 @@ PERLMOD_MAKEVAR_PREFIX =
 # Configuration options related to the preprocessor
 #---------------------------------------------------------------------------
 ENABLE_PREPROCESSING   = YES
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = NO
 SEARCH_INCLUDES        = YES
 INCLUDE_PATH           =
@@ -297,7 +296,7 @@ CLASS_DIAGRAMS         = YES
 MSCGEN_PATH            =
 DIA_PATH               =
 HIDE_UNDOC_RELATIONS   = YES
-HAVE_DOT               = NO
+HAVE_DOT               = YES
 DOT_NUM_THREADS        = 0
 DOT_FONTNAME           = Helvetica
 DOT_FONTSIZE           = 10
@@ -310,8 +309,8 @@ UML_LIMIT_NUM_FIELDS   = 10
 TEMPLATE_RELATIONS     = NO
 INCLUDE_GRAPH          = YES
 INCLUDED_BY_GRAPH      = YES
-CALL_GRAPH             = NO
-CALLER_GRAPH           = NO
+CALL_GRAPH             = YES
+CALLER_GRAPH           = YES
 GRAPHICAL_HIERARCHY    = YES
 DIRECTORY_GRAPH        = YES
 DOT_IMAGE_FORMAT       = png

--- a/cmake/UseDoxygen.cmake
+++ b/cmake/UseDoxygen.cmake
@@ -104,52 +104,6 @@ if(DOXYGEN_FOUND AND DOXYFILE_IN_FOUND)
   usedoxygen_set_default(DOXYFILE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src"
     PATH "Input files source directory")
 
-  ### Apparently, we must explicitly specificy our source dirs.
-  ### Flipping on recursion in Doxyfile.in has no effect (though it apparently did in 1.8.10)
-  ### See https://github.com/monero-project/kovri/issues/68
-  ### TODO(unassigned): resolve this patch
-  usedoxygen_set_default(DOXYFILE_SOURCE_API
-    "${DOXYFILE_SOURCE_DIR}/app \
-    ${DOXYFILE_SOURCE_DIR}/app/util"
-    STRING "Application source files")
-
-  usedoxygen_set_default(DOXYFILE_SOURCE_CLIENT
-    "${DOXYFILE_SOURCE_DIR}/client \
-    ${DOXYFILE_SOURCE_DIR}/client/i2p_control \
-    ${DOXYFILE_SOURCE_DIR}/client/i2p_tunnel"
-    STRING "Client source files")
-
-  usedoxygen_set_default(DOXYFILE_SOURCE_CORE
-    "${DOXYFILE_SOURCE_DIR}/core \
-    ${DOXYFILE_SOURCE_DIR}/core/crypto \
-    ${DOXYFILE_SOURCE_DIR}/core/crypto/pimpl \
-    ${DOXYFILE_SOURCE_DIR}/core/crypto/pimpl/cryptopp/ \
-    ${DOXYFILE_SOURCE_DIR}/core/crypto/pimpl/cryptopp/util/ \
-    ${DOXYFILE_SOURCE_DIR}/core/crypto/pimpl/supercop/ \
-    ${DOXYFILE_SOURCE_DIR}/core/crypto/pimpl/supercop/ed25519 \
-    ${DOXYFILE_SOURCE_DIR}/core/crypto/util \
-    ${DOXYFILE_SOURCE_DIR}/core/transport \
-    ${DOXYFILE_SOURCE_DIR}/core/tunnel \
-    ${DOXYFILE_SOURCE_DIR}/core/util \
-    ${DOXYFILE_SOURCE_DIR}/core/util/pimpl"
-    STRING "Core source files")
-
-  usedoxygen_set_default(DOXYFILE_SOURCE_CLIENT
-    "${DOXYFILE_SOURCE_DIR}/tests/benchmarks \
-    ${DOXYFILE_SOURCE_DIR}/tests/unit_tests \
-    ${DOXYFILE_SOURCE_DIR}/tests/unit_tests/core \
-    ${DOXYFILE_SOURCE_DIR}/tests/unit_tests/core/crypto \
-    ${DOXYFILE_SOURCE_DIR}/tests/unit_tests/core/crypto/util \
-    ${DOXYFILE_SOURCE_DIR}/tests/unit_tests/core/util"
-    STRING "Unit-tests/Benchmarks")
-
-  set(DOXYFILE_SOURCE_DIRS
-    "${DOXYFILE_SOURCE_DIR} \
-    ${DOXYFILE_SOURCE_API} \
-    ${DOXYFILE_SOURCE_CLIENT} \
-    ${DOXYFILE_SOURCE_CORE} \
-    ${DOXYFILE_SOURCE_TESTS}")
-
   usedoxygen_set_default(DOXYFILE_LATEX YES BOOL "Generate LaTeX API documentation" OFF)
   usedoxygen_set_default(DOXYFILE_LATEX_DIR "latex" STRING "LaTex output directory")
 

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -14,8 +14,9 @@
 Optional:
 
 - [Clang](http://clang.llvm.org/) 3.5 ([3.6 on FreeBSD](https://llvm.org/bugs/show_bug.cgi?id=28887))
-- [Doxygen](http://www.doxygen.org/) 1.8.6
 - [MiniUPnP](http://miniupnp.free.fr/files/) 1.6
+- [Doxygen](http://www.doxygen.org/) 1.8.6
+- [Graphviz](http://graphviz.org/) 2.36
 
 ### MacOSX
 - [Homebrew](http://brew.sh/)
@@ -25,7 +26,7 @@ Optional:
 ###  Amazon EC2
 ```bash
 $ sudo yum install gcc-c++ cmake openssl-devel libquadmath
-$ sudo yum install doxygen  # optional
+$ sudo yum install doxygen graphviz # optional
 $ wget https://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.tar.gz
 $ tar -xf boost_1_61_0.tar.gz
 $ cd boost_1_61_0
@@ -39,7 +40,8 @@ $ export BOOST_ROOT
 ```bash
 $ sudo apt-get install g++-4.9 cmake libboost-all-dev libssl-dev libssl1.0.0
 $ sudo apt-get install clang-3.5  # optional
-$ sudo apt-get install libminiupnpc-dev doxygen  # optional
+$ sudo apt-get install doxygen graphviz  # optional
+$ sudo apt-get install libminiupnpc-dev  # optional
 ```
 
 ### Ubuntu Trusty 14.04:
@@ -51,7 +53,8 @@ $ sudo apt-get update
 $ sudo apt-get install libboost-{chrono,log,program-options,date-time,thread,system,filesystem,regex,test}1.58{-dev,.0}
 $ sudo apt-get install g++-4.9 cmake libboost-all-dev libssl-dev libssl1.0.0
 $ sudo apt-get install clang-3.5  # optional
-$ sudo apt-get install libminiupnpc-dev doxygen  # optional
+$ sudo apt-get install doxygen graphviz  # optional
+$ sudo apt-get install libminiupnpc-dev  # optional
 
 ```
 
@@ -59,20 +62,23 @@ $ sudo apt-get install libminiupnpc-dev doxygen  # optional
 ```bash
 $ sudo pacman -Syu cmake boost  # gcc/g++ and openssl installed by default
 $ sudo pacman -S clang  # optional
-$ sudo pacman -S miniupnpc doxygen  # optional
+$ sudo pacman -S doxygen graphviz  # optional
+$ sudo pacman -S miniupnpc  # optional
 ```
 
 ### MacOSX
 ```bash
 $ brew install cmake boost openssl # clang installed by default
-$ brew install miniupnpc doxygen  # optional
+$ brew install doxygen graphviz # optional
+$ brew install miniupnpc  # optional
 ```
 Note: see Clang build instructions below
 
 ### FreeBSD 10
 ```bash
 $ sudo pkg install git cmake gmake clang36 openssl
-$ sudo pkg install miniupnpc doxygen  # optional
+$ sudo pkg install doxygen graphviz  # optional
+$ sudo pkg install miniupnpc # optional
 # Build latest boost (1.58 minimum)
 $ wget https://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.tar.bz2/download -O boost_1_61_0.tar.bz2
 $ tar xvjf boost_1_61_0.tar.bz2 && cd boost_1_61_0
@@ -93,6 +99,7 @@ pacman -Su
 * For those of you already familiar with pacman, you can run the normal ```pacman -Syu``` to update, but you may get errors and need to restart MSYS2 if pacman's dependencies are updated.
 * Install dependencies: ```pacman -S make mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc mingw-w64-x86_64-boost mingw-w64-x86_64-openssl```
 * Optional: ```mingw-w64-x86_64-doxygen mingw-w64-x86_64-miniupnpc```
+* Note: if using doxygen, you'll need [Graphviz](http://graphviz.org/doc/winbuild.html)
 
 ## Step 3. Build
 Minimum requirement:


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

- The previous input filter was somehow preventing a fair amount of code
  from being processed. We don't need the filter for now as its only
  purpose was to showcase TODO's.
- Without paranthesis around cmake's input for source dirs, recursion
  wouldn't work correctly. Solution: add paranthesis.
- Add graphviz dependency to building docs
- Add graphviz dependency to Travis CI