### PR TITLE
Tunnels: remove redundant stopping of tunnel pool

### DIFF
--- a/src/client/destination.cc
+++ b/src/client/destination.cc
@@ -204,13 +204,12 @@ void ClientDestination::Stop() {
     }
     if (m_Pool) {
       m_Pool->SetLocalDestination(nullptr);
-      kovri::core::tunnels.StopTunnelPool(m_Pool);
       kovri::core::tunnels.DeleteTunnelPool(m_Pool);
     }
     m_Service.stop();
     if (m_Thread) {
       m_Thread->join();
-      m_Thread.reset(0);
+      m_Thread.reset(nullptr);
     }
   }
 }

--- a/src/core/router/tunnel/impl.cc
+++ b/src/core/router/tunnel/impl.cc
@@ -355,6 +355,7 @@ std::shared_ptr<TunnelPool> Tunnels::CreateTunnelPool(
 
 void Tunnels::DeleteTunnelPool(
     std::shared_ptr<TunnelPool> pool) {
+  LogPrint(eLogDebug, "Tunnels: deleting tunnel pool");
   if (pool) {
     StopTunnelPool(pool); {
       std::unique_lock<std::mutex> l(m_PoolsMutex);


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

Is called during tunnel pool deletion.

Also, reset thread pointer appropriately, add log message.