### PR TITLE
snap: specify git as a source to get submodules

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,7 @@ apps:
 parts:
   kovri:
     source: .
+    source-type: git
     plugin: make
     build-packages:
       - g++


### PR DESCRIPTION
Now that kovri is using submodules, this change is required to get them during the snapcraft pull.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

