### PR TITLE
Util: ByteStream members init and unit-test

### DIFF
--- a/src/core/util/byte_stream.cc
+++ b/src/core/util/byte_stream.cc
@@ -38,6 +38,7 @@
 #include <iomanip>
 
 #include "core/util/i2p_endian.h"
+#include "core/util/log.h"
 
 namespace kovri {
 namespace core {
@@ -100,6 +101,13 @@ void OutputByteStream::ProduceData(std::size_t amount) {
 }
 
 void OutputByteStream::WriteData(const std::uint8_t* data, std::size_t len) {
+  if (!len)
+    {
+      LOG(debug) << "OutputByteStream: skip empty data";
+      return;
+    }
+  if (!data)
+    throw std::runtime_error("OutputByteStream: null data");
   std::uint8_t* ptr = m_Data; 
   ProduceData(len);
   std::memcpy(ptr, data, len);

--- a/src/core/util/byte_stream.h
+++ b/src/core/util/byte_stream.h
@@ -103,7 +103,7 @@ class InputByteStream {
 
  protected:
   std::uint8_t* m_Data; ///< Pointer to first unparsed byte of the stream
-  std::size_t m_Length; ///< Remaining length of the stream
+  std::size_t m_Length{};  ///< Remaining length of the stream
 };
 
 /// @class OutputByteStream
@@ -165,9 +165,9 @@ class OutputByteStream {
 
  protected:
   std::uint8_t* m_Data; ///< Pointer to the first unwritten byte
-  std::size_t m_Length; ///< Remaining length of the stream
-  std::size_t m_Counter;  ///< Counter for amount of incremented data
-  std::size_t m_Size;  ///< Total size of stream given at initialization
+  std::size_t m_Length{};  ///< Remaining length of the stream
+  std::size_t m_Counter{};  ///< Counter for amount of incremented data
+  std::size_t m_Size{};  ///< Total size of stream given at initialization
 };
 
 /// @brief Returns hex encoding of given data


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/anonimal/kovri-docs/blob/master/developer/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---
For `Util: OutputByteStream add check for empty data` : 

I saw in [std::memcpy spec](http://en.cppreference.com/w/cpp/string/byte/memcpy) : 

    If either dest or src is a null pointer, the behavior is undefined, even if count is zero. 

But I would like to write things like

    packet->SetIPAddress(nullptr, 0)

and avoid to have to do the checks in the caller