### PR TITLE
GarlicRoutingSession: use raw pointer for GarlicDestination. Fixes #342

### DIFF
--- a/src/core/router/garlic.cc
+++ b/src/core/router/garlic.cc
@@ -91,6 +91,7 @@ GarlicRoutingSession::~GarlicRoutingSession() {
   for (auto it : m_UnconfirmedTagsMsgs)
     delete it.second;
   m_UnconfirmedTagsMsgs.clear();
+  m_Owner = nullptr;
 }
 
 GarlicRoutingSession::UnconfirmedTags*

--- a/src/core/router/garlic.h
+++ b/src/core/router/garlic.h
@@ -178,7 +178,7 @@ class GarlicRoutingSession
   UnconfirmedTags* GenerateSessionTags();
 
  private:
-  std::unique_ptr<GarlicDestination> m_Owner;
+  GarlicDestination* m_Owner;
   std::shared_ptr<const kovri::core::RoutingDestination> m_Destination;
   kovri::core::AESKey m_SessionKey;
   std::list<SessionTag> m_SessionTags;


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

References #342 