### PR TITLE
Kovri: update clang-format and style guide

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,16 +2,18 @@ Language: Cpp
 BasedOnStyle: Google
 
 AlignAfterOpenBracket: AlwaysBreak
-AlignTrailingComments: true
+AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortFunctionsOnASingleLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 BinPackArguments: false
 BinPackParameters: false
-BreakBeforeBinaryOperators: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: GNU
 ColumnLimit: 80
+CommentPragmas: '.*'
 DerivePointerAlignment: false
 PointerAlignment: Left
 SpacesBeforeTrailingComments: 2
-CommentPragmas: '.*'

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,1 @@
+filter=-whitespace/braces,-whitespace/newline,-whitespace/line_length

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 - [FAQ's](https://github.com/monero-project/kovri/blob/master/doc/FAQ.md) and other documentation available in the [doc directory](https://github.com/monero-project/kovri/tree/master/doc)
 
 ## Developers
-- [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md) before sending a pull-request
+- [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md) and [Style Guide](https://github.com/monero-project/kovri/blob/master/doc/STYLE.md) before sending a pull-request
 - [Forum Funding System](https://forum.getmonero.org/8/funding-required) to get funded for your work, [submit a proposal](https://forum.getmonero.org/7/open-tasks/2379/forum-funding-system-ffs-sticky)
 - [build.getmonero.org](https://build.getmonero.org/) or monero-build.i2p for detailed build information
 - [repo.getmonero.org](https://repo.getmonero.org/monero-project/kovri) or monero-repo.i2p are alternatives to GitHub for non-push repository access

--- a/doc/STYLE.md
+++ b/doc/STYLE.md
@@ -1,13 +1,22 @@
 # Style
-1. Read [Google's C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
-2. Run [cpplint](https://pypi.python.org/pypi/cpplint/)
-```bash
-$ cpplint src/path/to/my/file
-```
-3. Run [clang-format](http://llvm.org/releases/3.8.0/tools/clang/docs/ClangFormat.html) with ```-style=file``` using provided [.clang-format](https://github.com/monero-project/kovri/blob/master/.clang-format)
+1. Read [Google's C++ Style Guide](https://google.github.io/styleguide/cppguide.html) (particularly for non-formatting style reference)
+2. Run [clang-format](http://clang.llvm.org/docs/ClangFormat.html) with ```-style=file``` (which uses our provided [.clang-format](https://github.com/monero-project/kovri/blob/master/.clang-format))
 ```bash
 $ cd kovri/ && clang-format -i -style=file src/path/to/my/file
 ```
+3. Run [cpplint](https://pypi.python.org/pypi/cpplint/) (which uses our provided [CPPLINT.cfg](https://github.com/monero-project/kovri/blob/master/CPPLINT.cfg)) to catch any issues that were missed by clang-format
+```bash
+$ cd kovri/ && cpplint src/path/to/my/file && [edit file manually to apply fixes]
+```
+
+### Plugins
+
+- Vim integration
+  - [clang-format](http://clang.llvm.org/docs/ClangFormat.html#vim-integration)
+  - [cpplint.vim](https://github.com/vim-syntastic/syntastic/blob/master/syntax_checkers/cpp/cpplint.vim)
+- Emacs integration
+  - [clang-format](http://clang.llvm.org/docs/ClangFormat.html#emacs-integration) + [clang-format.el](https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format.el)
+  - [flycheck-google-cpplint.el](https://github.com/flycheck/flycheck-google-cpplint)
 
 ## Here's what's currently not caught by clang-format and differs from Google's proposed C++ style
 

--- a/doc/STYLE.md
+++ b/doc/STYLE.md
@@ -11,37 +11,6 @@ $ cd kovri/ && clang-format -i -style=file src/path/to/my/file
 
 ## Here's what's currently not caught by clang-format and differs from Google's proposed C++ style
 
-- Keep with codebase's present (vertical) style for consistency
-- Newline break all function parameters for consisentcy across codebase
-- When function args newline break, ensure that *every* arg indent is 4 spaces
-
-```cpp
-  /// @brief Constructs SSU header with pre-determined payload type
-  explicit SSUHeader(
-      SSUPayloadType type);
-
-  /// @brief Constructs SSU header with pre-determined payload type and content
-  /// @note Assumes content is valid
-  /// @param SSUPayloadType SSU payload type
-  /// @param mac Pointer to header's MAC material
-  /// @param iv Pointer to header's IV material
-  /// @param time Header's timestamp
-  SSUHeader(
-      SSUPayloadType type,
-      std::uint8_t* mac,
-      std::uint8_t* iv,
-      std::uint32_t time);
-
-  /// @brief Sets MAC from appointed position within header
-  /// @note Assumes content is valid (based on position)
-  void SetMAC(
-      std::uint8_t* mac);
-
-  /// @brief Gets acquired MAC after it has been set when parsed
-  /// @return Pointer to MAC material
-  std::uint8_t* GetMAC() const;
-```
-
 - Expressions can be broken before operators if:
   - The line is greater that 80 columns
   - Doing so aids in better documentation
@@ -61,9 +30,7 @@ return SSUPacket::GetSize()
        + m_SignatureSize;   // Signature size
 ```
 
-- Class member variables should be prepended with ```m_```
-- Don't use "cheap function" names; always use MixedCaseFunctions()
 - Avoid prepended mixed-case ```k``` and MACRO_TYPE for all constants
 - Use Doxygen three-slash ```/// C++ comments``` when documenting for Doxygen
-- Document all your work for Doxygen as you progress
+- Try to document all your work for Doxygen as you progress
 - If anonymity is a concern, try to blend in with a present contributor's style


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

Reduces developer dependency on *our* style guide while
- strengthening our clang-format'er
- allowing new developer styles to flourish (with parameters)
- *giving-in* to more Google style idioms. 😄 

Most notable: the new format leans toward GNU bracing (something I never thought I'd do) but I think doing so is a good compromise (otherwise I'm always leaning toward personal tendencies).