### PR TITLE
SSUSession: trivial patch to handle segfault in #119

### DIFF
--- a/src/core/router/transports/ssu/session.cc
+++ b/src/core/router/transports/ssu/session.cc
@@ -358,8 +358,12 @@ void SSUSession::ProcessSessionCreated(
   auto packet = static_cast<SSUSessionCreatedPacket*>(pkt);
   // x, y, our IP, our port, remote IP, remote port, relay tag, signed on time
   SignedData s;
-  // TODO(unassigned): if we cannot create shared key, we should not continue
-  CreateAESandMACKey(packet->GetDhY());
+  if (!CreateAESandMACKey(packet->GetDhY())) {
+    LogPrint(eLogError,
+        "SSUSession:", GetFormattedSessionInfo(),
+        "invalid DH-Y, not sending SessionConfirmed");
+    return;
+  }
   s.Insert(m_DHKeysPair->public_key.data(), 256);  // x
   s.Insert(packet->GetDhY(), 256);  // y
   boost::asio::ip::address our_IP;

--- a/src/core/router/transports/ssu/session.cc
+++ b/src/core/router/transports/ssu/session.cc
@@ -99,14 +99,14 @@ boost::asio::io_service& SSUSession::GetService() {
   return m_Server.GetService();
 }
 
-void SSUSession::CreateAESandMACKey(
+bool SSUSession::CreateAESandMACKey(
     const std::uint8_t* pub_key) {
   kovri::core::DiffieHellman dh;
   std::array<std::uint8_t, 256> shared_key;
   if (!dh.Agree(shared_key.data(), m_DHKeysPair->private_key.data(), pub_key)) {
     LogPrint(eLogError,
         "SSUSession:", GetFormattedSessionInfo(), "couldn't create shared key");
-    return;
+    return false;
   }
   std::uint8_t* session_key = m_SessionKey();
   std::uint8_t* mac_key = m_MACKey();
@@ -126,7 +126,7 @@ void SSUSession::CreateAESandMACKey(
         LogPrint(eLogWarn,
             "SSUSession:", GetFormattedSessionInfo(),
             "first 32 bytes of shared key is all zeros. Ignored");
-        return;
+        return false;
       }
     }
     memcpy(session_key, non_zero, 32);
@@ -135,9 +135,9 @@ void SSUSession::CreateAESandMACKey(
         non_zero,
         64 - (non_zero - shared_key.data()));
   }
-  m_IsSessionKey = true;
   m_SessionKeyEncryption.SetKey(m_SessionKey);
   m_SessionKeyDecryption.SetKey(m_SessionKey);
+  return m_IsSessionKey = true;
 }
 
 /**
@@ -292,7 +292,12 @@ void SSUSession::ProcessSessionRequest(
   SetRemoteEndpoint(sender_endpoint);
   if (!m_DHKeysPair)
     m_DHKeysPair = transports.GetNextDHKeysPair();
-  CreateAESandMACKey(packet->GetDhX());
+  if (!CreateAESandMACKey(packet->GetDhX())) {
+    LogPrint(eLogError,
+        "SSUSession:", GetFormattedSessionInfo(),
+        "invalid DH-X, not sending SessionCreated");
+    return;
+  }
   SendSessionCreated(packet->GetDhX());
 }
 

--- a/src/core/router/transports/ssu/session.h
+++ b/src/core/router/transports/ssu/session.h
@@ -208,7 +208,7 @@ class SSUSession
  private:
   boost::asio::io_service& GetService();
 
-  void CreateAESandMACKey(
+  bool CreateAESandMACKey(
       const std::uint8_t* pub_key);
 
   void PostI2NPMessages(


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

A trivial patch until the bigger issue is resolved; this will prevent
sending SessionCreated to the very few routers who send bad?
SessionRequest data (at least uninitialized Diffie-Hellman?).
It's not ideal but it works for now, and is better than what we have at
the moment (which is nothing).

Note: this is not related to ParseHeader() which, despite the TODO, even
after initializing m_Data for the length of keying material before
moving pointer with ConsumeData(), the segfault will occur during key
creation (without this patch).

References #119 