### PR TITLE
Refactor I2np protocol message with unique_ptr

### DIFF
--- a/src/client/datagram.h
+++ b/src/client/datagram.h
@@ -99,16 +99,16 @@ class DatagramDestination {
  private:
   void HandleLeaseSetRequestComplete(
       std::shared_ptr<i2p::data::LeaseSet> leaseSet,
-      I2NPMessage* msg);
+      std::unique_ptr<I2NPMessage> msg);
 
-  I2NPMessage* CreateDataMessage(
+  std::unique_ptr<I2NPMessage> CreateDataMessage(
       const uint8_t* payload,
       size_t len,
       uint16_t fromPort,
       uint16_t toPort);
 
   void SendMsg(
-      I2NPMessage* msg,
+      std::unique_ptr<I2NPMessage> msg,
       std::shared_ptr<const i2p::data::LeaseSet> remote);
 
   void HandleDatagram(

--- a/src/core/i2np_protocol.h
+++ b/src/core/i2np_protocol.h
@@ -299,6 +299,9 @@ struct I2NPMessageBuffer : public I2NPMessage {
   uint8_t m_Buffer[SZ + 16] = {};
 };
 
+// TODO(rakhimov): Consider shared_ptr instead of unique_ptr
+//                 if a shared msg is the common case.
+//                 ``ToSharedI2NPMessage`` is already providing a shared_ptr.
 std::unique_ptr<I2NPMessage> NewI2NPMessage();
 std::unique_ptr<I2NPMessage> NewI2NPMessage(
     size_t len);

--- a/src/core/i2np_protocol.h
+++ b/src/core/i2np_protocol.h
@@ -33,11 +33,11 @@
 #ifndef SRC_CORE_I2NP_PROTOCOL_H_
 #define SRC_CORE_I2NP_PROTOCOL_H_
 
-#include <inttypes.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
-#include <set>
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "identity.h"
@@ -299,23 +299,21 @@ struct I2NPMessageBuffer : public I2NPMessage {
   uint8_t m_Buffer[SZ + 16] = {};
 };
 
-I2NPMessage* NewI2NPMessage();
-I2NPMessage* NewI2NPMessage(
+std::unique_ptr<I2NPMessage> NewI2NPMessage();
+std::unique_ptr<I2NPMessage> NewI2NPMessage(
     size_t len);
 
-I2NPMessage* NewI2NPShortMessage();
-
-void DeleteI2NPMessage(
-    I2NPMessage* msg);
+std::unique_ptr<I2NPMessage> NewI2NPShortMessage();
 
 std::shared_ptr<I2NPMessage> ToSharedI2NPMessage(
-    I2NPMessage* msg);
+    std::unique_ptr<I2NPMessage> msg);
 
-I2NPMessage* CreateI2NPMessage(
+std::unique_ptr<I2NPMessage> CreateI2NPMessage(
     I2NPMessageType msgType,
     const uint8_t* buf,
     int len,
     uint32_t replyMsgID = 0);
+
 std::shared_ptr<I2NPMessage> CreateI2NPMessage(
     const uint8_t* buf,
     int len,
@@ -367,24 +365,27 @@ void HandleTunnelBuildMsg(
     uint8_t* buf,
     size_t len);
 
-I2NPMessage* CreateTunnelDataMsg(
+std::unique_ptr<I2NPMessage> CreateTunnelDataMsg(
     const uint8_t * buf);
-I2NPMessage* CreateTunnelDataMsg(
+
+std::unique_ptr<I2NPMessage> CreateTunnelDataMsg(
     uint32_t tunnelID,
     const uint8_t* payload);
 
 std::shared_ptr<I2NPMessage> CreateEmptyTunnelDataMsg();
 
-I2NPMessage* CreateTunnelGatewayMsg(
+std::unique_ptr<I2NPMessage> CreateTunnelGatewayMsg(
     uint32_t tunnelID,
     const uint8_t* buf,
     size_t len);
-I2NPMessage* CreateTunnelGatewayMsg(
+
+std::unique_ptr<I2NPMessage> CreateTunnelGatewayMsg(
     uint32_t tunnelID,
     I2NPMessageType msgType,
     const uint8_t* buf,
     size_t len,
     uint32_t replyMsgID = 0);
+
 std::shared_ptr<I2NPMessage> CreateTunnelGatewayMsg(
     uint32_t tunnelID,
     std::shared_ptr<I2NPMessage> msg);
@@ -395,6 +396,7 @@ size_t GetI2NPMessageLength(
 void HandleI2NPMessage(
     uint8_t* msg,
     size_t len);
+
 void HandleI2NPMessage(
     std::shared_ptr<I2NPMessage> msg);
 

--- a/src/core/transport/ntcp_session.cc
+++ b/src/core/transport/ntcp_session.cc
@@ -886,7 +886,7 @@ bool NTCPSession::DecryptNextBlock(
           static_cast<std::size_t>(NTCPSize::phase3_alice_ri) ?
             NewI2NPShortMessage() :
             NewI2NPMessage();
-      m_NextMessage = ToSharedI2NPMessage(msg);
+      m_NextMessage = ToSharedI2NPMessage(std::move(msg));
       memcpy(
           m_NextMessage->buf,
           buf.data(),

--- a/src/core/tunnel/tunnel.cc
+++ b/src/core/tunnel/tunnel.cc
@@ -120,11 +120,11 @@ void Tunnel::Build(
     outboundTunnel->SendTunnelDataMsg(
         GetNextIdentHash(),
         0,
-        ToSharedI2NPMessage(msg));
+        ToSharedI2NPMessage(std::move(msg)));
   else
     i2p::transport::transports.SendMessage(
         GetNextIdentHash(),
-        ToSharedI2NPMessage(msg));
+        ToSharedI2NPMessage(std::move(msg)));
 }
 
 bool Tunnel::HandleTunnelBuildResponse(


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [x] I confirm.

---

The message is refactored with a unique_ptr instead of a raw pointer that acts like a handle.
Releasable shared_ptr is implemented to make callback functions copy constructible.
This seems to suggest that messages must be constructed with a shared_ptr by default.

If that is the case,
I will rewrite the messages with the shared_ptr instead of unique_ptr.

This approach should solve some false-positives from Coverity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/monero-project/kovri/327)
<!-- Reviewable:end -->
