### PR TITLE
App/Core: fix filesystem-related issues introduced in #414

### DIFF
--- a/src/app/daemon.cc
+++ b/src/app/daemon.cc
@@ -72,8 +72,7 @@ bool Daemon_Singleton::Init() {
   LogPrint(eLogInfo, "Daemon_Singleton: initializing");
   kovri::context.Init(
       kovri::app::var_map["host"].as<std::string>(),
-      kovri::app::var_map["port"].as<int>(),
-      kovri::app::GetDataPath());
+      kovri::app::var_map["port"].as<int>());
   m_IsDaemon = kovri::app::var_map["daemon"].as<bool>();
   auto port = kovri::app::var_map["port"].as<int>();
   kovri::context.UpdatePort(port);

--- a/src/app/daemon_linux.cc
+++ b/src/app/daemon_linux.cc
@@ -46,6 +46,7 @@
 #include "app/util/filesystem.h"
 
 #include "core/util/log.h"
+#include "core/util/filesystem.h"
 
 void handle_signal(int sig) {
   switch (sig) {
@@ -87,7 +88,7 @@ bool DaemonLinux::Start() {
       LogPrint("Error, could not create process group.");
       return false;
     }
-    std::string d(kovri::app::GetDataPath().string());  // makes copy
+    std::string d(kovri::core::GetDataPath().string());  // makes copy
     chdir(d.c_str());
     // close stdin/stdout/stderr descriptors
     ::close(0);
@@ -101,7 +102,7 @@ bool DaemonLinux::Start() {
       return false;
   }
   // Pidfile
-  m_pidFile = (kovri::app::GetDataPath() / "kovri.pid").string();
+  m_pidFile = (kovri::core::GetDataPath() / "kovri.pid").string();
   m_pidFilehandle = open(
       m_pidFile.c_str(),
       O_RDWR | O_CREAT,

--- a/src/app/util/filesystem.cc
+++ b/src/app/util/filesystem.cc
@@ -44,13 +44,11 @@
 namespace kovri {
 namespace app {
 
-std::string g_AppName("kovri");
-
 boost::filesystem::path GetConfigFile() {
   boost::filesystem::path kovri_conf(
       kovri::app::var_map["kovriconf"].as<std::string>());
   if (!kovri_conf.is_complete())
-    kovri_conf = GetDataPath() / kovri_conf;
+    kovri_conf = kovri::core::GetDataPath() / kovri_conf;
   return kovri_conf;
 }
 
@@ -58,82 +56,8 @@ boost::filesystem::path GetTunnelsConfigFile() {
   boost::filesystem::path tunnels_conf(
       kovri::app::var_map["tunnelsconf"].as<std::string>());
   if (!tunnels_conf.is_complete())
-    tunnels_conf = GetDataPath() / tunnels_conf;
+    tunnels_conf = kovri::core::GetDataPath() / tunnels_conf;
   return tunnels_conf;
-}
-
-boost::filesystem::path GetSU3CertsPath() {
-  return GetDataPath() / "certificates" / "su3";
-}
-
-boost::filesystem::path GetSSLCertsPath() {
-  return GetDataPath() / "certificates" / "ssl";
-}
-
-const boost::filesystem::path GetLogsPath() {
-  return GetDataPath() / "logs";
-}
-
-std::string GetFullPath(
-    const std::string& filename) {
-  std::string full_path = GetDataPath().string();
-#ifdef _WIN32
-  full_path.append("\\");
-#else
-  full_path.append("/");
-#endif
-  full_path.append(filename);
-  return full_path;
-}
-
-const boost::filesystem::path& GetDataPath() {
-  static boost::filesystem::path path;
-  path = GetDefaultDataPath();
-  if (!boost::filesystem::exists(path)) {
-    // Create data directory
-    if (!boost::filesystem::create_directory(path)) {
-      LogPrint(eLogError, "Filesystem: failed to create data directory!");
-      path = "";
-      return path;
-    }
-  }
-  if (!boost::filesystem::is_directory(path))
-    path = GetDefaultDataPath();
-  return path;
-}
-
-boost::filesystem::path GetDefaultDataPath() {
-  // Custom path, or default path:
-  // Windows < Vista: C:\Documents and Settings\Username\Application Data\kovri
-  // Windows >= Vista: C:\Users\Username\AppData\Roaming\kovri
-  // Mac: ~/Library/Application Support/kovri
-  // Unix: ~/.kovri
-#ifdef KOVRI_CUSTOM_DATA_PATH
-  return boost::filesystem::path(std::string(KOVRI_CUSTOM_DATA_PATH));
-#else
-#ifdef _WIN32
-  // Windows
-  char local_app_data[MAX_PATH];
-  SHGetFolderPath(NULL, CSIDL_APPDATA, 0, NULL, local_app_data);
-  return boost::filesystem::path(std::string(local_app_data) + "\\" + g_AppName);
-#else
-  boost::filesystem::path path_ret;
-  char* home = getenv("HOME");
-  if (home == NULL || strlen(home) == 0)
-      path_ret = boost::filesystem::path("/");
-  else
-      path_ret = boost::filesystem::path(home);
-#ifdef __APPLE__
-  // Mac
-  path_ret /= "Library/Application Support";
-  create_directory(path_ret);
-  return path_ret / g_AppName;
-#else
-  // Unix
-  return path_ret / (std::string(".") + g_AppName);
-#endif
-#endif
-#endif
 }
 
 }  // namespace app

--- a/src/app/util/filesystem.cc
+++ b/src/app/util/filesystem.cc
@@ -44,16 +44,7 @@
 namespace kovri {
 namespace app {
 
-std::string app_name("kovri");
-
-void SetAppName(
-    const std::string& name) {
-  app_name = name;
-}
-
-std::string GetAppName() {
-  return app_name;
-}
+std::string g_AppName("kovri");
 
 boost::filesystem::path GetConfigFile() {
   boost::filesystem::path kovri_conf(
@@ -124,7 +115,7 @@ boost::filesystem::path GetDefaultDataPath() {
   // Windows
   char local_app_data[MAX_PATH];
   SHGetFolderPath(NULL, CSIDL_APPDATA, 0, NULL, local_app_data);
-  return boost::filesystem::path(std::string(local_app_data) + "\\" + app_name);
+  return boost::filesystem::path(std::string(local_app_data) + "\\" + g_AppName);
 #else
   boost::filesystem::path path_ret;
   char* home = getenv("HOME");
@@ -136,10 +127,10 @@ boost::filesystem::path GetDefaultDataPath() {
   // Mac
   path_ret /= "Library/Application Support";
   create_directory(path_ret);
-  return path_ret / app_name;
+  return path_ret / g_AppName;
 #else
   // Unix
-  return path_ret / (std::string(".") + app_name);
+  return path_ret / (std::string(".") + g_AppName);
 #endif
 #endif
 #endif

--- a/src/app/util/filesystem.h
+++ b/src/app/util/filesystem.h
@@ -47,21 +47,11 @@
 namespace kovri {
 namespace app {
 
-/// @return the full path of a file within the kovri directory
-std::string GetFullPath(
-    const std::string& filename);
-
 /// @return the path of the configuration file
 boost::filesystem::path GetConfigFile();
 
 /// @return the path of the tunnels configuration file
 boost::filesystem::path GetTunnelsConfigFile();
-
-/// @return the path of the kovri directory
-const boost::filesystem::path& GetDataPath();
-
-/// @return the default directory for app data
-boost::filesystem::path GetDefaultDataPath();
 
 }  // namespace app
 }  // namespace kovri

--- a/src/app/util/filesystem.h
+++ b/src/app/util/filesystem.h
@@ -47,15 +47,6 @@
 namespace kovri {
 namespace app {
 
-/**
- * Change the application name.
- */
-void SetAppName(
-    const std::string& name);
-
-/// @return the application name.
-std::string GetAppName();
-
 /// @return the full path of a file within the kovri directory
 std::string GetFullPath(
     const std::string& filename);

--- a/src/client/address_book/storage.h
+++ b/src/client/address_book/storage.h
@@ -138,7 +138,7 @@ class AddressBookStorage : public AddressBookDefaults {
   /// @brief Gets data path and appends address book's path
   /// @return Boost.Filesystem path of address book path
   boost::filesystem::path GetAddressBookPath() const {
-    return kovri::context.GetDataPath() / GetDefaultPathname();
+    return kovri::core::GetDataPath() / GetDefaultPathname();
   }
 };
 

--- a/src/client/api/i2p_control/i2p_control.cc
+++ b/src/client/api/i2p_control/i2p_control.cc
@@ -50,8 +50,10 @@
 #include "core/router/transports/transports.h"
 #include "core/router/tunnel/tunnel.h"
 
+#include "core/util/filesystem.h"
 #include "core/util/log.h"
 #include "core/util/timestamp.h"
+
 #include "core/version.h"
 
 namespace kovri {
@@ -474,7 +476,7 @@ void I2PControlSession::HandleDatapath(
     Response& response) {
   response.SetParam(
       ROUTER_INFO_DATAPATH,
-      kovri::context.GetDataPath().string());
+      kovri::core::GetDataPath().string());
 }
 
 void I2PControlSession::HandleNetDbKnownPeers(

--- a/src/core/router/context.cc
+++ b/src/core/router/context.cc
@@ -58,18 +58,15 @@ RouterContext::RouterContext()
       m_StartupTime(0),
       m_Status(eRouterStatusOK),
       m_Port(0),
-      m_DataPath(),
       m_ReseedSkipSSLCheck(false),
       m_SupportsNTCP(true),
       m_SupportsSSU(true) {}
 
 void RouterContext::Init(
     const std::string& host,
-    int port,
-    const boost::filesystem::path& dataPath) {
+    int port) {
   m_Host = host;
   m_Port = port;
-  m_DataPath = dataPath;
   m_StartupTime = kovri::core::GetSecondsSinceEpoch();
   if (!Load())
     CreateNewRouter();

--- a/src/core/router/context.h
+++ b/src/core/router/context.h
@@ -68,11 +68,10 @@ class RouterContext : public kovri::core::GarlicDestination {
 
   /// Initializes the router context, must be called before use
   /// @param host The external address of this router
-  /// @param dataPath port the port to be used (for both SSU and NTCP)
+  /// @param port The external port of this router
   void Init(
       const std::string& host,
-      int port,
-      const boost::filesystem::path& dataPath);
+      int port);
 
   // @return This RouterContext's RouterInfo
   kovri::core::RouterInfo& GetRouterInfo() {
@@ -256,15 +255,6 @@ class RouterContext : public kovri::core::GarlicDestination {
   void ProcessDeliveryStatusMessage(
       std::shared_ptr<I2NPMessage> msg);
 
-  boost::filesystem::path GetDataPath() const {
-    return m_DataPath;
-  }
-
-  /// @return the full path of a file within m_DataPath
-  // TODO(EinMByte): Eventually use this everywhere instead of kovri::core
-  std::string GetFullPath(
-      const std::string& file);
-
   /**
    * Note: these reseed functions are not ideal but
    * they fit into our current design. We need to initialize
@@ -313,7 +303,6 @@ class RouterContext : public kovri::core::GarlicDestination {
   std::mutex m_GarlicMutex;
   std::string m_Host;
   int m_Port;
-  boost::filesystem::path m_DataPath;
   std::string m_ReseedFrom;
   bool m_ReseedSkipSSLCheck;
   bool m_SupportsNTCP, m_SupportsSSU;

--- a/src/core/router/net_db/net_db.cc
+++ b/src/core/router/net_db/net_db.cc
@@ -52,6 +52,7 @@
 #include "core/router/tunnel/tunnel.h"
 
 #include "core/util/base64.h"
+#include "core/util/filesystem.h"
 #include "core/util/i2p_endian.h"
 #include "core/util/log.h"
 #include "core/util/timestamp.h"
@@ -309,7 +310,7 @@ bool NetDb::CreateNetDb(
 }
 
 bool NetDb::Load() {
-  boost::filesystem::path p(kovri::context.GetDataPath() / m_NetDbPath);
+  boost::filesystem::path p(kovri::core::GetDataPath() / m_NetDbPath);
   if (!boost::filesystem::exists(p)) {
     // seems netDb doesn't exist yet
     if (!CreateNetDb(p))
@@ -362,7 +363,7 @@ void NetDb::SaveUpdated() {
     return directory / (std::string("r") + s[0]) / ("router_info_" + s + ".dat");
   };
   boost::filesystem::path full_directory(
-      kovri::context.GetDataPath() / m_NetDbPath);
+      kovri::core::GetDataPath() / m_NetDbPath);
   int count = 0,
       deleted_count = 0;
   auto total = GetNumRouters();

--- a/src/core/router/profiling.cc
+++ b/src/core/router/profiling.cc
@@ -38,9 +38,8 @@
 
 #include <string>
 
-#include "core/router/context.h"
-
 #include "core/util/base64.h"
+#include "core/util/filesystem.h"
 #include "core/util/log.h"
 
 namespace kovri {
@@ -96,7 +95,7 @@ void RouterProfile::Save() {
       PEER_PROFILE_SECTION_USAGE,
       usage);
   // save to file
-  auto path = kovri::context.GetDataPath() / PEER_PROFILES_DIRECTORY;
+  auto path = kovri::core::GetDataPath() / PEER_PROFILES_DIRECTORY;
   if (!boost::filesystem::exists(path)) {
     // Create directory is necessary
     if (!boost::filesystem::create_directory(path)) {
@@ -124,7 +123,7 @@ void RouterProfile::Save() {
 
 void RouterProfile::Load() {
   std::string base64 = m_IdentHash.ToBase64();
-  auto path = kovri::context.GetDataPath() / PEER_PROFILES_DIRECTORY;
+  auto path = kovri::core::GetDataPath() / PEER_PROFILES_DIRECTORY;
   path /= std::string("p") + base64[0];
   auto filename = path / (std::string(PEER_PROFILE_PREFIX) + base64 + ".txt");
   if (boost::filesystem::exists(filename)) {
@@ -229,7 +228,7 @@ void DeleteObsoleteProfiles() {
   int num = 0;
   auto ts = boost::posix_time::second_clock::local_time();
   boost::filesystem::path p(
-      kovri::context.GetDataPath() / PEER_PROFILES_DIRECTORY);
+      kovri::core::GetDataPath() / PEER_PROFILES_DIRECTORY);
   if (boost::filesystem::exists(p)) {
     boost::filesystem::directory_iterator end;
     for (boost::filesystem::directory_iterator it(p); it != end; ++it) {

--- a/src/core/util/filesystem.cc
+++ b/src/core/util/filesystem.cc
@@ -30,30 +30,34 @@
  * Parts of the project are originally copyright (c) 2013-2015 The PurpleI2P Project          //
  */
 
-#include "filesystem.h"
+#include "core/util/filesystem.h"
 
 #include <string>
 
 #include "core/router/context.h"
 
+#include "core/util/log.h"
+
 namespace kovri {
 namespace core {
 
+std::string g_AppName("kovri");
+
 boost::filesystem::path GetSU3CertsPath() {
-  return kovri::context.GetDataPath() / "certificates" / "su3";
+  return GetDataPath() / "certificates" / "su3";
 }
 
 boost::filesystem::path GetSSLCertsPath() {
-  return kovri::context.GetDataPath() / "certificates" / "ssl";
+  return GetDataPath() / "certificates" / "ssl";
 }
 
 const boost::filesystem::path GetLogsPath() {
-  return kovri::context.GetDataPath() / "logs";
+  return GetDataPath() / "logs";
 }
 
 std::string GetFullPath(
     const std::string& filename) {
-  std::string full_path = kovri::context.GetDataPath().string();
+  std::string full_path = GetDataPath().string();
 #ifdef _WIN32
   full_path.append("\\");
 #else
@@ -61,6 +65,56 @@ std::string GetFullPath(
 #endif
   full_path.append(filename);
   return full_path;
+}
+
+const boost::filesystem::path& GetDataPath() {
+  static boost::filesystem::path path;
+  path = GetDefaultDataPath();
+  if (!boost::filesystem::exists(path)) {
+    // Create data directory
+    if (!boost::filesystem::create_directory(path)) {
+      LogPrint(eLogError, "Filesystem: failed to create data directory!");
+      path = "";
+      return path;
+    }
+  }
+  if (!boost::filesystem::is_directory(path))
+    path = GetDefaultDataPath();
+  return path;
+}
+
+boost::filesystem::path GetDefaultDataPath() {
+  // Custom path, or default path:
+  // Windows < Vista: C:\Documents and Settings\Username\Application Data\kovri
+  // Windows >= Vista: C:\Users\Username\AppData\Roaming\kovri
+  // Mac: ~/Library/Application Support/kovri
+  // Unix: ~/.kovri
+#ifdef KOVRI_CUSTOM_DATA_PATH
+  return boost::filesystem::path(std::string(KOVRI_CUSTOM_DATA_PATH));
+#else
+#ifdef _WIN32
+  // Windows
+  char local_app_data[MAX_PATH];
+  SHGetFolderPath(NULL, CSIDL_APPDATA, 0, NULL, local_app_data);
+  return boost::filesystem::path(std::string(local_app_data) + "\\" + g_AppName);
+#else
+  boost::filesystem::path path_ret;
+  char* home = getenv("HOME");
+  if (home == NULL || strlen(home) == 0)
+      path_ret = boost::filesystem::path("/");
+  else
+      path_ret = boost::filesystem::path(home);
+#ifdef __APPLE__
+  // Mac
+  path_ret /= "Library/Application Support";
+  create_directory(path_ret);
+  return path_ret / g_AppName;
+#else
+  // Unix
+  return path_ret / (std::string(".") + g_AppName);
+#endif
+#endif
+#endif
 }
 
 }  // namespace core

--- a/src/core/util/filesystem.h
+++ b/src/core/util/filesystem.h
@@ -84,6 +84,12 @@ class StringStream {
 /// @return the full path of a file within the kovri directory
 std::string GetFullPath(const std::string& filename);
 
+/// @return the path of the kovri directory
+const boost::filesystem::path& GetDataPath();
+
+/// @return the default directory for app data
+boost::filesystem::path GetDefaultDataPath();
+
 /// @return the path to certificates for SU3 verification
 boost::filesystem::path GetSU3CertsPath();
 


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

Our data path / data dir is hardcoded, defined at compile time. There is
nothing flexible about it: once you start the router, you it will work
within the same data directory indefinitely (though there are some
run-time options that provide *some* flexibility where some of the
data within the directory can be found/redirected).

Initializing router context (as if the data dir were a mutable type)
is unnecessary and confusing. Ideally, we would *like* as much
flexibility as possible but, for now; this lends itself to breakage.

Also, this PR moves any filesystem related confusion out of app and
into core because of said reasons (and to remove redundancy). This is
not the *ideal* abstraction I had in mind for #330 but it is good
enough for now (and solves the issue at hand).

Run-time breakage was introduced in 95b35bf because of said reasons.

Closes #330