### PR TITLE
Add the packaging metadata to build the kovri snap

### DIFF
--- a/snap/kovri-wrapper
+++ b/snap/kovri-wrapper
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ ! -d "$SNAP_USER_DATA/.kovri" ]; then
+  mkdir $SNAP_USER_DATA/.kovri/
+  cp -R $SNAP/config $SNAP_USER_DATA/.kovri/
+  cp -R $SNAP/client $SNAP_USER_DATA/.kovri/
+fi
+
+exec "$SNAP/bin/kovri" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: kovri
+version: master
+summary: The Kovri I2P Router Project
+description: |
+  Kovri is a security-focused, community-driven C++ implementation of I2P
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  kovri:
+    command: kovri
+    plugs: [network, network-bind]
+
+parts:
+  kovri:
+    source: .
+    plugin: make
+    build-packages:
+      - g++
+      - libboost-all-dev
+      - libssl-dev
+      - libssl1.0.0
+    artifacts:
+      - build/kovri
+      - pkg
+    organize:
+      build/kovri: bin/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,7 @@ confinement: strict
 
 apps:
   kovri:
-    command: kovri
+    command: kovri-wrapper
     plugs: [network, network-bind]
 
 parts:
@@ -23,6 +23,12 @@ parts:
       - libssl1.0.0
     artifacts:
       - build/kovri
-      - pkg
+      - pkg/config
+      - pkg/client
     organize:
       build/kovri: bin/
+      pkg/*: .
+  wrapper:
+    plugin: dump
+    source: snap/
+    stage: [kovri-wrapper]


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds that then can be distributed to many users through the Ubuntu store.

Kudos to @anonimal for making the snapcraft.yaml. I only added a few touches and sent the PR for some stolen karma :)