### PR TITLE
STYLE :: clang-format ubuntu 16 note

### DIFF
--- a/doc/STYLE.md
+++ b/doc/STYLE.md
@@ -13,6 +13,7 @@ $ cd kovri/ && cpplint src/path/to/my/file && [edit file manually to apply fixes
 
 - Vim integration
   - [clang-format](http://clang.llvm.org/docs/ClangFormat.html#vim-integration)
+  - [clang-format ubuntu 16.04 vim workaround](http://stackoverflow.com/questions/39490082/clang-format-not-working-under-gvim)
   - [cpplint.vim](https://github.com/vim-syntastic/syntastic/blob/master/syntax_checkers/cpp/cpplint.vim)
 - Emacs integration
   - [clang-format](http://clang.llvm.org/docs/ClangFormat.html#emacs-integration) + [clang-format.el](https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format.el)


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Add a note about clang-format for vim on ubuntu 16