### PR TITLE
Repo: remove fluff from GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,9 @@
+
+---
 **By submitting this issue, I confirm the following:**
 
 - I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
 - I have checked that the issue I am reporting can be replicated or that the feature I am suggesting is not present.
 - I have checked opened or recently closed [pull requests](https://github.com/monero-project/kovri/pulls) for existing solutions/implementations to my issue/suggestion.
-
-*Place an X inside the bracket to confirm*
-- [ ] I confirm.
-
 ---
 
-*Enter your issue here*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+
+---
 **By submitting this pull-request, I confirm the following:**
 
 - I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
@@ -5,10 +7,5 @@
 - I have considered and confirmed that this submission will be valuable to others.
 - I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
 - I give this submission freely under the BSD 3-clause license.
-
-*Place an X inside the bracket (or click the box in preview) to confirm*
-- [ ] I confirm.
-
 ---
 
-*Enter your pull-request summary here*


### PR DESCRIPTION
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [X] I confirm.

---

Removes extra step to confirm and placeholder text

