### PR TITLE
SSU: better fix for #658

### DIFF
--- a/src/core/router/transports/ssu/packet.cc
+++ b/src/core/router/transports/ssu/packet.cc
@@ -217,13 +217,12 @@ std::uint8_t const* SSUSessionCreatedPacket::GetDhY() const {
 void SSUSessionCreatedPacket::SetIPAddress(
     std::uint8_t* address,
     std::size_t size) {
-  m_IPAddress.reset(new std::uint8_t[size]);
-  std::memcpy(m_IPAddress.get(), address, size);
+  m_IPAddress = address;
   m_AddressSize = size;
 }
 
 std::uint8_t const* SSUSessionCreatedPacket::GetIPAddress() const {
-  return m_IPAddress.get();
+  return m_IPAddress;
 }
 
 std::size_t SSUSessionCreatedPacket::GetIPAddressSize() const {

--- a/src/core/router/transports/ssu/packet.h
+++ b/src/core/router/transports/ssu/packet.h
@@ -336,8 +336,7 @@ class SSUSessionCreatedPacket : public SSUPacket {
 
  private:
   std::size_t m_AddressSize, m_SignatureSize;
-  std::uint8_t *m_DhY, *m_Signature;
-  std::unique_ptr<std::uint8_t[]> m_IPAddress;
+  std::uint8_t *m_DhY, *m_Signature, *m_IPAddress;
   std::uint16_t m_Port;
   std::uint32_t m_RelayTag, m_SignedOnTime;
 };

--- a/src/core/util/byte_stream.cc
+++ b/src/core/util/byte_stream.cc
@@ -158,5 +158,18 @@ const std::string GetFormattedHex(const std::uint8_t* data, std::size_t size) {
   return hex.str();
 }
 
+std::unique_ptr<std::vector<std::uint8_t>> AddressToByteVector(
+    const boost::asio::ip::address& address)
+{
+  bool is_v4(address.is_v4());
+  auto data = std::make_unique<std::vector<std::uint8_t>>(is_v4 ? 4 : 16);
+  std::memcpy(
+      data->data(),
+      is_v4 ? address.to_v4().to_bytes().data()
+            : address.to_v6().to_bytes().data(),
+      data->size());
+  return data;
+}
+
 } // namespace core
 } // namespace kovri

--- a/src/core/util/byte_stream.h
+++ b/src/core/util/byte_stream.h
@@ -31,10 +31,12 @@
 #ifndef SRC_CORE_UTIL_BYTESTREAM_H_
 #define SRC_CORE_UTIL_BYTESTREAM_H_
 
-#include <cstdint>
+#include <boost/asio.hpp>
 #include <cstddef>
-#include <type_traits>
+#include <cstdint>
 #include <ios>
+#include <memory>
+#include <type_traits>
 
 namespace kovri {
 namespace core {
@@ -172,6 +174,11 @@ class OutputByteStream {
 /// @param data Pointer to data
 /// @param size Total size of data
 const std::string GetFormattedHex(const std::uint8_t* data, std::size_t size);
+
+/// @brief Returns vector of bytes representing address
+/// @param address IP v4 or v6 address
+std::unique_ptr<std::vector<std::uint8_t>> AddressToByteVector(
+    const boost::asio::ip::address& address);
 
 } // namespace core
 } // namespace kovri

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -15,7 +15,8 @@ set(TESTS_CORE
   "core/crypto/util/x509.cc"
   "core/router/identity.cc"
   "core/router/transports/ssu/packet.cc"
-  "core/util/base64.cc")
+  "core/util/base64.cc"
+  "core/util/byte_stream.cc")
 
 set(TESTS_MAIN
   ${TESTS_CLIENT}

--- a/tests/unit_tests/core/util/byte_stream.cc
+++ b/tests/unit_tests/core/util/byte_stream.cc
@@ -1,0 +1,89 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ *                                                                                            //
+ */
+
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include "core/util/byte_stream.h"
+
+namespace core = kovri::core;
+
+struct ByteStreamFixture
+{
+  const std::string m_IPv4String = "10.11.12.13";
+  const std::array<std::uint8_t, 4> m_IPv4Array{{0x0A, 0x0B, 0x0C, 0x0D}};
+
+  const std::string m_IPv6String = "fe80::42:acff:fe11:2";
+  const std::array<std::uint8_t, 16> m_IPv6Array{{
+      0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x42, 0xac, 0xff, 0xfe, 0x11, 0x00, 0x02}};
+};
+
+BOOST_FIXTURE_TEST_SUITE(ByteStreamTests, ByteStreamFixture)
+
+BOOST_AUTO_TEST_CASE(AddressToByteVectorIPv4)
+{
+  boost::asio::ip::address address;
+  BOOST_CHECK_NO_THROW(
+      address = boost::asio::ip::address::from_string(m_IPv4String));
+  auto const ip = core::AddressToByteVector(address);
+  BOOST_CHECK_EQUAL(ip->size(), address.to_v4().to_bytes().size());
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+      ip->data(),
+      ip->data() + ip->size(),
+      m_IPv4Array.data(),
+      m_IPv4Array.data() + m_IPv4Array.size());
+  // Reconstruct a new address and check with original
+  boost::asio::ip::address_v4::bytes_type bytes;
+  std::memcpy(bytes.data(), ip->data(), address.to_v4().to_bytes().size());
+  BOOST_CHECK_EQUAL(boost::asio::ip::address_v4(bytes), address.to_v4());
+}
+
+BOOST_AUTO_TEST_CASE(AddressToByteVectorIPv6)
+{
+  boost::asio::ip::address address;
+  BOOST_CHECK_NO_THROW(
+      address = boost::asio::ip::address::from_string(m_IPv6String));
+  auto const ip = core::AddressToByteVector(address);
+  BOOST_CHECK_EQUAL(ip->size(), address.to_v6().to_bytes().size());
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+      ip->data(),
+      ip->data() + ip->size(),
+      m_IPv6Array.data(),
+      m_IPv6Array.data() + m_IPv6Array.size());
+  // Reconstruct a new address and check with original
+  boost::asio::ip::address_v6::bytes_type bytes;
+  std::memcpy(bytes.data(), ip->data(), address.to_v6().to_bytes().size());
+  BOOST_CHECK_EQUAL(boost::asio::ip::address_v6(bytes), address.to_v6());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/anonimal/kovri-docs/blob/master/developer/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---
IMHO, i think this is a better fix for #658 "design-wise" (with the disclamer that i'm usually not very good at design)

IIUC, the idea behind the builder is that all data are already available and we only need to find pointers to these data. The problem is that the internal data of boost::asio::ip::address is not accessible, only a copy through `to_bytes().data()`. So i think, to be consistent design-wise, it is better to treat "ip" like other elements in the builder and leave the memory allocation outside. Or said otherwise, it was a bug in the usage of the class, not in the class itself ... i think ;) 

Ref #140 