### PR TITLE
NetDb: refactor magic numbers + docs + style fixes. Refs #444

### DIFF
--- a/src/core/router/net_db/impl.h
+++ b/src/core/router/net_db/impl.h
@@ -80,10 +80,37 @@ enum struct NetDbInterval : const std::uint16_t {
   DelayedExploratory = 90,
 };
 
+/// @enum NetDbTime
+/// @brief Constants defining timestamp
+///  variables for various NetDb operations
+enum struct NetDbTime : const std::uint32_t {
+  /// @var RouterExpiration
+  /// @brief in milliseconds
+  RouterExpiration = 3600 * 1000,
+  /// @var RouterStartupPeriod
+  /// @brief in seconds, defines
+  ///  a grace period when a router
+  ///  has just started to not set
+  ///  expired routers as unreachable,
+  ///  so tunnels will be built quickly
+  RouterStartupPeriod = 600,
+  /// @var RouterMinGracePeriod
+  /// @brief in hours, defines a grace
+  ///  period for expiring routers when
+  ///  router count exceeds MaxRouterCheckUnreachable
+  RouterMinGracePeriod = 30,
+  /// @var RouterMaxGracePeriod
+  /// @brief in hours, defines a grace
+  ///  period for expiring routers when
+  ///  router count exceeds MinRouterCheckUnreachable
+  RouterMaxGracePeriod = 72,
+};
+
 /// @enum NetDbSize
 /// @brief Constants defining NetDb sizes
 ///   for how many known routers are wanted for
 ///   a large variety of peers to build tunnels
+///   and other uses
 enum struct NetDbSize : const std::uint16_t {
   /// @var MinKnownRouters
   /// @brief minimum number of known routers
@@ -105,6 +132,26 @@ enum struct NetDbSize : const std::uint16_t {
   /// @brief max number of NetDb messages
   ///   that can be processed in succession
   MaxMessagesRead = 100,
+  /// @var MaxExcludedPeers
+  /// @brief max number of excluded peers
+  ///  for handling database lookup messages,
+  ///  currently only used for printing error logs
+  MaxExcludedPeers = 512,
+  /// @var RouterCheckUnreachableThreshold
+  /// @brief defines the threshold where
+  ///  routers get checked if they have
+  ///  expired ie unreachable
+  RouterCheckUnreachableThreshold = 75,
+  /// @var MinRouterCheckUnreachable
+  /// @brief the minimum limit for
+  ///  number of routers to be checked and
+  ///  set unreachable by expiration date
+  MinRouterCheckUnreachable = 120,
+  /// @var MaxRouterCheckUnreachable
+  /// @brief the maximum limit for number of
+  ///  routers to be checked and set unreachable
+  ///  by expiration date
+  MaxRouterCheckUnreachable = 300,
 };
 
 class NetDb {

--- a/src/core/router/transports/impl.cc
+++ b/src/core/router/transports/impl.cc
@@ -266,7 +266,6 @@ bool Transports::IsBandwidthExceeded() const {
 void Transports::SendMessage(
     const kovri::core::IdentHash& ident,
     std::shared_ptr<kovri::I2NPMessage> msg) {
-  LogPrint(eLogDebug, "Transports: sending messages");
   SendMessages(
       ident,
       std::vector<std::shared_ptr<kovri::I2NPMessage>> {msg});
@@ -275,6 +274,7 @@ void Transports::SendMessage(
 void Transports::SendMessages(
     const kovri::core::IdentHash& ident,
     const std::vector<std::shared_ptr<kovri::I2NPMessage>>& msgs) {
+  LogPrint(eLogDebug, "Transports: sending messages");
   m_Service.post(
       std::bind(
           &Transports::PostMessages,


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [ X] I confirm.

---

*Enter your pull-request summary here*

References commits in #444

NetDb: removed redundant file path checking for deleting a file

NetDb: variable styling fix to keep consistency throughout codebase

NetDb: organize arbitrary router expiration timestamps into a documented enum struct

Transports: better logging for sending messages

NetDb: organize more magic numbers into organized enum structs

NetDb: various logging/documentation fixes etc. Refs #444

NetDb: better readability for logging and arithmetic. Refs #444

NetDb: better styling for arithmetic. Refs #444

NetDb: use long-long int for an arithmetic operation. Refs #444