### PR TITLE
Crypto: establish default client signing-key type

### DIFF
--- a/src/client/client_context.cc
+++ b/src/client/client_context.cc
@@ -60,7 +60,7 @@ ClientContext::~ClientContext() {
 
 void ClientContext::Start() {
   if (!m_SharedLocalDestination) {
-    m_SharedLocalDestination = CreateNewLocalDestination();  // non-public, DSA
+    m_SharedLocalDestination = CreateNewLocalDestination();  // Non-public
     m_Destinations[m_SharedLocalDestination->GetIdentity().GetIdentHash()] =
       m_SharedLocalDestination;
     m_SharedLocalDestination->Start();
@@ -155,8 +155,7 @@ std::shared_ptr<ClientDestination> ClientContext::LoadLocalDestination(
     std::string full_path = i2p::util::filesystem::GetFullPath(filename);
     LogPrint(eLogError,
         "ClientContext: can't open file ", full_path, ", creating new one");
-    keys = i2p::data::PrivateKeys::CreateRandomKeys(
-        i2p::data::SIGNING_KEY_TYPE_ECDSA_SHA256_P256);
+    keys = i2p::data::PrivateKeys::CreateRandomKeys();  // Generate default type
     std::ofstream f(full_path, std::ofstream::binary | std::ofstream::out);
     size_t len = keys.GetFullLen();
     auto buf = std::make_unique<std::uint8_t[]>(len);

--- a/src/client/client_context.h
+++ b/src/client/client_context.h
@@ -70,12 +70,13 @@ class ClientContext {
     return m_SharedLocalDestination;
   }
 
+  // Non-public
   std::shared_ptr<ClientDestination> CreateNewLocalDestination(
       bool is_public = false,
-      // TODO(anonimal): we don't need DSA-SHA1 for default
-      i2p::data::SigningKeyType sigType = i2p::data::SIGNING_KEY_TYPE_DSA_SHA1,
+      i2p::data::SigningKeyType sigType = i2p::data::DEFAULT_CLIENT_SIGNING_KEY_TYPE,
       const std::map<std::string, std::string>* params = nullptr);  // transient
 
+  // Public
   std::shared_ptr<ClientDestination> CreateNewLocalDestination(
       const i2p::data::PrivateKeys& keys,
       bool is_public = true,

--- a/src/client/i2p_service.cc
+++ b/src/client/i2p_service.cc
@@ -40,23 +40,17 @@
 namespace i2p {
 namespace client {
 
-static const i2p::data::SigningKeyType I2P_SERVICE_DEFAULT_KEY_TYPE =
-  i2p::data::SIGNING_KEY_TYPE_ECDSA_SHA256_P256;
-
 I2PService::I2PService(
     std::shared_ptr<ClientDestination> localDestination)
     : m_LocalDestination(
-        localDestination ? localDestination :
-        i2p::client::context.CreateNewLocalDestination(
-          false,
-          I2P_SERVICE_DEFAULT_KEY_TYPE)) {}
+        localDestination
+        ? localDestination
+        : i2p::client::context.CreateNewLocalDestination()) {}
 
 I2PService::I2PService(
-    i2p::data::SigningKeyType kt)
+    i2p::data::SigningKeyType key_type)
     : m_LocalDestination(
-        i2p::client::context.CreateNewLocalDestination(
-          false,
-          kt)) {}
+        i2p::client::context.CreateNewLocalDestination(key_type)) {}
 
 void I2PService::CreateStream(
     StreamRequestComplete streamRequestComplete,

--- a/src/core/identity.h
+++ b/src/core/identity.h
@@ -193,8 +193,13 @@ const uint16_t SIGNING_KEY_TYPE_RSA_SHA384_3072 = 5;
 const uint16_t SIGNING_KEY_TYPE_RSA_SHA512_4096 = 6;
 const uint16_t SIGNING_KEY_TYPE_EDDSA_SHA512_ED25519 = 7;
 
+// TODO(anonimal): review/implement to bump client type to EdDSA-SHA512-Ed25519
+const uint16_t DEFAULT_CLIENT_SIGNING_KEY_TYPE = SIGNING_KEY_TYPE_ECDSA_SHA256_P256;
+const uint16_t DEFAULT_ROUTER_SIGNING_KEY_TYPE = SIGNING_KEY_TYPE_EDDSA_SHA512_ED25519;
+
 typedef uint16_t SigningKeyType;
 typedef uint16_t CryptoKeyType;
+
 
 class IdentityEx {
  public:
@@ -326,7 +331,7 @@ class PrivateKeys {  // for eepsites
   std::string ToBase64() const;
 
   static PrivateKeys CreateRandomKeys(
-      SigningKeyType type = SIGNING_KEY_TYPE_DSA_SHA1);
+      SigningKeyType type = DEFAULT_CLIENT_SIGNING_KEY_TYPE);
 
  private:
   void CreateSigner();

--- a/src/core/router_context.cc
+++ b/src/core/router_context.cc
@@ -78,7 +78,7 @@ void RouterContext::Init(
 
 void RouterContext::CreateNewRouter() {
   m_Keys = i2p::data::PrivateKeys::CreateRandomKeys(
-      i2p::data::SIGNING_KEY_TYPE_EDDSA_SHA512_ED25519);
+      i2p::data::DEFAULT_ROUTER_SIGNING_KEY_TYPE);
   SaveKeys();
   NewRouterInfo();
 }


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

Router is stable (aside from unrelated open issues), client/server tunnels fully functional.
I haven't look into this further, but current attempts with Ed result in non-functional client/server tunnels and:

```
WRN   Stream: another remote lease has been selected for stream
WRN   Stream: another outbound tunnel has been selected for stream
```

so, a TODO was added in the commit.

Leaving open for now, will return in ~12-16 hours for further work or review.

---

- Default signing key for client local destinations is now ECDSA-SHA256-P256
- Creating random keys now defaults to this (client) type
- Created constant to reflect default router type (still EdDSA-SHA512-Ed25519)
- Add TODO to review/implement to bump client type to default router type
- Related refactoring + notes

References #364 #340