### PR TITLE
IdentityEx/SSUPacketParser: throw for bad buffer + invalid length

### DIFF
--- a/src/core/router/transports/ssu/packet.cc
+++ b/src/core/router/transports/ssu/packet.cc
@@ -766,7 +766,8 @@ std::unique_ptr<SSUSessionConfirmedPacket> SSUPacketParser::ParseSessionConfirme
   ConsumeData(1);  // Skip info byte
   std::uint16_t identity_size = ReadUInt16();
   kovri::core::IdentityEx identity;
-  identity.FromBuffer(ReadBytes(identity_size), identity_size);
+  if (!identity.FromBuffer(ReadBytes(identity_size), identity_size))
+    throw std::length_error("SSUPacketParser: invalid length within identity");
   packet->SetRemoteRouterIdentity(identity);
   packet->SetSignedOnTime(ReadUInt32());
   const std::size_t padding_size = ((m_Length - init_length) + identity.GetSignatureLen()) % 16;

--- a/src/core/router/transports/ssu/session.cc
+++ b/src/core/router/transports/ssu/session.cc
@@ -212,7 +212,13 @@ void SSUSession::ProcessDecryptedMessage(
     packet = parser.ParsePacket();
   } catch(const std::exception& e) {
     LogPrint(eLogError,
-        "SSUSession: invalid SSU session packet from ", sender_endpoint);
+        "SSUSession: invalid SSU session packet from ", sender_endpoint,
+        " --> ", e.what());
+    return;
+  } catch (...) {
+    LogPrint(eLogError,
+        "SSUSession: invalid SSU session packet from ", sender_endpoint,
+        " --> unknown exception");
     return;
   }
   switch (packet->GetHeader()->GetPayloadType()) {


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

Patches #432 in terms of maintaining run-time operation. Several days of live testing + valgrind show that fix is legitimate.