### PR TITLE
HTTP :: use enums for status from cpp-netlib

### DIFF
--- a/src/client/util/http.h
+++ b/src/client/util/http.h
@@ -61,12 +61,6 @@ enum struct Timeout : std::uint8_t {
   Receive = 30,
 };
 
-enum struct ResponseCode : std::uint16_t {
-  // TODO(anonimal): see if cpp-netlib has this readily available
-  HTTP_OK = 200,
-  HTTP_NOT_MODIFIED = 304,
-};
-
 /// @class HTTPStorage
 /// @brief Storage for class HTTP
 class HTTPStorage {


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

