### PR TITLE
MTU: resolve CID 135924 (strncpy() not null-terminated). Refs #263.

### DIFF
--- a/src/core/util/mtu.cc
+++ b/src/core/util/mtu.cc
@@ -122,7 +122,8 @@ int GetMTUUnix(
     if (fd > 0) {
       ifreq ifr;
       // set interface for query
-      strcpy(ifr.ifr_name, ifa->ifa_name);
+      strncpy(ifr.ifr_name, ifa->ifa_name,IFNAMSIZ);
+      ifr.ifr_name[IFNAMSIZ]='\0';
       if (ioctl(fd, SIOCGIFMTU, &ifr) >= 0)
         mtu = ifr.ifr_mtu;  // MTU
       else

--- a/src/core/util/mtu.cc
+++ b/src/core/util/mtu.cc
@@ -122,7 +122,8 @@ int GetMTUUnix(
     if (fd > 0) {
       ifreq ifr;
       // set interface for query
-      strncpy(ifr.ifr_name, ifa->ifa_name, IFNAMSIZ);
+//      strncpy(ifr.ifr_name, ifa->ifa_name, IFNAMSIZ);
+      strcpy(ifr.ifr_name, ifa->ifa_name);
       if (ioctl(fd, SIOCGIFMTU, &ifr) >= 0)
         mtu = ifr.ifr_mtu;  // MTU
       else

--- a/src/core/util/mtu.cc
+++ b/src/core/util/mtu.cc
@@ -122,7 +122,6 @@ int GetMTUUnix(
     if (fd > 0) {
       ifreq ifr;
       // set interface for query
-//      strncpy(ifr.ifr_name, ifa->ifa_name, IFNAMSIZ);
       strcpy(ifr.ifr_name, ifa->ifa_name);
       if (ioctl(fd, SIOCGIFMTU, &ifr) >= 0)
         mtu = ifr.ifr_mtu;  // MTU


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [ x] I confirm.

---

*Enter your pull-request summary here*
This should take care of the error on coverity CID 135924
sockets on my server are not v6 they are v4 so I was not able to test this branch of the code.
I am not familiar with how I would go about settting up a v6 socket.  I do see I can add support for V6, but that did not appear to send the code down this method.
I did look up if the struct irfreq at http://linux.die.net/man/7/netdevice.
It is initialized to the size IFNAMSIZ already.
struct ifreq {
    char ifr_name[IFNAMSIZ]; /* Interface name */

…ination