### PR TITLE
SSU: fix SessionCreated Alice's IP

### DIFF
--- a/src/core/router/transports/ssu/packet.cc
+++ b/src/core/router/transports/ssu/packet.cc
@@ -217,12 +217,13 @@ std::uint8_t const* SSUSessionCreatedPacket::GetDhY() const {
 void SSUSessionCreatedPacket::SetIPAddress(
     std::uint8_t* address,
     std::size_t size) {
-  m_IPAddress = address;
+  m_IPAddress.reset(new std::uint8_t[size]);
+  std::memcpy(m_IPAddress.get(), address, size);
   m_AddressSize = size;
 }
 
 std::uint8_t const* SSUSessionCreatedPacket::GetIPAddress() const {
-  return m_IPAddress;
+  return m_IPAddress.get();
 }
 
 std::size_t SSUSessionCreatedPacket::GetIPAddressSize() const {

--- a/src/core/router/transports/ssu/packet.h
+++ b/src/core/router/transports/ssu/packet.h
@@ -335,7 +335,8 @@ class SSUSessionCreatedPacket : public SSUPacket {
 
  private:
   std::size_t m_AddressSize, m_SignatureSize;
-  std::uint8_t* m_DhY, *m_IPAddress, *m_Signature;
+  std::uint8_t *m_DhY, *m_Signature;
+  std::unique_ptr<std::uint8_t[]> m_IPAddress;
   std::uint16_t m_Port;
   std::uint32_t m_RelayTag, m_SignedOnTime;
 };


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/anonimal/kovri-docs/blob/master/developer/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

https://github.com/monero-project/kovri/blob/master/src/core/router/transports/ssu/session.cc#L474 overwrites the data being pointed by https://github.com/monero-project/kovri/blob/master/src/core/router/transports/ssu/session.cc#L466, so we were sending Bob's IP instead of Alice's IP
