### PR TITLE
Crypto: minor fixes/refactor of AES-NI runtime check

### DIFF
--- a/src/core/crypto/aes.h
+++ b/src/core/crypto/aes.h
@@ -91,7 +91,7 @@ class AESAlignedBuffer {  // 16 bytes alignment
 /// @brief Checks for AES-NI support in Intel/AMD processors
 /// @note https://en.wikipedia.org/wiki/CPUID
 /// @return True if supported, false if not
-bool AESNIExists();
+bool HasAESNI();
 
 /// @brief Returns result of AESNIExists()
 /// @note Used for runtime AES-NI implementation

--- a/src/core/crypto/pimpl/cryptopp/aes.cc
+++ b/src/core/crypto/pimpl/cryptopp/aes.cc
@@ -44,32 +44,31 @@ namespace i2p {
 namespace crypto {
 
 /// TODO(unassigned): if we switch libraries, we should move AES-NI elsewhere.
-/// TODO(unassigned): MSVC x86-64 support?
-bool AESNIExists() {
+/// TODO(unassigned): ARM support? MSVC x86-64 support?
+bool HasAESNI() {
   unsigned int eax, ecx;  // We only need ECX
   const unsigned int flag = (1 << 25);  // ECX bit 25 for AES-NI
-  LogPrint(eLogInfo, "Crypto: checking for AES-NI...");
+  LogPrint(eLogDebug, "Crypto: checking for AES-NI...");
   __asm__ __volatile__(
       "cpuid"
       : "=a"(eax), "=c"(ecx)  // 0x2000000;
       : "a"(1), "c"(0)
       : "%ebx", "%edx");
   if ((ecx & flag) == flag) {
-    LogPrint(eLogInfo, "Crypto: AES-NI is available!");
-  } else {
-    LogPrint(eLogInfo, "Crypto: AES-NI is not available. Using library.");
-    return false;
+    LogPrint(eLogDebug, "Crypto: AES-NI is available!");
+    return true;
   }
-  return true;
+  LogPrint(eLogDebug, "Crypto: AES-NI is not available. Using library.");
+  return false;
 }
 
 // Initialize once to avoid repeated tests for AES-NI
 // TODO(unassigned): better place to initialize?
-bool aesni(AESNIExists());
+static const bool g_HasAESNI(HasAESNI());
 
 // For runtime AES-NI
 bool UsingAESNI() {
-  return aesni;
+  return g_HasAESNI;
 }
 
 /// @class ECBCryptoAESNI


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

Successfully tested on both aesni enabled/disabled machines.

- static const for global bool type
  - static is implied because this particular const type
    exists in namespace but static const appears 'const correct'
- Log to debug channel, not info
- Refactor if/else + type names for clarity
- Add TODO for ARM support

References #285