### PR TITLE
Kovri: remove brace-elision for array initialization

### DIFF
--- a/src/app/daemon_linux.cc
+++ b/src/app/daemon_linux.cc
@@ -138,7 +138,7 @@ bool DaemonLinux::Init() {
     return false;
   }
   LOG(debug) << "DaemonLinux: writing pid file";
-  std::array<char, 10> pid{};
+  std::array<char, 10> pid {{}};
   snprintf(pid.data(), pid.size(), "%d\n", getpid());
   if (write(m_PIDFileHandle, pid.data(), strlen(pid.data())) < 0) {
     LOG(error)
@@ -147,7 +147,7 @@ bool DaemonLinux::Init() {
   }
   LOG(debug) << "DaemonLinux: pid file ready";
   // Signal handler
-  struct sigaction sa{};
+  struct sigaction sa {{}};
   sa.sa_handler = handle_signal;
   sigemptyset(&sa.sa_mask);
   sa.sa_flags = SA_RESTART;

--- a/src/client/api/i2p_control/session.cc
+++ b/src/client/api/i2p_control/session.cc
@@ -344,7 +344,7 @@ bool I2PControlSession::Authenticate(
 
 std::string I2PControlSession::GenerateToken() const {
   // Generate random data for token
-  std::array<std::uint8_t, TOKEN_SIZE> rand = {};
+  std::array<std::uint8_t, TOKEN_SIZE> rand {{}};
   kovri::core::RandBytes(rand.data(), TOKEN_SIZE);
   // Create base16 token from random data
   std::stringstream token;

--- a/src/client/api/streaming.cc
+++ b/src/client/api/streaming.cc
@@ -105,7 +105,7 @@ Stream::Stream(
       m_Status(eStreamStatusNew),
       m_IsAckSendScheduled(false),
       m_LocalDestination(local),
-      m_CurrentRemoteLease {},
+      m_CurrentRemoteLease {{}},
       m_ReceiveTimer(m_Service),
       m_ResendTimer(m_Service),
       m_AckSendTimer(m_Service),

--- a/src/core/crypto/impl/cryptopp/signature.cc
+++ b/src/core/crypto/impl/cryptopp/signature.cc
@@ -756,7 +756,7 @@ class RSARawVerifier {
             m_Modulus));  // s^e mod n
     std::vector<std::uint8_t> buf(key_length);
     encrypted_signature.Encode(buf.data(), buf.size());
-    std::array<std::uint8_t, Hash::DIGESTSIZE> digest{};
+    std::array<std::uint8_t, Hash::DIGESTSIZE> digest {{}};
     m_Hash.Final(digest.data());
     if (buf.size() < Hash::DIGESTSIZE)
       return false;  // Can't verify digest longer than key

--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -667,7 +667,7 @@ void RouterInfo::CreateRouterInfo(
 
   // Write ident
   // TODO(anonimal): review the following arbitrary size (must be >= 387)
-  std::array<std::uint8_t, 1024> ident{};
+  std::array<std::uint8_t, 1024> ident {{}};
   auto ident_len =
       private_keys.GetPublic().ToBuffer(ident.data(), ident.size());
   router_info.Write(ident.data(), ident_len);
@@ -750,7 +750,7 @@ void RouterInfo::CreateRouterInfo(
                       introducer.host.to_string());
 
                   // Write introducer key
-                  std::array<char, 64> key{};
+                  std::array<char, 64> key {{}};
                   core::ByteStreamToBase64(
                       introducer.key,
                       sizeof(introducer.key),
@@ -775,7 +775,7 @@ void RouterInfo::CreateRouterInfo(
             }
 
           // Write key
-          std::array<char, 64> value{};
+          std::array<char, 64> value {{}};
           core::ByteStreamToBase64(
               address.key, sizeof(address.key), value.data(), value.size());
 

--- a/src/core/router/net_db/impl.cc
+++ b/src/core/router/net_db/impl.cc
@@ -554,7 +554,7 @@ void NetDb::HandleDatabaseStoreMsg(
     try {
       kovri::core::Gunzip decompressor;
       decompressor.Put(buf + offset, size);
-      std::array<std::uint8_t, RouterInfo::Size::MaxBuffer> uncompressed{};
+      std::array<std::uint8_t, RouterInfo::Size::MaxBuffer> uncompressed {{}};
       std::size_t uncompressed_size = decompressor.MaxRetrievable();
       if (uncompressed_size > RouterInfo::Size::MaxBuffer) {
         LOG(error)
@@ -573,7 +573,7 @@ void NetDb::HandleDatabaseStoreMsg(
 void NetDb::HandleDatabaseSearchReplyMsg(
     std::shared_ptr<const I2NPMessage> msg) {
   const std::uint8_t* buf = msg->GetPayload();
-  std::array<char, 48> key{};
+  std::array<char, 48> key {{}};
   core::ByteStreamToBase64(buf, 32, key.data(), key.size());
   std::uint8_t num = buf[32];  // num
   LOG(debug) << "NetDb: DatabaseSearchReply for " << std::string(key.data()) << " num=" << num;
@@ -641,7 +641,7 @@ void NetDb::HandleDatabaseSearchReplyMsg(
   // try responses
   for (std::uint8_t i = 0; i < num; i++) {
     const std::uint8_t* router = buf + 33 + i * 32;
-    std::array<char, 48> peer_hash{};
+    std::array<char, 48> peer_hash {{}};
     core::ByteStreamToBase64(router, 32, peer_hash.data(), peer_hash.size());
     LOG(debug) << "NetDb: " << i << ": " << peer_hash.data();
     auto r = FindRouter(router);
@@ -664,7 +664,7 @@ void NetDb::HandleDatabaseLookupMsg(
     LOG(error) << "NetDb: DatabaseLookup for zero ident. Ignored";
     return;
   }
-  std::array<char, 48> key{};
+  std::array<char, 48> key {{}};
   core::ByteStreamToBase64(buf, 32, key.data(), key.size());
   std::uint8_t flag = buf[64];
   LOG(debug)
@@ -780,7 +780,7 @@ void NetDb::Explore(std::uint16_t num_destinations)
   auto inbound =
     exploratory_pool ? exploratory_pool->GetNextInboundTunnel() : nullptr;
   bool through_tunnels = outbound && inbound;
-  std::array<std::uint8_t, 32> random_hash{};  // Must be randomized before exploring
+  std::array<std::uint8_t, 32> random_hash {{}};  // Must be randomized before exploring
   std::vector<kovri::core::TunnelMessageBlock> msgs;
   std::set<const RouterInfo *> floodfills;
   // TODO(unassigned): docs

--- a/src/core/router/transports/ssu/packet.cc
+++ b/src/core/router/transports/ssu/packet.cc
@@ -660,7 +660,7 @@ SSUFragment SSUPacketParser::ParseFragment() {
   SSUFragment fragment;
   fragment.SetMessageID(ReadUInt32());
   // TODO(EinMByte): clean this up
-  std::array<std::uint8_t, 4> info_buf {};
+  std::array<std::uint8_t, 4> info_buf {{}};
   memcpy(info_buf.data() + 1, ReadBytes(3), 3);
   const std::uint32_t fragment_info = bufbe32toh(info_buf.data());
   fragment.SetSize(fragment_info & 0x3FFF);  // bits 0 - 13

--- a/src/core/router/transports/ssu/server.cc
+++ b/src/core/router/transports/ssu/server.cc
@@ -376,7 +376,7 @@ std::shared_ptr<SSUSession> SSUServer::GetSession(
             session->WaitForIntroduction();
             // if we are unreachable
             if (kovri::context.GetRouterInfo().UsesIntroducer()) {
-              std::array<std::uint8_t, 1> buf {};
+              std::array<std::uint8_t, 1> buf {{}};
               Send(buf.data(), 0, remote_endpoint);  // send HolePunch
             }
             introducer_session->Introduce(introducer->tag, introducer->key);

--- a/src/core/router/transports/ssu/session.cc
+++ b/src/core/router/transports/ssu/session.cc
@@ -625,7 +625,7 @@ void SSUSession::SendRelayRequest(
       << __func__ << ": SSU is not supported";
     return;
   }
-  std::array<std::uint8_t, 96 + 18> buf {};  // TODO(unassigned): document size values
+  std::array<std::uint8_t, 96 + 18> buf {{}};  // TODO(unassigned): document size values
   auto payload = buf.data() + GetType(SSUSize::HeaderMin);
   htobe32buf(payload, introducer_tag);
   payload += 4;
@@ -697,7 +697,7 @@ void SSUSession::SendRelayResponse(
     const boost::asio::ip::udp::endpoint& from,
     const std::uint8_t* intro_key,
     const boost::asio::ip::udp::endpoint& to) {
-  std::array<std::uint8_t, 80 + 18> buf {};  // 64 Alice's ipv4 and 80 Alice's ipv6
+  std::array<std::uint8_t, 80 + 18> buf {{}};  // 64 Alice's ipv4 and 80 Alice's ipv6
   auto payload = buf.data() + GetType(SSUSize::HeaderMin);
   // Charlie's address always v4
   if (!to.address().is_v4()) {
@@ -796,7 +796,7 @@ void SSUSession::SendRelayIntro(
       << __func__ << ": Alice's IP must be V4";
     return;
   }
-  std::array<std::uint8_t, 48 + 18> buf {};
+  std::array<std::uint8_t, 48 + 18> buf {{}};
   auto payload = buf.data() + GetType(SSUSize::HeaderMin);
   *payload = 4;
   payload++;  // size
@@ -978,7 +978,7 @@ void SSUSession::SendPeerTest(
     const std::uint8_t* intro_key,
     bool to_address,  // is true for Alice<->Charlie communications only
     bool send_address) {  // is false if message comes from Alice
-  std::array<std::uint8_t, 80 + 18> buf {};
+  std::array<std::uint8_t, 80 + 18> buf {{}};
   auto payload = buf.data() + GetType(SSUSize::HeaderMin);
   htobe32buf(payload, nonce);
   payload += 4;  // nonce
@@ -1066,7 +1066,7 @@ void SSUSession::SendPeerTest() {
 
 void SSUSession::SendSesionDestroyed() {
   if (m_IsSessionKey) {
-    std::array<std::uint8_t, 48 + 18> buf {};
+    std::array<std::uint8_t, 48 + 18> buf {{}};
     // encrypt message with session key
     FillHeaderAndEncrypt(
         GetType(SSUPayloadType::SessionDestroyed),
@@ -1086,7 +1086,7 @@ void SSUSession::SendSesionDestroyed() {
 
 void SSUSession::SendKeepAlive() {
   if (m_State == SessionState::Established) {
-    std::array<std::uint8_t, 48 + 18> buf {};  // TODO(unassigned): document values
+    std::array<std::uint8_t, 48 + 18> buf {{}};  // TODO(unassigned): document values
     auto payload = buf.data() + GetType(SSUSize::HeaderMin);
     *payload = 0;  // flags
     payload++;
@@ -1476,7 +1476,7 @@ void SSUSession::Send(
     std::uint8_t type,
     const std::uint8_t* payload,
     std::size_t len) {
-  std::array<std::uint8_t, GetType(SSUSize::MTUv4) + 18> buf {};
+  std::array<std::uint8_t, GetType(SSUSize::MTUv4) + 18> buf {{}};
   auto msg_size = len + GetType(SSUSize::HeaderMin);
   auto padding_size = msg_size & 0x0F;  // %16
   if (padding_size > 0)

--- a/src/core/router/transports/upnp.h
+++ b/src/core/router/transports/upnp.h
@@ -79,8 +79,8 @@ class UPnP {
   std::unique_ptr<std::thread> m_Thread;
 
   // Miniupnpc POD-types
-  struct UPNPUrls m_upnpUrls = {};
-  struct IGDdatas m_upnpData = {};
+  struct UPNPUrls m_upnpUrls {{}};
+  struct IGDdatas m_upnpData {{}};
 
   // For miniupnpc
   const char* m_MulticastIf = 0;

--- a/src/core/router/tunnel/config.cc
+++ b/src/core/router/tunnel/config.cc
@@ -169,7 +169,7 @@ void TunnelHopConfig::CreateBuildRequestRecord(
   LOG(debug) << "TunnelHopConfig: creating build request record";
 
   // Create clear text record
-  std::array<std::uint8_t, BUILD_REQUEST_RECORD_CLEAR_TEXT_SIZE> clear_text{};
+  std::array<std::uint8_t, BUILD_REQUEST_RECORD_CLEAR_TEXT_SIZE> clear_text {{}};
   auto stream = std::make_unique<OutputByteStream>(clear_text.data(), clear_text.size());
 
   // Tunnel ID to receive messages as


### PR DESCRIPTION
gcc 4.9 may not? zero-initialize subaggregates of aggregate with
implicitly-defined (default) ctor when using brace-elision (despite
brace-elision being allowed in c++14 (and subsequent gcc versions)).

For now, adding the extra braces ensures initialization and quiets
-Wmissing-field-initializers.


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

