### PR TITLE
NetDb/Crypto: refactor rand router implementation

### DIFF
--- a/src/core/crypto/rand.h
+++ b/src/core/crypto/rand.h
@@ -82,6 +82,19 @@ namespace core {
     return ret;
   }
 
+  /// @brief CSPRNG shuffle of a sequence container
+  /// @param begin iterator to the first element in container
+  /// @param end iterator beyond the last element in container
+  /// @note IT must meet the requirements of ForwardIterator.
+  ///   begin, end must meet the requirements of Swappable.
+  template <class IT>
+  void Shuffle(IT begin, IT end) {
+    for (; begin != end; ++begin)
+      std::iter_swap(
+          begin,
+          begin + kovri::core::RandInRange<std::size_t>(0, end - begin - 1));
+  }
+
 }  // namespace core
 }  // namespace kovri
 

--- a/src/core/router/net_db/impl.h
+++ b/src/core/router/net_db/impl.h
@@ -259,6 +259,9 @@ class NetDb {
   void ManageLeaseSets();
   void ManageRequests();
 
+  /// @brief Randomly selects a router from stored RI's according to filter
+  ///   (and other criteria determined internally)
+  /// @param filter Template type which serves as filter for criteria
   template<typename Filter>
   std::shared_ptr<const RouterInfo> GetRandomRouter(
       Filter filter) const;


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X ] I confirm.

---

The original code was only randomly choosing a router indice on the first pass and if a router was not found then on the second pass it would start searching from the beginning(not random). This PR fixes that and on the second pass will start from the random router indice and search the routers in reverse to keep the router being chosen random.