### PR TITLE
Build: fix GCC 7 implicit fallthrough warnings

### DIFF
--- a/src/client/api/streaming.cc
+++ b/src/client/api/streaming.cc
@@ -749,7 +749,7 @@ void Stream::HandleResendTimer(
         case 2:
           // drop RTO to initial upon tunnels pair change first time
           m_RTO = INITIAL_RTO;
-          // no break here
+          // fall-through
         case 4:
           UpdateCurrentRemoteLease();  // pick another lease
           LOG(warning)

--- a/src/client/proxy/socks.cc
+++ b/src/client/proxy/socks.cc
@@ -622,6 +622,7 @@ bool SOCKSHandler::HandleData(
           case UDP:
             if (m_SOCKSVersion == SOCKS5)
               break;
+            // fall-through
           default:
             LOG(error)
               << "SOCKSHandler: invalid command: "

--- a/src/core/router/identity.cc
+++ b/src/core/router/identity.cc
@@ -695,6 +695,7 @@ PrivateKeys PrivateKeys::CreateRandomKeys(SigningKeyType type) {
         LOG(warning)
           << "IdentityEx: Signing key type "
           << static_cast<int>(type) << " is not supported, creating DSA-SHA1";
+        // fall-through
       case SIGNING_KEY_TYPE_DSA_SHA1:
         return PrivateKeys(kovri::core::CreateRandomKeys());  // DSA-SHA1
     }

--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -251,6 +251,7 @@ void RouterInfo::ParseRouterInfo(const std::string& router_info)
                             LOG(warning)
                                 << "RouterInfo: unexpected SSU address "
                                 << value;
+                            // fall-through
                           default:
                             is_valid_address = false;
                         }


### PR DESCRIPTION
Note: GCC 7 will also recognize the [[clang::fallthrough]] attribute but
we currently avoid doing this because of the older compilers we use.

From https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html:

>C++17 provides a standard way to suppress the -Wimplicit-fallthrough
warning using [[fallthrough]]; instead of the GNU attribute. In C++11 or
C++14 users can use [[gnu::fallthrough]];, which is a GNU extension.
Instead of these attributes, it is also possible to add a fallthrough
comment to silence the warning. The whole body of the C or C++ style
comment should match the given regular expressions listed below. The
option argument n specifies what kind of comments are accepted:


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/anonimal/kovri-docs/blob/master/developer/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

