### PR TITLE
clang-format :: fix mangled license

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,3 +14,4 @@ ColumnLimit: 80
 DerivePointerAlignment: false
 PointerAlignment: Left
 SpacesBeforeTrailingComments: 2
+CommentPragmas: '.*'


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [x ] I confirm.

---

*Enter your pull-request summary here*

```
"commentPragma:
A regular expression that describes comments with special meaning, which should not be split into lines or otherwise changed."
```

so using this regular expression we are telling clang format to ignore all comments.
cpplint does catch the space needed after comments anyway. cpplint also catches todo needing a name