### PR TITLE
Build: add CXXFLAGS for clang/cryptopp to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,13 @@
 
 #TODO(unassigned): improve this Makefile
 
+# TODO(unassigned): hack for weidai11/cryptopp#232
+# Only needed for clang but doesn't hurt with gcc
+ifeq ($(CXXFLAGS),)
+  CXXFLAGS += -maes -march=native
+  export CXXFLAGS
+endif
+
 # Get custom data path
 # If no path is given, set default path
 system := $(shell uname)

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -141,12 +141,11 @@ To build with clang, you **must** export the following:
 
 ```bash
 $ export CC=clang CXX=clang++  # replace ```clang``` with a clang version/path of your choosing
-$ export CXXFLAGS="-maes -march=native"  # weidai11/cryptopp#232
 ```
 
 ### FreeBSD
 ```bash
-$ export CC=clang36 CXX=clang++36 CXXFLAGS="-maes -march=native"
+$ export CC=clang36 CXX=clang++36
 $ gmake dependencies && gmake && gmake install-resources
 ```
 - Replace ```make``` with ```gmake``` for all other build options


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

- Needed for weidai11/cryptopp#232
- Remove requirement from docs