### PR TITLE
TunnelPool: fix signed int overflow when logging tunnel test

### DIFF
--- a/src/core/router/tunnel/pool.cc
+++ b/src/core/router/tunnel/pool.cc
@@ -245,7 +245,7 @@ void TunnelPool::CreateTunnels() {
 void TunnelPool::TestTunnels() {
   for (auto it : m_Tests) {
     LogPrint(eLogWarn,
-        "TunnelPool: tunnel test ", static_cast<int>(it.first), " failed");
+        "TunnelPool: tunnel test ", it.first, " failed");
     // if test failed again with another tunnel we consider it failed
     if (it.second.first) {
       if (it.second.first->GetState() == e_TunnelStateTestFailed) {


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

The magician struck again: casting `uint32_t` to `int` has undefined behaviour.
Forunately, the effect was trivial and only produced invalid ID's when logging.