### PR TITLE
Program options arg types and Bash completion

### DIFF
--- a/pkg/kovri-bash.sh
+++ b/pkg/kovri-bash.sh
@@ -57,25 +57,31 @@ _parse_kovri_help() {
 #   Completion suggestions
 ########################################
 _kovri() {
-  local cur prev
+  local cur prev type
   _init_completion -n = || return
 
   case "${prev}" in
-    --host|--port|--service|--httpproxyport|--httpproxyaddress|--socksproxyport| \
-    --socksproxyaddress|--i2pcontrolport|--i2pcontroladdress|--i2pcontrolpassword| \
-    --reseed-from)
-      # An argument is required.
-      return
-      ;;
-    --log-to-file|--log-to-console|--floodfill|-f|--enable-ssu|--enable-ntcp| \
-    --daemon)
-      COMPREPLY=($(compgen -W "on off yes no true false 1 0" -- "${cur}"))
-      return
-      ;;
     --log-level)
       COMPREPLY=($(compgen -W "0 1 2 3 4 5" -- "${cur}"))
       return
       ;;
+    -*)
+      type=$(kovri --help | \
+        grep -Poi "^\s*(${prev}|\-\w \[ ${prev} \]|${prev} \[ --\S+ \])\s\K\w+")
+      case "${type}" in
+        path)
+          _filedir
+          return
+          ;;
+        bool)
+          COMPREPLY=($(compgen -W "on off yes no true false 1 0" -- "${cur}"))
+          return
+          ;;
+        arg)
+          # An argument is required.
+          return
+          ;;
+      esac
   esac
 
   # Start parsing the help for option suggestions.

--- a/src/app/config.cc
+++ b/src/app/config.cc
@@ -75,13 +75,17 @@ void Configuration::ParseKovriConfig() {
       "host", bpo::value<std::string>()->default_value("127.0.0.1"))(
       "port,p", bpo::value<int>()->default_value(0))(
       "data-dir",
-      bpo::value<std::string>()->default_value(
-          kovri::core::GetDefaultDataPath().string()))(
-      "daemon,d", bpo::value<bool>()->default_value(false))(
+      bpo::value<std::string>()
+          ->default_value(kovri::core::GetDefaultDataPath().string())
+          ->value_name("path"))(
+      "daemon,d", bpo::value<bool>()->default_value(false)->value_name("bool"))(
       "service,s", bpo::value<std::string>()->default_value(""))(
-      "log-to-console", bpo::value<bool>()->default_value(true))(
-      "log-to-file", bpo::value<bool>()->default_value(true))(
-      "log-file-name", bpo::value<std::string>()->default_value(""))(
+      "log-to-console",
+      bpo::value<bool>()->default_value(true)->value_name("bool"))(
+      "log-to-file",
+      bpo::value<bool>()->default_value(true)->value_name("bool"))(
+      "log-file-name",
+      bpo::value<std::string>()->default_value("")->value_name("path"))(
       // TODO(anonimal): use only 1 log file?
       // Log levels
       // 0 = fatal
@@ -90,20 +94,25 @@ void Configuration::ParseKovriConfig() {
       // 3 = info warn error fatal
       // 4 = debug info warn error fatal
       // 5 = trace debug info warn error fatal
-      "log-level", bpo::value<std::uint16_t>()->default_value(3))(
-      "kovriconf,c", bpo::value<std::string>()->default_value(""))(
-      "tunnelsconf,t", bpo::value<std::string>()->default_value(""));
+      "log-level",
+      bpo::value<std::uint16_t>()->default_value(3))(
+      "kovriconf,c",
+      bpo::value<std::string>()->default_value("")->value_name("path"))(
+      "tunnelsconf,t",
+      bpo::value<std::string>()->default_value("")->value_name("path"));
   // This is NOT our default values for port, log-file-name, kovriconf and tunnelsconf
 
   bpo::options_description network("\nnetwork");
   network.add_options()
-    ("v6,6", bpo::value<bool>()->default_value(false))
-    ("floodfill,f", bpo::value<bool>()->default_value(false))
+    ("v6,6", bpo::value<bool>()->default_value(false)->value_name("bool"))
+    ("floodfill,f",
+     bpo::value<bool>()->default_value(false)->value_name("bool"))
     ("bandwidth,b", bpo::value<std::string>()->default_value("L"))
-    ("enable-ssu", bpo::value<bool>()->default_value(true))
-    ("enable-ntcp", bpo::value<bool>()->default_value(true))
+    ("enable-ssu", bpo::value<bool>()->default_value(true)->value_name("bool"))
+    ("enable-ntcp", bpo::value<bool>()->default_value(true)->value_name("bool"))
     ("reseed-from,r", bpo::value<std::string>()->default_value(""))
-    ("reseed-skip-ssl-check", bpo::value<bool>()->default_value(false));
+    ("reseed-skip-ssl-check",
+     bpo::value<bool>()->default_value(false)->value_name("bool"));
 
   bpo::options_description client("\nclient");
   client.add_options()

--- a/src/util/base.cc
+++ b/src/util/base.cc
@@ -48,8 +48,12 @@ BaseCommand::BaseCommand() : m_Desc("General options")
 {
   m_Desc.add_options()("help,h", "produce this help message")(
       "type,t", bpo::value<std::string>(&m_OptType), "encode/decode")(
-      "infile,i", bpo::value<std::string>(&m_OptInfile), "input file")(
-      "outfile,o", bpo::value<std::string>(&m_OptOutfile), "output file");
+      "infile,i",
+      bpo::value<std::string>(&m_OptInfile)->value_name("path"),
+      "input file")(
+      "outfile,o",
+      bpo::value<std::string>(&m_OptOutfile)->value_name("path"),
+      "output file");
 }
 
 void BaseCommand::PrintUsage(const std::string& name) const

--- a/src/util/main.cc
+++ b/src/util/main.cc
@@ -70,9 +70,12 @@ int main(int argc, const char* argv[])
   // See src/app/config.cc for log options
   general_desc.add_options()("help,h", "produce this help message")(
       "all,a", "print all options")(
-      "log-to-console", bpo::value<bool>()->default_value(true))(
-      "log-to-file", bpo::value<bool>()->default_value(false))(
-      "log-file-name", bpo::value<std::string>()->default_value(""))(
+      "log-to-console",
+      bpo::value<bool>()->default_value(true)->value_name("bool"))(
+      "log-to-file",
+      bpo::value<bool>()->default_value(false)->value_name("bool"))(
+      "log-file-name",
+      bpo::value<std::string>()->default_value("")->value_name("path"))(
       "log-level", bpo::value<std::uint16_t>()->default_value(3));
 
   bpo::options_description spec("Specific options");


### PR DESCRIPTION
This additional information is helpful for deducing the hints.
Only bool and path arguments are added.
Adding type information with Boost program options
is verbose and repetitive due to lack of reflection.
Macros can help, but it is still ugly.

The refactoring removes
most hard-coded options in the completion script.
The suggestions are deduced from argument types (path, bool).

Issue #611 

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

