### PR TITLE
kovri-install.sh: fix option checking

### DIFF
--- a/pkg/kovri-install.sh
+++ b/pkg/kovri-install.sh
@@ -134,7 +134,7 @@ PrepareOptions() {
     fi
   else
     # Ensure proper command line
-    if [[ ! -z $_package_file || $_create_checksum_file == false ]]; then
+    if [[ ! -z $_package_file || $_create_checksum_file == true ]]; then
       usage ; false ; catch "set the package option to build a package"
     fi
   fi


### PR DESCRIPTION
The current comparison between $_create_checksum_file and false at line 137 will always yield false since $_create_checksum_file at that point is either empty or true.  I am guessing that the intent is to fail if the caller supplies -c, but not -p.  If this is the case, then the script should fail if $_create_checksum_file is true, which is what this commit does.

(I ran into this when trying to port the install script to a shell different from bash for my own purposes.  Replacing the "== false" with "!= true", which is the right way to do this comparison results in the script failing the option checks when called without arguments from 'make install'.)


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

