### PR TITLE
Crypto/NetDb: throw/catch cryptopp impl exception

### DIFF
--- a/src/core/crypto/impl/cryptopp/util/compression.cc
+++ b/src/core/crypto/impl/cryptopp/util/compression.cc
@@ -256,8 +256,8 @@ class Gunzip::GunzipImpl {
       unprocessed_bytes = m_Gunzip.Put(buffer, length);
       m_Gunzip.MessageEnd();
     } catch (CryptoPP::Exception& e) {
-      LOG(error)
-        << "GunzipImpl: " << __func__ << " caught exception '" << e.what() << "'";
+      // TODO(anonimal): this is a trivial hotfix patch for #538. What we really need is an exception dispatcher for the crypto impl (if not globally)
+      throw std::runtime_error("GunzipImpl: " + std::string(__func__) + " caught exception '" + e.what() + "'");
     }
     return unprocessed_bytes;
   }

--- a/src/core/router/net_db/impl.cc
+++ b/src/core/router/net_db/impl.cc
@@ -538,14 +538,16 @@ void NetDb::HandleDatabaseStoreMsg(
       decompressor.Put(buf + offset, size);
       std::array<std::uint8_t, MAX_RI_BUFFER_SIZE> uncompressed;
       std::size_t uncompressed_size = decompressor.MaxRetrievable();
-      if (uncompressed_size <= MAX_RI_BUFFER_SIZE) {
-        decompressor.Get(uncompressed.data(), uncompressed_size);
-        AddRouterInfo(ident, uncompressed.data(), uncompressed_size);
-      } else {
+      if (uncompressed_size > MAX_RI_BUFFER_SIZE) {
         LOG(error)
           << "NetDb: invalid RouterInfo uncompressed length "
           << static_cast<int>(uncompressed_size);
+	return;
       }
+      decompressor.Get(uncompressed.data(), uncompressed_size);
+      AddRouterInfo(ident, uncompressed.data(), uncompressed_size);
+    } catch (const std::exception& ex) {
+      LOG(error) << "NetDb: " << __func__ << ": '" << ex.what() << "'";
     } catch (...) {
       LOG(error) << "NetDb: " << __func__ << " caught unknown exception";
     }


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

```
&anonimal       On an unrelated note, a trivial hotfix is working for #538: routers on all platforms are still online after ~22 hours; logs show success.
&anonimal       In hindsight, what we really need is an exception dispatcher for the crypto impl if not globally (or maybe a global custom exception class).
&anonimal       I can send/merge the hotfix and #538 will end up needing more research for the core of the issue - but at least it won't be a blocker.
```

#538 