### PR TITLE
Instance: fix failed conversion when supplying port

### DIFF
--- a/src/app/instance.cc
+++ b/src/app/instance.cc
@@ -97,7 +97,7 @@ void Instance::InitRouterContext() {
   // Random generated port if none is supplied via CLI or config
   // See: i2p.i2p/router/java/src/net/i2p/router/transport/udp/UDPEndpoint.java
   auto port = map["port"].defaulted() ? kovri::core::RandInRange32(9111, 30777)
-                                      : map["port"].as<std::uint16_t>();
+                                      : map["port"].as<int>();
   // TODO(unassigned): context should be in core namespace (see TODO in router context)
   context.Init(host, port);
   context.UpdatePort(port);


### PR DESCRIPTION
Fixes boost::bad_any_cast when supplying port


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

