### PR TITLE
UNIT TESTS :: fix 457; segfault unit tests

### DIFF
--- a/tests/unit_tests/core/crypto/aes.cc
+++ b/tests/unit_tests/core/crypto/aes.cc
@@ -36,6 +36,7 @@
 
 #include "core/crypto/aes.h"
 #include "core/util/impl/log.cc"
+extern std::string kovri::core::g_LogFileName;
 
 BOOST_AUTO_TEST_SUITE(AESTests)
 

--- a/tests/unit_tests/core/crypto/aes.cc
+++ b/tests/unit_tests/core/crypto/aes.cc
@@ -35,6 +35,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "core/crypto/aes.h"
+#include "core/util/impl/log.cc"
 
 BOOST_AUTO_TEST_SUITE(AESTests)
 


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [ x] I confirm.

---

fix segfault on unit tests for ubuntu

