### PR TITLE
Transports: implement #348, set SSU extended options, default EdDSA

### DIFF
--- a/src/core/identity.cc
+++ b/src/core/identity.cc
@@ -307,7 +307,7 @@ size_t IdentityEx::GetSignatureLen() const {
     CreateVerifier();
   if (m_Verifier)
     return m_Verifier->GetSignatureLen();
-  return 40;
+  return i2p::crypto::DSA_SIGNATURE_LENGTH;
 }
 bool IdentityEx::Verify(
     const uint8_t* buf,
@@ -527,59 +527,62 @@ void PrivateKeys::CreateSigner() {
 }
 
 PrivateKeys PrivateKeys::CreateRandomKeys(SigningKeyType type) {
-  if (type != SIGNING_KEY_TYPE_DSA_SHA1) {
-    PrivateKeys keys;
-    // signature
-    uint8_t signingPublicKey[512];  // signing public key is 512 bytes max
-    switch (type) {
-      case SIGNING_KEY_TYPE_ECDSA_SHA256_P256:
-        i2p::crypto::CreateECDSAP256RandomKeys(
-            keys.m_SigningPrivateKey,
-            signingPublicKey);
-      break;
-      case SIGNING_KEY_TYPE_ECDSA_SHA384_P384:
-        i2p::crypto::CreateECDSAP384RandomKeys(
-            keys.m_SigningPrivateKey,
-            signingPublicKey);
-      break;
-      case SIGNING_KEY_TYPE_ECDSA_SHA512_P521:
-        i2p::crypto::CreateECDSAP521RandomKeys(
-            keys.m_SigningPrivateKey,
-            signingPublicKey);
-      break;
-      case SIGNING_KEY_TYPE_RSA_SHA256_2048:
-        i2p::crypto::CreateRSARandomKeys(
-            i2p::crypto::RSASHA2562048_KEY_LENGTH,
-            keys.m_SigningPrivateKey,
-            signingPublicKey);
-      break;
-      case SIGNING_KEY_TYPE_RSA_SHA384_3072:
-        i2p::crypto::CreateRSARandomKeys(
-            i2p::crypto::RSASHA3843072_KEY_LENGTH,
-            keys.m_SigningPrivateKey,
-            signingPublicKey);
-      break;
-      case SIGNING_KEY_TYPE_RSA_SHA512_4096:
-        i2p::crypto::CreateRSARandomKeys(
-            i2p::crypto::RSASHA5124096_KEY_LENGTH,
-            keys.m_SigningPrivateKey,
-            signingPublicKey);
-      break;
-      default:
-        LogPrint(eLogWarn,
-            "IdentityEx: Signing key type ",
-            static_cast<int>(type), " is not supported, creating DSA-SHA1");
-        return PrivateKeys(i2p::data::CreateRandomKeys());  // DSA-SHA1
-    }
-    // encryption
-    uint8_t public_key[256];
-    i2p::crypto::GenerateElGamalKeyPair(keys.m_PrivateKey, public_key);
-    // identity
-    keys.m_Public = IdentityEx(public_key, signingPublicKey, type);
-    keys.CreateSigner();
-    return keys;
+  PrivateKeys keys;
+  // signature
+  uint8_t signingPublicKey[512];  // signing public key is 512 bytes max
+  switch (type) {
+    case SIGNING_KEY_TYPE_ECDSA_SHA256_P256:
+      i2p::crypto::CreateECDSAP256RandomKeys(
+          keys.m_SigningPrivateKey,
+          signingPublicKey);
+    break;
+    case SIGNING_KEY_TYPE_ECDSA_SHA384_P384:
+      i2p::crypto::CreateECDSAP384RandomKeys(
+          keys.m_SigningPrivateKey,
+          signingPublicKey);
+    break;
+    case SIGNING_KEY_TYPE_ECDSA_SHA512_P521:
+      i2p::crypto::CreateECDSAP521RandomKeys(
+          keys.m_SigningPrivateKey,
+          signingPublicKey);
+    break;
+    case SIGNING_KEY_TYPE_RSA_SHA256_2048:
+      i2p::crypto::CreateRSARandomKeys(
+          i2p::crypto::RSASHA2562048_KEY_LENGTH,
+          keys.m_SigningPrivateKey,
+          signingPublicKey);
+    break;
+    case SIGNING_KEY_TYPE_RSA_SHA384_3072:
+      i2p::crypto::CreateRSARandomKeys(
+          i2p::crypto::RSASHA3843072_KEY_LENGTH,
+          keys.m_SigningPrivateKey,
+          signingPublicKey);
+    break;
+    case SIGNING_KEY_TYPE_RSA_SHA512_4096:
+      i2p::crypto::CreateRSARandomKeys(
+          i2p::crypto::RSASHA5124096_KEY_LENGTH,
+          keys.m_SigningPrivateKey,
+          signingPublicKey);
+    break;
+    case SIGNING_KEY_TYPE_EDDSA_SHA512_ED25519:
+      i2p::crypto::CreateEDDSARandomKeys(
+          keys.m_SigningPrivateKey,
+          signingPublicKey);
+    break;
+    default: // Includes 
+      LogPrint(eLogWarning,
+          "IdentityEx: Signing key type ",
+          static_cast<int>(type), " is not supported, creating DSA-SHA1");
+    case SIGNING_KEY_TYPE_DSA_SHA1:
+      return PrivateKeys(i2p::data::CreateRandomKeys());  // DSA-SHA1
   }
-  return PrivateKeys(i2p::data::CreateRandomKeys());  // DSA-SHA1
+  // encryption
+  uint8_t public_key[256];
+  i2p::crypto::GenerateElGamalKeyPair(keys.m_PrivateKey, public_key);
+  // identity
+  keys.m_Public = IdentityEx(public_key, signingPublicKey, type);
+  keys.CreateSigner();
+  return keys;
 }
 
 Keys CreateRandomKeys() {

--- a/src/core/identity.cc
+++ b/src/core/identity.cc
@@ -569,8 +569,8 @@ PrivateKeys PrivateKeys::CreateRandomKeys(SigningKeyType type) {
           keys.m_SigningPrivateKey,
           signingPublicKey);
     break;
-    default: // Includes 
-      LogPrint(eLogWarning,
+    default:
+      LogPrint(eLogWarn,
           "IdentityEx: Signing key type ",
           static_cast<int>(type), " is not supported, creating DSA-SHA1");
     case SIGNING_KEY_TYPE_DSA_SHA1:

--- a/src/core/transport/ntcp.h
+++ b/src/core/transport/ntcp.h
@@ -54,6 +54,7 @@ namespace transport {
 class NTCPServer {
  public:
   explicit NTCPServer(
+      boost::asio::io_service& service,
       std::size_t port);
 
   ~NTCPServer();
@@ -84,8 +85,6 @@ class NTCPServer {
       const std::shared_ptr<NTCPSession>& session);
 
  private:
-  void Run();
-
   void HandleAccept(
       std::shared_ptr<NTCPSession> conn,
       const boost::system::error_code& ecode);
@@ -100,10 +99,8 @@ class NTCPServer {
 
  private:
   bool m_IsRunning;
-  std::unique_ptr<std::thread> m_Thread;
 
-  boost::asio::io_service m_Service;
-  boost::asio::io_service::work m_Work;
+  boost::asio::io_service& m_Service;
 
   boost::asio::ip::tcp::endpoint m_NTCPEndpoint, m_NTCPEndpointV6;
   std::unique_ptr<boost::asio::ip::tcp::acceptor> m_NTCPAcceptor, m_NTCPV6Acceptor;

--- a/src/core/transport/ssu.cc
+++ b/src/core/transport/ssu.cc
@@ -53,17 +53,13 @@ namespace i2p {
 namespace transport {
 
 SSUServer::SSUServer(
+    boost::asio::io_service& service,
     std::size_t port)
-    : m_Thread(nullptr),
-      m_ThreadV6(nullptr),
-      m_ReceiversThread(nullptr),
-      m_Work(m_Service),
-      m_WorkV6(m_ServiceV6),
-      m_ReceiversWork(m_ReceiversService),
+    : m_Service(service),
       m_Endpoint(boost::asio::ip::udp::v4(), port),
       m_EndpointV6(boost::asio::ip::udp::v6(), port),
-      m_Socket(m_ReceiversService, m_Endpoint),
-      m_SocketV6(m_ReceiversService),
+      m_Socket(m_Service, m_Endpoint),
+      m_SocketV6(m_Service),
       m_IntroducersUpdateTimer(m_Service),
       m_PeerTestsCleanupTimer(m_Service) {
   m_Socket.set_option(boost::asio::socket_base::receive_buffer_size(65535));
@@ -82,27 +78,12 @@ SSUServer::~SSUServer() {}
 void SSUServer::Start() {
   LogPrint(eLogDebug, "SSUServer: starting");
   m_IsRunning = true;
-  m_ReceiversThread =
-    std::make_unique<std::thread>(
-        std::bind(
-          &SSUServer::RunReceivers,
-          this));
-  m_Thread =
-    std::make_unique<std::thread>(
-        std::bind(
-            &SSUServer::Run,
-            this));
-  m_ReceiversService.post(
+  m_Service.post(
       std::bind(
           &SSUServer::Receive,
           this));
   if (context.SupportsV6()) {
-    m_ThreadV6 =
-      std::make_unique<std::thread>(
-          std::bind(
-              &SSUServer::RunV6,
-              this));
-    m_ReceiversService.post(
+    m_Service.post(
         std::bind(
             &SSUServer::ReceiveV6,
             this));
@@ -116,62 +97,8 @@ void SSUServer::Stop() {
   LogPrint(eLogDebug, "SSUServer: stopping");
   DeleteAllSessions();
   m_IsRunning = false;
-  m_Service.stop();
   m_Socket.close();
-  m_ServiceV6.stop();
   m_SocketV6.close();
-  m_ReceiversService.stop();
-  if (m_ReceiversThread) {
-    m_ReceiversThread->join();
-    m_ReceiversThread.reset(nullptr);
-  }
-  if (m_Thread) {
-    m_Thread->join();
-    m_Thread.reset(nullptr);
-  }
-  if (m_ThreadV6) {
-    m_ThreadV6->join();
-    m_ThreadV6.reset(nullptr);
-  }
-}
-
-void SSUServer::Run() {
-  while (m_IsRunning) {
-    try {
-      LogPrint(eLogDebug, "SSUServer: running ioservice");
-      m_Service.run();
-    }
-    catch (std::exception& ex) {
-      LogPrint(eLogError,
-          "SSUServer: Run() ioservice error: '", ex.what(), "'");
-    }
-  }
-}
-
-void SSUServer::RunV6() {
-  while (m_IsRunning) {
-    try {
-      LogPrint(eLogDebug, "SSUServer: running V6 ioservice");
-      m_ServiceV6.run();
-    }
-    catch (std::exception& ex) {
-      LogPrint(eLogError,
-          "SSUServer: RunV6() ioservice error: '", ex.what(), "'");
-    }
-  }
-}
-
-void SSUServer::RunReceivers() {
-  while (m_IsRunning) {
-    try {
-      LogPrint(eLogDebug, "SSUServer: running receivers ioservice");
-      m_ReceiversService.run();
-    }
-    catch (std::exception& ex) {
-      LogPrint(eLogError,
-          "SSUServer: RunReceivers() ioservice error: '", ex.what(), "'");
-    }
-  }
 }
 
 void SSUServer::AddRelay(
@@ -303,7 +230,7 @@ void SSUServer::HandleReceivedFromV6(
       packets.push_back(packet);
       moreBytes = m_SocketV6.available();
     }
-    m_ServiceV6.post(
+    m_Service.post(
         std::bind(
             &SSUServer::HandleReceivedPackets,
             this,

--- a/src/core/transport/ssu.h
+++ b/src/core/transport/ssu.h
@@ -71,6 +71,7 @@ struct SSUPacket {
 class SSUServer {
  public:
   SSUServer(
+      boost::asio::io_service& service,
       std::size_t port);
 
   ~SSUServer();
@@ -99,10 +100,6 @@ class SSUServer {
 
   boost::asio::io_service& GetService() {
     return m_Service;
-  }
-
-  boost::asio::io_service& GetServiceV6() {
-    return m_ServiceV6;
   }
 
   const boost::asio::ip::udp::endpoint& GetEndpoint() const {
@@ -189,10 +186,7 @@ class SSUServer {
 
   bool m_IsRunning;
 
-  std::unique_ptr<std::thread> m_Thread, m_ThreadV6, m_ReceiversThread;
-
-  boost::asio::io_service m_Service, m_ServiceV6, m_ReceiversService;
-  boost::asio::io_service::work m_Work, m_WorkV6, m_ReceiversWork;
+  boost::asio::io_service& m_Service;
 
   boost::asio::ip::udp::endpoint m_Endpoint, m_EndpointV6;
   boost::asio::ip::udp::socket m_Socket, m_SocketV6;

--- a/src/core/transport/ssu.h
+++ b/src/core/transport/ssu.h
@@ -137,12 +137,6 @@ class SSUServer {
       uint32_t nonce);
 
  private:
-  void Run();
-
-  void RunV6();
-
-  void RunReceivers();
-
   void Receive();
 
   void ReceiveV6();

--- a/src/core/transport/ssu_session.cc
+++ b/src/core/transport/ssu_session.cc
@@ -164,9 +164,7 @@ SSUSession::SSUSession(
 SSUSession::~SSUSession() {}
 
 boost::asio::io_service& SSUSession::GetService() {
-  return IsV6() ?
-    m_Server.GetServiceV6() :
-    m_Server.GetService();
+  return m_Server.GetService();
 }
 
 void SSUSession::CreateAESandMacKey(

--- a/src/core/transport/ssu_session.h
+++ b/src/core/transport/ssu_session.h
@@ -383,7 +383,8 @@ class SSUSession
       size_t len,
       const uint8_t* aesKey,
       const uint8_t* iv,
-      const uint8_t* macKey);
+      const uint8_t* macKey,
+      uint8_t flag = 0);
 
   // With session key
   void FillHeaderAndEncrypt(

--- a/src/core/transport/transports.cc
+++ b/src/core/transport/transports.cc
@@ -165,7 +165,7 @@ void Transports::Start() {
         i2p::data::RouterInfo::eTransportNTCP && address.host.is_v4()) {
       if (!m_NTCPServer) {
         LogPrint(eLogInfo, "Transports: TCP listening on port ", address.port);
-        m_NTCPServer = std::make_unique<NTCPServer>(address.port);
+        m_NTCPServer = std::make_unique<NTCPServer>(m_Service, address.port);
         m_NTCPServer->Start();
       } else {
         LogPrint(eLogError, "Transports: TCP server already exists");

--- a/src/core/transport/transports.cc
+++ b/src/core/transport/transports.cc
@@ -175,7 +175,7 @@ void Transports::Start() {
         i2p::data::RouterInfo::eTransportSSU && address.host.is_v4()) {
       if (!m_SSUServer) {
         LogPrint(eLogInfo, "Transports: UDP listening on port ", address.port);
-        m_SSUServer = std::make_unique<SSUServer>(address.port);
+        m_SSUServer = std::make_unique<SSUServer>(m_Service, address.port);
         m_SSUServer->Start();
         DetectExternalIP();
       } else {

--- a/src/core/transport/transports.cc
+++ b/src/core/transport/transports.cc
@@ -239,10 +239,11 @@ void Transports::UpdateBandwidth() {
   if (m_LastBandwidthUpdateTime > 0) {
     auto delta = ts - m_LastBandwidthUpdateTime;
     if (delta > 0) {
+      // Bandwidth in bytes per second
       m_InBandwidth =
-        (m_TotalReceivedBytes - m_LastInBandwidthUpdateBytes) * 1000 / delta;  // per second
+        (m_TotalReceivedBytes - m_LastInBandwidthUpdateBytes) * 1000 / delta;
       m_OutBandwidth =
-        (m_TotalSentBytes - m_LastOutBandwidthUpdateBytes) * 1000 / delta;  // per second
+        (m_TotalSentBytes - m_LastOutBandwidthUpdateBytes) * 1000 / delta;
     }
   }
   m_LastBandwidthUpdateTime = ts;
@@ -295,10 +296,9 @@ void Transports::PostMessages(
     bool connected = false;
     try {
       auto router = i2p::data::netdb.FindRouter(ident);
-      it = m_Peers.insert(
-          std::make_pair(
-              ident,
-              Peer{ 0, router, {}, i2p::util::GetSecondsSinceEpoch(), {} })).first;
+      it = m_Peers.insert(std::make_pair(
+          ident,
+          Peer{ 0, router, {}, i2p::util::GetSecondsSinceEpoch(), {} })).first;
       connected = ConnectToPeer(ident, it->second);
     } catch (std::exception& ex) {
       LogPrint(eLogError, "Transports: PostMessages(): '", ex.what(), "'");
@@ -317,7 +317,7 @@ void Transports::PostMessages(
 bool Transports::ConnectToPeer(
     const i2p::data::IdentHash& ident,
     Peer& peer) {
-  if (!peer.router) { // We don't have the RI
+  if (!peer.router) {  // We don't have the RI
     LogPrint(eLogDebug, "Transports: RI not found, requesting");
     i2p::data::netdb.RequestDestination(
         ident,
@@ -358,14 +358,14 @@ bool Transports::ConnectToPeer(
       "no NTCP/SSU address available");
   peer.Done();
   m_Peers.erase(ident);
-  return false;  
+  return false;
 }
 
 bool Transports::ConnectToPeerNTCP(
     const i2p::data::IdentHash& ident,
     Peer& peer) {
   if (!m_NTCPServer)
-    return false; // NTCP not supported
+    return false;  // NTCP not supported
 
   LogPrint(eLogDebug,
       "Transports: attempting NTCP for peer",
@@ -396,7 +396,7 @@ bool Transports::ConnectToPeerNTCP(
 
 bool Transports::ConnectToPeerSSU(Peer& peer) {
   if (!m_SSUServer)
-    return false; // SSU not supported
+    return false;  // SSU not supported
 
   LogPrint(eLogDebug,
     "Transports: attempting SSU for peer",
@@ -510,8 +510,8 @@ void Transports::PostCloseSession(
         "Transports: SSU session [",
         router->GetIdentHashAbbreviation(), "] closed");
   }
-  auto ntcp_session =
-    m_NTCPServer ? m_NTCPServer->FindNTCPSession(router->GetIdentHash()) : nullptr;
+  auto ntcp_session = m_NTCPServer ?
+      m_NTCPServer->FindNTCPSession(router->GetIdentHash()) : nullptr;
   if (ntcp_session) {
     m_NTCPServer->RemoveNTCPSession(ntcp_session);
     LogPrint(eLogInfo,
@@ -523,7 +523,7 @@ void Transports::PostCloseSession(
 void Transports::DetectExternalIP() {
   LogPrint(eLogDebug, "Transports: detecting external IP");
 
-  if (!m_SSUServer) { // SSU not supported
+  if (!m_SSUServer) {  // SSU not supported
     LogPrint(eLogError,
         "Transports: can't detect external IP, SSU is not available");
     return;

--- a/src/core/transport/transports.cc
+++ b/src/core/transport/transports.cc
@@ -37,6 +37,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <ostream>
 
 #include "i2np_protocol.h"
 #include "net_db.h"
@@ -125,6 +126,11 @@ void DHKeysPairSupplier::Return(
   m_Queue.push(std::move(pair));
 }
 
+void Peer::Done() {
+  for (auto it : sessions)
+    it->Done();
+}
+
 Transports transports;
 
 Transports::Transports()
@@ -158,8 +164,8 @@ void Transports::Start() {
   m_IsRunning = true;
   m_Thread = std::make_unique<std::thread>(std::bind(&Transports::Run, this));
   // create acceptors
-  auto addresses = context.GetRouterInfo().GetAddresses();
-  for (auto& address : addresses) {
+  const auto addresses = context.GetRouterInfo().GetAddresses();
+  for (const auto& address : addresses) {
     LogPrint("Transports: creating servers for address ", address.host);
     if (address.transport_style ==
         i2p::data::RouterInfo::eTransportNTCP && address.host.is_v4()) {
@@ -229,7 +235,7 @@ void Transports::Run() {
 
 void Transports::UpdateBandwidth() {
   LogPrint(eLogDebug, "Transports: updating bandwidth");
-  uint64_t ts = i2p::util::GetMillisecondsSinceEpoch();
+  const uint64_t ts = i2p::util::GetMillisecondsSinceEpoch();
   if (m_LastBandwidthUpdateTime > 0) {
     auto delta = ts - m_LastBandwidthUpdateTime;
     if (delta > 0) {
@@ -297,7 +303,8 @@ void Transports::PostMessages(
     } catch (std::exception& ex) {
       LogPrint(eLogError, "Transports: PostMessages(): '", ex.what(), "'");
     }
-    if (!connected) return;
+    if (!connected)
+      return;
   }
   if (!it->second.sessions.empty()) {
     it->second.sessions.front()->SendI2NPMessages(msgs);
@@ -310,58 +317,7 @@ void Transports::PostMessages(
 bool Transports::ConnectToPeer(
     const i2p::data::IdentHash& ident,
     Peer& peer) {
-  // we have RI already
-  if (peer.router) {
-    LogPrint(eLogDebug,
-        "Transports: connecting to peer",
-        GetFormattedSessionInfo(peer.router));
-    // NTCP
-    if (!peer.num_attempts && i2p::context.SupportsNTCP()) {
-      LogPrint(eLogDebug,
-          "Transports: attempting NTCP for peer",
-          GetFormattedSessionInfo(peer.router));
-      peer.num_attempts++;
-      auto address = peer.router->GetNTCPAddress(!context.SupportsV6());
-      if (address) {
-#if BOOST_VERSION >= 104900
-        if (!address->host.is_unspecified())  // we have address now
-#else
-        boost::system::error_code ecode;
-        address->host.to_string(ecode);
-        if (!ecode)
-#endif
-        {
-          if (!peer.router->UsesIntroducer() && !peer.router->IsUnreachable()) {
-            auto s = std::make_shared<NTCPSession>(*m_NTCPServer, peer.router);
-            m_NTCPServer->Connect(address->host, address->port, s);
-            return true;
-          }
-        } else {  // we don't have address
-          if (address->address_string.length() > 0) {  // trying to resolve
-            LogPrint(eLogInfo,
-                "Transports: NTCP resolving ", address->address_string);
-            NTCPResolve(address->address_string, ident);
-            return true;
-          }
-        }
-      }
-    } else if (peer.num_attempts == 1 && i2p::context.SupportsSSU()) {  // SSU
-      LogPrint(eLogDebug,
-         "Transports: attempting SSU for peer",
-          GetFormattedSessionInfo(peer.router));
-      peer.num_attempts++;
-      if (m_SSUServer) {
-        if (m_SSUServer->GetSession(peer.router))
-          return true;
-      }
-    }
-    LogPrint(eLogError,
-        "Transports:", GetFormattedSessionInfo(peer.router),
-        "no NTCP/SSU address available");
-    peer.Done();
-    m_Peers.erase(ident);
-    return false;
-  } else {  // otherwise request RI
+  if (!peer.router) { // We don't have the RI
     LogPrint(eLogDebug, "Transports: RI not found, requesting");
     i2p::data::netdb.RequestDestination(
         ident,
@@ -370,9 +326,89 @@ bool Transports::ConnectToPeer(
             this,
             std::placeholders::_1,
             ident));
+    return true;
   }
-  return true;
+
+  // We have the RI, connect to it
+  LogPrint(eLogDebug,
+      "Transports: connecting to peer",
+      GetFormattedSessionInfo(peer.router));
+
+  // If only NTCP or SSU is supported, always try the supported transport
+  // If both are supported, SSU is used for the second attempt
+  // Peers that fail on all supported transports are removed
+  bool result = false;
+  if (!m_NTCPServer && m_SSUServer)
+    result = ConnectToPeerSSU(peer);
+  else if (m_NTCPServer && !m_SSUServer)
+    result = ConnectToPeerNTCP(ident, peer);
+  else if (peer.num_attempts == 0)
+    result = ConnectToPeerNTCP(ident, peer);
+  else if (peer.num_attempts == 1)
+    result = ConnectToPeerSSU(peer);
+
+  // Increase the number of attempts (even when no transports are available)
+  ++peer.num_attempts;
+  if (result)
+    return true;
+
+  // Couldn't connect, get rid of this peer
+  LogPrint(eLogError,
+      "Transports:", GetFormattedSessionInfo(peer.router),
+      "no NTCP/SSU address available");
+  peer.Done();
+  m_Peers.erase(ident);
+  return false;  
 }
+
+bool Transports::ConnectToPeerNTCP(
+    const i2p::data::IdentHash& ident,
+    Peer& peer) {
+  if (!m_NTCPServer)
+    return false; // NTCP not supported
+
+  LogPrint(eLogDebug,
+      "Transports: attempting NTCP for peer",
+      GetFormattedSessionInfo(peer.router));
+
+  const auto address = peer.router->GetNTCPAddress(!context.SupportsV6());
+
+  // No NTCP address found
+  if (!address)
+    return false;
+
+  if (!address->host.is_unspecified()) {
+    if (!peer.router->UsesIntroducer() && !peer.router->IsUnreachable()) {
+      auto s = std::make_shared<NTCPSession>(*m_NTCPServer, peer.router);
+      m_NTCPServer->Connect(address->host, address->port, s);
+      return true;
+    }
+  } else {  // we don't have address
+    if (address->address_string.length() > 0) {  // trying to resolve
+      LogPrint(eLogInfo,
+          "Transports: NTCP resolving ", address->address_string);
+          NTCPResolve(address->address_string, ident);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool Transports::ConnectToPeerSSU(Peer& peer) {
+  if (!m_SSUServer)
+    return false; // SSU not supported
+
+  LogPrint(eLogDebug,
+    "Transports: attempting SSU for peer",
+    GetFormattedSessionInfo(peer.router));
+
+  if (m_SSUServer->GetSession(peer.router))
+    return true;
+
+  return false;
+}
+
+
 
 void Transports::RequestComplete(
     std::shared_ptr<const i2p::data::RouterInfo> router,
@@ -452,6 +488,7 @@ void Transports::CloseSession(
     std::shared_ptr<const i2p::data::RouterInfo> router) {
   if (!router)
     return;
+
   LogPrint(eLogDebug,
       "Transports: closing session for [",
       router->GetIdentHashAbbreviation(), "]");
@@ -485,22 +522,25 @@ void Transports::PostCloseSession(
 
 void Transports::DetectExternalIP() {
   LogPrint(eLogDebug, "Transports: detecting external IP");
-  if (m_SSUServer) {
-    i2p::context.SetStatus(eRouterStatusTesting);
-    for (int i = 0; i < 5; i++) {
-      auto router = i2p::data::netdb.GetRandomPeerTestRouter();
-      if (router  && router->IsSSU()) {
-        m_SSUServer->GetSession(router, true);  // peer test
-      } else {
-        // if not peer test capable routers found pick any
-        router = i2p::data::netdb.GetRandomRouter();
-        if (router && router->IsSSU())
-          m_SSUServer->GetSession(router);  // no peer test
-      }
-    }
-  } else {
+
+  if (!m_SSUServer) { // SSU not supported
     LogPrint(eLogError,
         "Transports: can't detect external IP, SSU is not available");
+    return;
+  }
+
+  i2p::context.SetStatus(eRouterStatusTesting);
+  // TODO(unassigned): Why 5 times? (make constant)
+  for (int i = 0; i < 5; i++) {
+    auto router = i2p::data::netdb.GetRandomPeerTestRouter();
+    if (router && router->IsSSU()) {
+      m_SSUServer->GetSession(router, true);  // peer test
+    } else {
+      // if not peer test capable routers found pick any
+      router = i2p::data::netdb.GetRandomRouter();
+      if (router && router->IsSSU())
+        m_SSUServer->GetSession(router);  // no peer test
+    }
   }
 }
 
@@ -610,6 +650,17 @@ std::shared_ptr<const i2p::data::RouterInfo> Transports::GetRandomPeer() const {
       i2p::crypto::RandInRange<size_t>(0, s - 1));
   return it->second.router;
 }
+
+std::string Transports::GetFormattedSessionInfo(
+    std::shared_ptr<const i2p::data::RouterInfo>& router) const {
+  if (router) {
+    std::ostringstream info;
+    info << " [" << router->GetIdentHashAbbreviation() << "] ";
+    return info.str();
+  }
+  return "[hash unavailable]";
+}
+
 
 }  // namespace transport
 }  // namespace i2p

--- a/src/core/transport/transports.h
+++ b/src/core/transport/transports.h
@@ -43,7 +43,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <ostream>
 #include <queue>
 #include <string>
 #include <thread>
@@ -64,6 +63,9 @@
 namespace i2p {
 namespace transport {
 
+/// @class DHKeysPairSupplier
+/// @brief Pregenerates Diffie-Hellman key pairs for use in key exchange
+/// TODO(unassigned): Does this really need to run on a separate thread?
 class DHKeysPairSupplier {
  public:
   DHKeysPairSupplier(
@@ -95,53 +97,81 @@ class DHKeysPairSupplier {
   std::mutex m_AcquiredMutex;
 };
 
+/// @class Peer
+/// @brief Stores information about transport peers.
 struct Peer {
   std::size_t num_attempts;
   std::shared_ptr<const i2p::data::RouterInfo> router;
   std::list<std::shared_ptr<TransportSession>> sessions;
   std::uint64_t creation_time;
   std::vector<std::shared_ptr<i2p::I2NPMessage>> delayed_messages;
-  void Done() {
-    for (auto it : sessions)
-      it->Done();
-  }
+
+  void Done();
 };
 
 const std::size_t SESSION_CREATION_TIMEOUT = 10;  // in seconds
-const std::uint32_t LOW_BANDWIDTH_LIMIT = 32 * 1024;  // 32KBs
+const std::uint32_t LOW_BANDWIDTH_LIMIT = 32 * 1024;  // 32KBps
 
+/// @class Transports
+/// @brief Provides functions to pass messages to a given peer.
+///        Manages the SSU and NTCP transports.
 class Transports {
  public:
   Transports();
+
   ~Transports();
 
+  /// @brief Starts SSU and NTCP server instances, as well as the cleanup timer.
+  ///        If enabled, the UPnP service is also started.
   void Start();
 
+  /// @brief Stops all services ran by this Transports object.
   void Stop();
 
+  /// @return a reference to the boost::asio::io_serivce that is used by this
+  ///         Transports object
   boost::asio::io_service& GetService() {
     return m_Service;
   }
 
+  /// @return a pointer to a Diffie-Hellman pair
   std::unique_ptr<i2p::transport::DHKeysPair> GetNextDHKeysPair();
 
+  /// @brief Returns a keypair for reuse.
+  // TODO(unassigned): Do not reuse ephemeral keys, the whole point is that they
+  //                   are not reused.
   void ReuseDHKeysPair(
       std::unique_ptr<DHKeysPair> pair);
 
+  /// @brief Asynchronously sends a message to a peer.
+  /// @param ident the router hash of the remote peer
+  /// @param msg the I2NP message to deliver
   void SendMessage(
       const i2p::data::IdentHash& ident,
       std::shared_ptr<i2p::I2NPMessage> msg);
 
+  /// @brief Asynchronously sends one or more messages to a peer.
+  /// @param ident the router hash of the remote peer
+  /// @param msgs the I2NP messages to deliver
   void SendMessages(
       const i2p::data::IdentHash& ident,
       const std::vector<std::shared_ptr<i2p::I2NPMessage>>& msgs);
 
+  /// @brief Asynchronously close all transport sessions to the given router.
+  /// @param router the i2p::data::RouterInfo of the router to disconnect from
+  /// @note if router is nullptr, nothing happens
   void CloseSession(
       std::shared_ptr<const i2p::data::RouterInfo> router);
 
+  /// @brief Informs this Transports object that a new peer has connected
+  ///        to us
+  /// @param session the new session
   void PeerConnected(
       std::shared_ptr<TransportSession> session);
 
+  /// @brief Informs this Transports object that a peer has disconnected
+  ///        from us
+  /// @param session the session that has ended
   void PeerDisconnected(
       std::shared_ptr<TransportSession> session);
 
@@ -185,15 +215,8 @@ class Transports {
   std::shared_ptr<const i2p::data::RouterInfo> GetRandomPeer() const;
 
   /// @return Log-formatted string of session info
-  const std::string GetFormattedSessionInfo(
-      std::shared_ptr<const i2p::data::RouterInfo>& router) {
-    if (router) {
-      std::ostringstream info;
-      info << " [" << router->GetIdentHashAbbreviation() << "] ";
-      return info.str();
-    }
-    return "[hash unavailable]";
-  }
+  std::string GetFormattedSessionInfo(
+      std::shared_ptr<const i2p::data::RouterInfo>& router) const;
 
  private:
   void Run();
@@ -215,6 +238,11 @@ class Transports {
 
   bool ConnectToPeer(
       const i2p::data::IdentHash& ident, Peer& peer);
+
+  bool ConnectToPeerNTCP(
+      const i2p::data::IdentHash& ident, Peer& peer);
+
+  bool ConnectToPeerSSU(Peer& peer);
 
   void HandlePeerCleanupTimer(
       const boost::system::error_code& ecode);


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---
Sets EdDSA as the default signature type for all new RIs.
Sets SSU extended options.
Reduces the number of `io_service` objects and threads for transports to one: resolves #348.
