### PR TITLE
RouterInfo: various refactoring

### DIFF
--- a/src/app/instance.cc
+++ b/src/app/instance.cc
@@ -97,7 +97,7 @@ void Instance::InitRouterContext() {
   // Random generated port if none is supplied via CLI or config
   // See: i2p.i2p/router/java/src/net/i2p/router/transport/udp/UDPEndpoint.java
   auto port = map["port"].defaulted() ? kovri::core::RandInRange32(9111, 30777)
-                                      : map["port"].as<int>();
+                                      : map["port"].as<std::uint16_t>();
   // TODO(unassigned): context should be in core namespace (see TODO in router context)
   context.Init(host, port);
   context.UpdatePort(port);

--- a/src/core/router/context.cc
+++ b/src/core/router/context.cc
@@ -213,7 +213,7 @@ void RouterContext::SetReachable() {
   // insert NTCP back
   auto& addresses = m_RouterInfo.GetAddresses();
   for (std::size_t i = 0; i < addresses.size(); i++) {
-    if (addresses[i].transport_style == core::RouterInfo::Transport::SSU) {
+    if (addresses[i].transport == core::RouterInfo::Transport::SSU) {
       // insert NTCP address with host/port form SSU
       m_RouterInfo.AddNTCPAddress(
           addresses[i].host.to_string().c_str(),
@@ -268,7 +268,7 @@ void RouterContext::UpdateNTCPV6Address(
   auto& addresses = m_RouterInfo.GetAddresses();
   for (auto& addr : addresses) {
     if (addr.host.is_v6() &&
-        addr.transport_style == core::RouterInfo::Transport::NTCP) {
+        addr.transport == core::RouterInfo::Transport::NTCP) {
       if (addr.host != host) {
         addr.host = host;
         updated = true;
@@ -346,7 +346,7 @@ void RouterContext::RemoveTransport(
     core::RouterInfo::Transport transport) {
   auto& addresses = m_RouterInfo.GetAddresses();
   for (std::size_t i = 0; i < addresses.size(); i++) {
-    if (addresses[i].transport_style == transport) {
+    if (addresses[i].transport == transport) {
       addresses.erase(addresses.begin() + i);
       break;
     }

--- a/src/core/router/context.cc
+++ b/src/core/router/context.cc
@@ -65,7 +65,7 @@ RouterContext::RouterContext()
 
 void RouterContext::Init(
     const std::string& host,
-    int port) {
+    std::uint16_t port) {
   m_Host = host;
   m_Port = port;
   m_StartupTime = kovri::core::GetSecondsSinceEpoch();
@@ -106,7 +106,7 @@ void RouterContext::UpdateRouterInfo() {
 }
 
 void RouterContext::UpdatePort(
-    int port) {
+    std::uint16_t port) {
   bool updated = false;
   for (auto& address : m_RouterInfo.GetAddresses()) {
     if (address.port != port) {
@@ -264,7 +264,7 @@ void RouterContext::UpdateNTCPV6Address(
     const boost::asio::ip::address& host) {
   bool updated = false,
        found = false;
-  int port = 0;
+  std::uint16_t port = 0;
   auto& addresses = m_RouterInfo.GetAddresses();
   for (auto& addr : addresses) {
     if (addr.host.is_v6() &&

--- a/src/core/router/context.h
+++ b/src/core/router/context.h
@@ -71,7 +71,7 @@ class RouterContext : public kovri::core::GarlicDestination {
   /// @param port The external port of this router
   void Init(
       const std::string& host,
-      int port);
+      std::uint16_t port);
 
   // @return This RouterContext's RouterInfo
   kovri::core::RouterInfo& GetRouterInfo() {
@@ -117,7 +117,7 @@ class RouterContext : public kovri::core::GarlicDestination {
   // Called from Daemon, updates this RouterContext's Port.
   // Rebuilds RouterInfo
   // @param port port number
-  void UpdatePort(int port);
+  void UpdatePort(std::uint16_t port);
 
   // Called From SSU or Daemon.
   // Update Our IP Address, external IP Address if behind NAT.
@@ -314,7 +314,7 @@ class RouterContext : public kovri::core::GarlicDestination {
   RouterStatus m_Status;
   std::mutex m_GarlicMutex;
   std::string m_Host;
-  int m_Port;
+  std::uint16_t m_Port;
   std::string m_ReseedFrom;
   bool m_ReseedSkipSSLCheck;
   bool m_SupportsNTCP, m_SupportsSSU;

--- a/src/core/router/context.h
+++ b/src/core/router/context.h
@@ -303,7 +303,7 @@ class RouterContext : public kovri::core::GarlicDestination {
   void UpdateRouterInfo();
   bool Load();
   void SaveKeys();
-  void RemoveTransport(kovri::core::RouterInfo::TransportStyle transport);
+  void RemoveTransport(core::RouterInfo::Transport transport);
 
  private:
   kovri::core::RouterInfo m_RouterInfo;

--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -291,7 +291,7 @@ void RouterInfo::ParseRouterInfo(const std::string& router_info)
                             // NTCP will (should be) resolved in transports
                             // TODO(unassigned): refactor. Though we will resolve host later, assigning values upon error is simply confusing.
                             m_SupportedTransports |= SupportedTransport::NTCPv4;
-                            address.address_string = value;
+                            address.address = value;
                             break;
 		          case Transport::SSU:
                             // TODO(unassigned): implement address resolver for SSU (then break from default case)

--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -317,10 +317,10 @@ void RouterInfo::ParseRouterInfo(const std::string& router_info)
                   break;
                 }
               case Trait::Port:
-                address.port = boost::lexical_cast<int>(value);
+                address.port = boost::lexical_cast<std::uint16_t>(value);
                 break;
               case Trait::MTU:
-                address.mtu = boost::lexical_cast<int>(value);
+                address.mtu = boost::lexical_cast<std::uint16_t>(value);
                 break;
               case Trait::Key:
                 kovri::core::Base64ToByteStream(
@@ -359,7 +359,7 @@ void RouterInfo::ParseRouterInfo(const std::string& router_info)
                           }
                           break;
                         case Trait::IntroPort:
-                          introducer.port = boost::lexical_cast<int>(value);
+                          introducer.port = boost::lexical_cast<std::uint16_t>(value);
                           break;
                         case Trait::IntroTag:
                           introducer.tag =
@@ -656,7 +656,7 @@ void RouterInfo::WriteString(
 
 void RouterInfo::AddNTCPAddress(
     const std::string& host,
-    int port) {
+    std::uint16_t port) {
   Address addr;
   addr.host = boost::asio::ip::address::from_string(host);
   addr.port = port;
@@ -671,9 +671,9 @@ void RouterInfo::AddNTCPAddress(
 
 void RouterInfo::AddSSUAddress(
     const std::string& host,
-    int port,
+    std::uint16_t port,
     const std::uint8_t* key,
-    int mtu) {
+    std::uint16_t mtu) {
   Address addr;
   addr.host = boost::asio::ip::address::from_string(host);
   addr.port = port;

--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -70,29 +70,37 @@ const int MAX_RI_BUFFER_SIZE = 2048;
 
 class RouterInfo : public RoutingDestination {
  public:
-  enum SupportedTransports {
-    eNTCPV4 = 0x01,
-    eNTCPV6 = 0x02,
-    eSSUV4 = 0x04,
-    eSSUV6 = 0x08
+  /// @enum Transport
+  /// @brief Transport type(s) within RI
+  enum Transport : std::uint8_t
+  {
+    NTCP,
+    SSU,
+    Unknown,
   };
 
-  enum Caps {
-    eFloodfill = 0x01,
-    eUnlimitedBandwidth = 0x02,
-    eHighBandwidth = 0x04,
-    eReachable = 0x08,
-    eSSUTesting = 0x10,
-    eSSUIntroducer = 0x20,
-    eHidden = 0x40,
-    eUnreachable = 0x80
+  /// @enum SupportedTransport
+  /// @brief Transport and IP version that *our* router will use for peer
+  enum SupportedTransport : std::uint8_t
+  {
+    NTCPv4 = 0x01,
+    NTCPv6 = 0x02,
+    SSUv4 = 0x04,
+    SSUv6 = 0x08,
   };
 
-  // TODO(anonimal): refactor
-  enum TransportStyle {
-    eTransportUnknown = 0,
-    eTransportNTCP,
-    eTransportSSU
+  /// @enum Caps
+  /// @brief RI capabilities
+  enum Caps : std::uint8_t
+  {
+    Floodfill = 0x01,
+    UnlimitedBandwidth = 0x02,
+    HighBandwidth = 0x04,
+    Reachable = 0x08,
+    SSUTesting = 0x10,
+    SSUIntroducer = 0x20,
+    Hidden = 0x40,
+    Unreachable = 0x80,
   };
 
   struct Introducer {
@@ -108,7 +116,7 @@ class RouterInfo : public RoutingDestination {
   };
 
   struct Address {
-    TransportStyle transport_style;
+    Transport transport_style;
     boost::asio::ip::address host;
     std::string address_string;
     int port{}, mtu{};
@@ -330,19 +338,19 @@ class RouterInfo : public RoutingDestination {
   bool UsesIntroducer() const;
 
   bool IsIntroducer() const {
-    return m_Caps & eSSUIntroducer;
+    return m_Caps & Caps::SSUIntroducer;
   }
 
   bool IsPeerTesting() const {
-    return m_Caps & eSSUTesting;
+    return m_Caps & Caps::SSUTesting;
   }
 
   bool IsHidden() const {
-    return m_Caps & eHidden;
+    return m_Caps & Caps::Hidden;
   }
 
   bool IsHighBandwidth() const {
-    return m_Caps & RouterInfo::eHighBandwidth;
+    return m_Caps & Caps::HighBandwidth;
   }
 
   std::uint8_t GetCaps() const {
@@ -443,7 +451,7 @@ class RouterInfo : public RoutingDestination {
       const char* value);
 
   const Address* GetAddress(
-      TransportStyle s,
+      Transport s,
       bool v4only,
       bool v6only = false) const;
 

--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -118,7 +118,7 @@ class RouterInfo : public RoutingDestination {
   struct Address {
     Transport transport;
     boost::asio::ip::address host;
-    std::string address_string;
+    std::string address;
     std::uint16_t port{}, mtu{};
     std::uint64_t date{};
     std::uint8_t cost{};

--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -211,12 +211,15 @@ class RouterInfo : public RoutingDestination {
     std::uint16_t port{};
     Tag<32> key;
     std::uint32_t tag{};
-
-    /// @brief Human readable description of this struct
-    /// @param prefix for tabulations
-    /// @returns human readable string
-    std::string GetDescription(const std::string& tabs = std::string()) const;
   };
+
+  /// @brief Human readable description of Introducer members
+  /// @param introducer Introducer class to get description from
+  /// @param tabs Prefix for tabulations
+  /// @returns human readable string
+  const std::string GetDescription(
+      const Introducer& introducer,
+      const std::string& tabs = std::string()) const;
 
   struct Address {
     Transport transport;
@@ -233,17 +236,21 @@ class RouterInfo : public RoutingDestination {
       return (host.is_v4() && other.is_v4()) ||
         (host.is_v6() && other.is_v6());
     }
-
-    /// @brief Human readable description of this struct
-    /// @param prefix for tabulations
-    /// @returns human readable string
-    std::string GetDescription(const std::string& tabs = std::string()) const;
   };
+
+  /// @brief Human readable description of Address members
+  /// @param address Address class to get description from
+  /// @param tabs Prefix for tabulations
+  /// @returns human readable string
+  const std::string GetDescription(
+      const Address& address,
+      const std::string& tabs = std::string()) const;
 
   /// @enum Trait
   /// @brief RI traits
   enum struct Trait : std::uint8_t
   {
+    // Address-specific
     NTCP,
     SSU,
     Host,
@@ -251,6 +258,8 @@ class RouterInfo : public RoutingDestination {
     MTU,
     Key,
     Caps,
+    Cost,
+    Date,
     // Introducer
     IntroHost,
     IntroPort,
@@ -269,6 +278,7 @@ class RouterInfo : public RoutingDestination {
   {
     switch (trait)
       {
+        // Address-specific
         case Trait::NTCP:
           return "NTCP";
         case Trait::SSU:
@@ -283,6 +293,10 @@ class RouterInfo : public RoutingDestination {
           return "key";
         case Trait::Caps:
           return "caps";
+        case Trait::Cost:
+          return "cost";
+        case Trait::Date:
+          return "date";
         // Introducer
         case Trait::IntroHost:
           return "ihost";
@@ -307,6 +321,7 @@ class RouterInfo : public RoutingDestination {
   /// @param value String value of potential trait given
   Trait GetTrait(const std::string& value) const noexcept
   {
+    // Address-specific
     if (value == GetTrait(Trait::NTCP))
       return Trait::NTCP;
     else if (value == GetTrait(Trait::SSU))
@@ -321,6 +336,10 @@ class RouterInfo : public RoutingDestination {
       return Trait::Key;
     else if (value == GetTrait(Trait::Caps))
       return Trait::Caps;
+    else if (value == GetTrait(Trait::Cost))
+      return Trait::Cost;
+    else if (value == GetTrait(Trait::Date))
+      return Trait::Date;
     // Introducer
     else if (value == GetTrait(Trait::IntroHost))
       return Trait::IntroHost;
@@ -531,7 +550,8 @@ class RouterInfo : public RoutingDestination {
   /// @brief Human readable description of this struct
   /// @param prefix for tabulations
   /// @returns human readable string
-  std::string GetDescription(const std::string& tabs = std::string()) const;
+  const std::string GetDescription(
+      const std::string& tabs = std::string()) const;
 
  private:
   bool LoadFile();

--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -105,9 +105,9 @@ class RouterInfo : public RoutingDestination {
 
   struct Introducer {
     boost::asio::ip::address host;
-    int port;
+    int port{};
     Tag<32> key;
-    std::uint32_t tag;
+    std::uint32_t tag{};
 
     /// @brief Human readable description of this struct
     /// @param prefix for tabulations

--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -51,21 +51,6 @@
 namespace kovri {
 namespace core {
 
-const char CAPS_FLAG_FLOODFILL = 'f';
-const char CAPS_FLAG_HIDDEN = 'H';
-const char CAPS_FLAG_REACHABLE = 'R';
-const char CAPS_FLAG_UNREACHABLE = 'U';
-const char CAPS_FLAG_LOW_BANDWIDTH1 = 'K';
-const char CAPS_FLAG_LOW_BANDWIDTH2 = 'L';
-const char CAPS_FLAG_HIGH_BANDWIDTH1 = 'M';
-const char CAPS_FLAG_HIGH_BANDWIDTH2 = 'N';
-const char CAPS_FLAG_HIGH_BANDWIDTH3 = 'O';
-const char CAPS_FLAG_HIGH_BANDWIDTH4 = 'P';
-const char CAPS_FLAG_UNLIMITED_BANDWIDTH = 'X';
-
-const char CAPS_FLAG_SSU_TESTING = 'B';
-const char CAPS_FLAG_SSU_INTRODUCER = 'C';
-
 const int MAX_RI_BUFFER_SIZE = 2048;
 
 class RouterInfo : public RoutingDestination {
@@ -102,6 +87,124 @@ class RouterInfo : public RoutingDestination {
     Hidden = 0x40,
     Unreachable = 0x80,
   };
+
+  /// @enum CapsFlag
+  /// @brief Flags used for RI capabilities
+  enum struct CapsFlag : std::uint8_t
+  {
+    Floodfill,
+    Hidden,
+    Reachable,
+    Unreachable,
+    LowBandwidth1,
+    LowBandwidth2,
+    HighBandwidth1,
+    HighBandwidth2,
+    HighBandwidth3,
+    HighBandwidth4,
+    UnlimitedBandwidth,
+    SSUTesting,
+    SSUIntroducer,
+    Unknown,
+  };
+
+  /// @return Char flag of given enumerated caps flag
+  /// @param flag Flag enum used for caps char flag
+  char GetTrait(CapsFlag flag) const noexcept
+  {
+    switch (flag)
+      {
+        case CapsFlag::Floodfill:
+          return 'f';
+
+        case CapsFlag::Hidden:
+          return 'H';
+
+        case CapsFlag::Reachable:
+          return 'R';
+
+        case CapsFlag::Unreachable:
+          return 'U';
+
+        case CapsFlag::LowBandwidth1:
+          return 'K';
+
+        case CapsFlag::LowBandwidth2:
+          return 'L';
+
+        case CapsFlag::HighBandwidth1:
+          return 'M';
+
+        case CapsFlag::HighBandwidth2:
+          return 'N';
+
+        case CapsFlag::HighBandwidth3:
+          return 'O';
+
+        case CapsFlag::HighBandwidth4:
+          return 'P';
+
+        case CapsFlag::UnlimitedBandwidth:
+          return 'X';
+
+        case CapsFlag::SSUTesting:
+          return 'B';
+
+        case CapsFlag::SSUIntroducer:
+          return 'C';
+
+        case CapsFlag::Unknown:
+        default:
+          return ' ';  // TODO(anonimal): review
+      }
+  }
+
+  /// @return Enumerated caps flag
+  /// @param value Char value of potential caps flag given
+  CapsFlag GetTrait(const char& value) const noexcept
+  {
+    if (value == GetTrait(CapsFlag::Floodfill))
+      return CapsFlag::Floodfill;
+
+    else if (value == GetTrait(CapsFlag::Hidden))
+      return CapsFlag::Hidden;
+
+    else if (value == GetTrait(CapsFlag::Reachable))
+      return CapsFlag::Reachable;
+
+    else if (value == GetTrait(CapsFlag::Unreachable))
+      return CapsFlag::Unreachable;
+
+    else if (value == GetTrait(CapsFlag::LowBandwidth1))
+      return CapsFlag::LowBandwidth1;
+
+    else if (value == GetTrait(CapsFlag::LowBandwidth2))
+      return CapsFlag::LowBandwidth2;
+
+    else if (value == GetTrait(CapsFlag::HighBandwidth1))
+      return CapsFlag::HighBandwidth1;
+
+    else if (value == GetTrait(CapsFlag::HighBandwidth2))
+      return CapsFlag::HighBandwidth2;
+
+    else if (value == GetTrait(CapsFlag::HighBandwidth3))
+      return CapsFlag::HighBandwidth3;
+
+    else if (value == GetTrait(CapsFlag::HighBandwidth4))
+      return CapsFlag::HighBandwidth4;
+
+    else if (value == GetTrait(CapsFlag::UnlimitedBandwidth))
+      return CapsFlag::UnlimitedBandwidth;
+
+    else if (value == GetTrait(CapsFlag::SSUTesting))
+      return CapsFlag::SSUTesting;
+
+    else if (value == GetTrait(CapsFlag::SSUIntroducer))
+      return CapsFlag::SSUIntroducer;
+
+    else
+      return CapsFlag::Unknown;  // TODO(anonimal): review
+  }
 
   struct Introducer {
     boost::asio::ip::address host;

--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -116,7 +116,7 @@ class RouterInfo : public RoutingDestination {
   };
 
   struct Address {
-    Transport transport_style;
+    Transport transport;
     boost::asio::ip::address host;
     std::string address_string;
     std::uint16_t port{}, mtu{};

--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -105,7 +105,7 @@ class RouterInfo : public RoutingDestination {
 
   struct Introducer {
     boost::asio::ip::address host;
-    int port{};
+    std::uint16_t port{};
     Tag<32> key;
     std::uint32_t tag{};
 
@@ -119,7 +119,7 @@ class RouterInfo : public RoutingDestination {
     Transport transport_style;
     boost::asio::ip::address host;
     std::string address_string;
-    int port{}, mtu{};
+    std::uint16_t port{}, mtu{};
     std::uint64_t date{};
     std::uint8_t cost{};
     // SSU only
@@ -290,13 +290,13 @@ class RouterInfo : public RoutingDestination {
 
   void AddNTCPAddress(
       const std::string& host,
-      int port);
+      std::uint16_t port);
 
   void AddSSUAddress(
       const std::string& host,
-      int port,
+      std::uint16_t port,
       const std::uint8_t* key,
-      int mtu = 0);
+      std::uint16_t mtu = 0);
 
   bool AddIntroducer(
       const Address* address,

--- a/src/core/router/net_db/impl.cc
+++ b/src/core/router/net_db/impl.cc
@@ -904,7 +904,7 @@ std::shared_ptr<const RouterInfo> NetDb::GetHighBandwidthRandomRouter(
       return !router->IsHidden() &&
       router != compatible_with &&
       router->IsCompatible(*compatible_with) &&
-      (router->GetCaps() & RouterInfo::eHighBandwidth);
+      (router->GetCaps() & RouterInfo::Caps::HighBandwidth);
     });
 }
 

--- a/src/core/router/transports/impl.cc
+++ b/src/core/router/transports/impl.cc
@@ -182,7 +182,7 @@ void Transports::Start() {
   for (const auto& address : addresses) {
     LOG(debug) << "Transports: creating servers for address " << address.host;
     if (address.transport_style ==
-        kovri::core::RouterInfo::eTransportNTCP && address.host.is_v4()) {
+        core::RouterInfo::Transport::NTCP && address.host.is_v4()) {
       if (!m_NTCPServer) {
         LOG(debug) << "Transports: TCP listening on port " << address.port;
         m_NTCPServer = std::make_unique<NTCPServer>(m_Service, address.port);
@@ -192,7 +192,7 @@ void Transports::Start() {
       }
     }
     if (address.transport_style ==
-        kovri::core::RouterInfo::eTransportSSU && address.host.is_v4()) {
+        core::RouterInfo::Transport::SSU && address.host.is_v4()) {
       if (!m_SSUServer) {
         LOG(debug) << "Transports: UDP listening on port " << address.port;
         m_SSUServer = std::make_unique<SSUServer>(m_Service, address.port);

--- a/src/core/router/transports/impl.cc
+++ b/src/core/router/transports/impl.cc
@@ -181,7 +181,7 @@ void Transports::Start() {
   const auto addresses = context.GetRouterInfo().GetAddresses();
   for (const auto& address : addresses) {
     LOG(debug) << "Transports: creating servers for address " << address.host;
-    if (address.transport_style ==
+    if (address.transport ==
         core::RouterInfo::Transport::NTCP && address.host.is_v4()) {
       if (!m_NTCPServer) {
         LOG(debug) << "Transports: TCP listening on port " << address.port;
@@ -191,7 +191,7 @@ void Transports::Start() {
         LOG(error) << "Transports: TCP server already exists";
       }
     }
-    if (address.transport_style ==
+    if (address.transport ==
         core::RouterInfo::Transport::SSU && address.host.is_v4()) {
       if (!m_SSUServer) {
         LOG(debug) << "Transports: UDP listening on port " << address.port;

--- a/src/core/router/transports/impl.cc
+++ b/src/core/router/transports/impl.cc
@@ -389,10 +389,9 @@ bool Transports::ConnectToPeerNTCP(
       return true;
     }
   } else {  // we don't have address
-    if (address->address_string.length() > 0) {  // trying to resolve
-      LOG(debug) <<
-          "Transports: NTCP resolving " << address->address_string;
-      NTCPResolve(address->address_string, ident);
+    if (address->address.length() > 0) {  // trying to resolve
+      LOG(debug) << "Transports: NTCP resolving " << address->address;
+      NTCPResolve(address->address, ident);
       return true;
     }
   }

--- a/src/core/router/transports/upnp.cc
+++ b/src/core/router/transports/upnp.cc
@@ -206,9 +206,9 @@ void UPnP::Run() {
   for (const auto& address : context.GetRouterInfo().GetAddresses()) {
     if (!address.host.is_v6()) {
       Discover();
-      if (address.transport_style == kovri::core::RouterInfo::eTransportSSU) {
+      if (address.transport == core::RouterInfo::Transport::SSU) {
         TryPortMapping(I2P_UPNP_UDP, address.port);
-      } else if (address.transport_style == kovri::core::RouterInfo::eTransportNTCP) {
+      } else if (address.transport == core::RouterInfo::Transport::NTCP) {
         TryPortMapping(I2P_UPNP_TCP, address.port);
       }
     }


### PR DESCRIPTION
WIP. Live tests pass. Referencing #617. This WIP is in pursuit of isolating #187.

**Note for any reviewers**: if skimming through the GitHub *"Files Changed"* tab, a clickable *"Large diffs are not loaded by default"* for `router/info.cc` is tucked into the diff.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

