### PR TITLE
SSU: fix and document raw packet buffer size

### DIFF
--- a/src/core/router/transports/ssu/packet.h
+++ b/src/core/router/transports/ssu/packet.h
@@ -58,7 +58,8 @@ enum struct SSUSize : std::uint16_t {
   MAC = 16,
   IV = 16,
   IntroKey = 32,
-  BufferMargin = 18,
+  BufferMargin = IV + 2,  // IV + 2 bytes size are appended on validation
+  RawPacketBuffer = MTUv4 + BufferMargin,
   KeyingMaterial = 64,
   DHPublic = 256,
   MaxReceivedMessages = 1000,  // TODO(unassigned): research this value

--- a/src/core/router/transports/ssu/server.h
+++ b/src/core/router/transports/ssu/server.h
@@ -49,6 +49,7 @@
 #include "core/router/i2np.h"
 #include "core/router/identity.h"
 #include "core/router/info.h"
+#include "core/router/transports/ssu/packet.h"
 #include "core/router/transports/ssu/session.h"
 
 #include "core/util/i2p_endian.h"
@@ -57,7 +58,7 @@ namespace kovri {
 namespace core {
 
 struct RawSSUPacket {
-  kovri::core::AESAlignedBuffer<1500> buf;
+  kovri::core::AESAlignedBuffer<GetType(SSUSize::RawPacketBuffer)> buf;
   boost::asio::ip::udp::endpoint from;
   std::size_t len;
 };


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/anonimal/kovri-docs/blob/master/developer/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---
Ref #140 

IIUC, it should be 1502  and not 1500 

Jftr, in practice, AESAlignedBuffer has room for alignment (15 bytes) so the overflow should have been extremely rare (a packet with max mtu size + max alignment).
