### PR TITLE
Tunnel/TunnelPool: use CSPRNG shuffle

### DIFF
--- a/src/core/router/tunnel/impl.cc
+++ b/src/core/router/tunnel/impl.cc
@@ -32,7 +32,6 @@
 
 #include <string.h>
 
-#include <algorithm>
 #include <map>
 #include <memory>
 #include <thread>
@@ -76,7 +75,7 @@ void Tunnel::Build(
   std::vector<int> record_indicies;
   for (int i = 0; i < num_records; i++)
     record_indicies.push_back(i);
-  std::random_shuffle(record_indicies.begin(), record_indicies.end());
+  kovri::core::Shuffle(record_indicies.begin(), record_indicies.end());
   // create real records
   std::uint8_t* records = msg->GetPayload() + 1;
   TunnelHopConfig* hop = m_Config->GetFirstHop();

--- a/src/core/router/tunnel/pool.cc
+++ b/src/core/router/tunnel/pool.cc
@@ -380,7 +380,7 @@ bool TunnelPool::SelectExplicitPeers(
   std::vector<int> peer_indicies;
   for (int i = 0; i < size; i++)
     peer_indicies.push_back(i);
-  std::random_shuffle(peer_indicies.begin(), peer_indicies.end());
+  kovri::core::Shuffle(peer_indicies.begin(), peer_indicies.end());
   int num_hops = is_inbound ? m_NumInboundHops : m_NumOutboundHops;
   for (int i = 0; i < num_hops; i++) {
     auto& ident = (*m_ExplicitPeers)[peer_indicies[i]];


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

Removes deprecated (in C++14) std::random_shuffle (refs #158)