### PR TITLE
SSU: fix SendSessionCreated endianness

### DIFF
--- a/src/core/router/transports/ssu/session.cc
+++ b/src/core/router/transports/ssu/session.cc
@@ -469,7 +469,7 @@ void SSUSession::SendSessionCreated(
     packet.SetIPAddress(remote_address.to_v6().to_bytes().data(), 16);
     s.Insert(remote_address.to_v6().to_bytes().data(), 16);
   }
-  s.Insert<std::uint16_t>(packet.GetPort());  // remote port
+  s.Insert<std::uint16_t>(htobe16(packet.GetPort()));  // remote port
   if (address->host.is_v4())
     s.Insert(address->host.to_v4().to_bytes().data(), 4);  // our IP V4
   else
@@ -485,8 +485,8 @@ void SSUSession::SendSessionCreated(
   }
   packet.SetRelayTag(relay_tag);
   packet.SetSignedOnTime(kovri::core::GetSecondsSinceEpoch());
-  s.Insert<std::uint32_t>(relay_tag);
-  s.Insert<std::uint32_t>(packet.GetSignedOnTime());
+  s.Insert<std::uint32_t>(htobe32(relay_tag));
+  s.Insert<std::uint32_t>(htobe32(packet.GetSignedOnTime()));
   // store for session confirmation
   m_SessionConfirmData = std::make_unique<SignedData>(s);
 


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/anonimal/kovri-docs/blob/master/developer/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Can't find this precisely in the specs, but [this is how](https://github.com/monero-project/kovri/blob/master/src/core/router/transports/ssu/session.cc#L402) the receiver is processing it (this difference between ProcessSessionCreated and SendSessionCreated is what's causing the error descrived in #661 )

Ref #140 