### PR TITLE
RouterContext: fix missing unique_ptr array when handling keys

### DIFF
--- a/src/core/router_context.cc
+++ b/src/core/router_context.cc
@@ -319,7 +319,7 @@ bool RouterContext::Load() {
   fk.seekg(0, std::ios::end);
   const size_t len = fk.tellg();
   fk.seekg(0, std::ios::beg);
-  std::unique_ptr<uint8_t[]> buf(new uint8_t[len]);
+  std::unique_ptr<uint8_t[]> buf(std::make_unique<uint8_t[]>(len));
   fk.read(reinterpret_cast<char*>(buf.get()), len);
   m_Keys.FromBuffer(buf.get(), len);
 
@@ -340,10 +340,10 @@ void RouterContext::SaveKeys() {
   std::ofstream fk(
       i2p::util::filesystem::GetFullPath(ROUTER_KEYS).c_str(),
       std::ofstream::binary | std::ofstream::out);
-  const size_t length = m_Keys.GetFullLen();
-  std::unique_ptr<uint8_t[]> buf(new uint8_t[length]);
-  m_Keys.ToBuffer(buf.get(), length);
-  fk.write(reinterpret_cast<char*>(buf.get()), length);
+  const size_t len = m_Keys.GetFullLen();
+  std::unique_ptr<uint8_t[]> buf(std::make_unique<uint8_t[]>(len));
+  m_Keys.ToBuffer(buf.get(), len);
+  fk.write(reinterpret_cast<char*>(buf.get()), len);
 }
 
 void RouterContext::RemoveTransport(


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---