### PR TITLE
ClientContext/Docs: add Base64 to address text file + user-guide tunnel setup

### DIFF
--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -50,18 +50,27 @@ Example:
 
 **Note: see kovri.conf to find your data path for Linux/OSX/Windows**
 
-## Step 5. Run Kovri
+## Step 5. (Optional) Register your new [eepsite](https://getmonero.org/knowledge-base/moneropedia/eepsite)
+
+**Stop! Until [#498](https://github.com/monero-project/kovri/issues/498) is resolved, consider only registering your service with Kovri and *not* stats.i2p!**
+
+- Open a request with `[Subscription Request] your-host.i2p` (replace your-host.i2p with your desired hostname) on the [Kovri issue tracker](https://github.com/monero-project/kovri/issues)
+- In the request body, paste the contents of your public `.txt` file that was mentioned in the previous step
+- After review, we will add your host and sign the subscription
+- Done!
+
+## Step 6. Run Kovri
 ```bash
 $ cd build/ && ./kovri
 ```
 - Wait 5 minutes or so to get bootstrapped into the network before attempting to use services
 
-## Step 6. Join us on IRC
+## Step 7. Join us on IRC
 1. Startup your [IRC client](https://en.wikipedia.org/wiki/List_of_IRC_clients)
 2. Setup your client to connect to kovri's IRC port (default 6669). This will connect you to the Irc2P network (I2P's IRC network)
 3. Join `#kovri` and `#kovri-dev`
 
-## Step 7. Browse an I2P website (garlic-site/eepsite)
+## Step 8. Browse an I2P website (garlic-site/eepsite)
 1. Startup a browser of your choosing (preferably a browser devoted to kovri usage)
 2. Configure your browser by reading [these instructions](https://geti2p.net/en/about/browser-config) **but instead of port 4444 and 4445** change HTTP proxy port to **4446** and SSL proxy port *also* to **4446**
 3. Visit http://check.kovri.i2p
@@ -74,7 +83,7 @@ Notes:
 - Look through hosts.txt in your data directory to view a list of default sites you can easily visit
 - Overall, HTTP Proxy and address book implementation are in development and not yet feature-complete
 
-## Step 8. Enjoy!
+## Step 9. Enjoy!
 - Read more about Kovri in the [Moneropedia](https://getmonero.org/knowledge-base/moneropedia/kovri).
 - Open your feature requests or report bugs on our [issues tracker](https://github.com/monero-project/kovri/issues)
 - Learn more about the I2P network on the [java I2P website](https://geti2p.net/en/docs)

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -46,7 +46,7 @@ Once setup, your [Base32 address](https://getmonero.org/knowledge-base/moneroped
 Example:
 
 - Private keys file: `client/keys/your-keys.dat`
-- Public Base32 address: `client/keys/your-keys.dat.txt`
+- Public [Base32](https://getmonero.org/knowledge-base/moneropedia/base32-address)/[Base64](https://getmonero.org/knowledge-base/moneropedia/base64-address) address: `client/keys/your-keys.dat.txt`
 
 **Note: see kovri.conf to find your data path for Linux/OSX/Windows**
 

--- a/src/client/context.cc
+++ b/src/client/context.cc
@@ -152,7 +152,7 @@ kovri::core::PrivateKeys ClientContext::LoadPrivateKeys(
     keys.FromBuffer(buf.get(), len);
     // Contingency: create associated address text file if the private keys
     // filename is swapped out with another set of keys with the same filename
-    CreateB32AddressTextFile(keys, filename);
+    CreateBaseAddressTextFile(keys, filename);
     LOG(info)
       << "ClientContext: " << file_path << " loaded: uses local address "
       << kovri::core::GetB32Address(keys.GetPublic().GetIdentHash());
@@ -177,14 +177,14 @@ kovri::core::PrivateKeys ClientContext::CreatePrivateKeys(
   len = keys.ToBuffer(buf.get(), len);
   file.write(reinterpret_cast<char *>(buf.get()), len);
   // Create associated address text file
-  CreateB32AddressTextFile(keys, filename);
+  CreateBaseAddressTextFile(keys, filename);
   LOG(info)
     << "ClientContext: created new private keys " << file_path << " for "
     << kovri::core::GetB32Address(keys.GetPublic().GetIdentHash());
   return keys;
 }
 
-void ClientContext::CreateB32AddressTextFile(
+void ClientContext::CreateBaseAddressTextFile(
     const kovri::core::PrivateKeys& keys,
     const std::string& filename) {
   auto path = kovri::core::EnsurePath(kovri::core::GetClientKeysPath());
@@ -192,9 +192,13 @@ void ClientContext::CreateB32AddressTextFile(
   // Create binary keys file
   std::ofstream file(file_path);
   if (!file)
-    throw std::runtime_error("ClientContext: could not open b32 address text file for writing");
-  file << kovri::core::GetB32Address(keys.GetPublic().GetIdentHash());
-  LOG(info) << "ClientContext: created b32 address file " << file_path;
+    throw std::runtime_error("ClientContext: could not open base address text file for writing");
+  // Re: identity, see #366
+  // Base32
+  file << kovri::core::GetB32Address(keys.GetPublic().GetIdentHash()) << "\n";
+  // Base64
+  file << keys.GetPublic().ToBase64();
+  LOG(info) << "ClientContext: created base address text file " << file_path;
 }
 
 std::shared_ptr<ClientDestination> ClientContext::LoadLocalDestination(

--- a/src/client/context.h
+++ b/src/client/context.h
@@ -99,7 +99,7 @@ class ClientContext {
   /// @brief Creates text file containing private key's public b32 address
   /// @param keys Private keys to derive b32 address from
   /// @param filename The relative name of the text address file
-  void CreateB32AddressTextFile(
+  void CreateBaseAddressTextFile(
       const kovri::core::PrivateKeys& keys,
       const std::string& filename);
 


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

Adds Base64 address output to text file for distribution + address book.