### PR TITLE
SSU: message validation process

### DIFF
--- a/src/core/router/transports/ssu/session.cc
+++ b/src/core/router/transports/ssu/session.cc
@@ -171,10 +171,16 @@ void SSUSession::ProcessNextMessage(
       return;  // ignore zero-length packets
     if (m_State == SessionState::Established)
       ScheduleTermination();
-    if (m_IsSessionKey) {
-      if (Validate(buf, len, m_MACKey)) {  // try session key first
+    // Try session key first
+    if (m_IsSessionKey)
+      {
+        if (!Validate(buf, len, m_MACKey))
+          {
+            LOG(error) << "SSUSession:" << GetFormattedSessionInfo()
+                       << ": validation failed with stored SessionKey";
+            return;
+          }
         DecryptSessionKey(buf, len);
-      }
     } else {
       // try intro key depending on side
       auto intro_key = GetIntroKey();


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/anonimal/kovri-docs/blob/master/developer/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---
Ref #140 

ProcessDecryptedMessage is processing encrypted data on hmac verif failure, leading most of the time to the error

>  InputByteStream: too many bytes to consume.

