### PR TITLE
kovri-tests :: fix unmatched curly address book unit tests

### DIFF
--- a/tests/unit_tests/client/address_book/impl.cc
+++ b/tests/unit_tests/client/address_book/impl.cc
@@ -41,7 +41,6 @@
 
 #include "core/crypto/rand.h"
 
-BOOST_AUTO_TEST_SUITE(AddressBook);
 
 /// @class SubscriptionFixture
 struct SubscriptionFixture {
@@ -171,4 +170,4 @@ BOOST_AUTO_TEST_CASE(PGPClearSign) {
 
 // TODO(unassigned): more cases?
 
-BOOST_AUTO_TEST_SUITE_END() }  // TODO(unassigned): why is this stray brace needed?
+BOOST_AUTO_TEST_SUITE_END() 


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

fix unmatched bracket in address book unit test