### PR TITLE
I2PControl: rewrite/refactor + client api + kovri-util integration + unit-test + fuzz-test

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CLIENT_SRC
   "address_book/impl.cc"
   "address_book/storage.cc"
   "api/datagram.cc"
+  "api/i2p_control/data.cc"
   "api/i2p_control/server.cc"
   "api/i2p_control/session.cc"
   "api/streaming.cc"

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CLIENT_SRC
   "reseed.cc"
   "service.cc"
   "tunnel.cc"
+  "util/json.cc"
   "util/parse.cc"
   "util/http.cc"
   "util/zip.cc")

--- a/src/client/api/i2p_control/data.cc
+++ b/src/client/api/i2p_control/data.cc
@@ -1,0 +1,1099 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ *                                                                                            //
+ */
+
+#include "client/api/i2p_control/data.h"
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+#include <iomanip>
+#include <stdexcept>
+
+namespace kovri
+{
+namespace client
+{
+/**
+ * @class SerializeVisitor
+ * @brief JSON formatted output of a ValueType
+ **/
+struct SerializeVisitor final : public boost::static_visitor<std::string>
+{
+  std::string operator()(bool value) const
+  {
+    return value ? "true" : "false";
+  }
+
+  std::string operator()(const std::size_t& value) const
+  {
+    return std::to_string(value);
+  }
+
+  std::string operator()(const double& value) const
+  {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2) << value;
+    return oss.str();
+  }
+
+  std::string operator()(const std::string& value) const
+  {
+    return (value.empty() ? "null" : "\"" + value + "\"");
+  }
+
+  std::string operator()(const JsonObject& value) const
+  {
+    auto str = value.ToString();
+    if (str.empty())
+      return "null";
+    return str;
+  }
+};
+
+/**
+ * Method
+ **/
+const std::string I2PControlDataTraits::GetTrait(Method method) const
+{
+  switch (method)
+    {
+      case Method::Authenticate:
+        return "Authenticate";
+      case Method::Echo:
+        return "Echo";
+      case Method::GetRate:
+        return "GetRate";
+      case Method::I2PControl:
+        return "I2PControl";
+      case Method::RouterInfo:
+        return "RouterInfo";
+      case Method::RouterManager:
+        return "RouterManager";
+      case Method::NetworkSetting:
+        return "NetworkSetting";
+      case Method::Unknown:
+        return "";
+    }
+  throw std::domain_error(
+      "Invalid method " + std::to_string(core::GetType(method)));
+}
+
+I2PControlDataTraits::Method I2PControlDataTraits::GetMethodFromString(
+    const std::string& value) const noexcept
+{
+  if (value == GetTrait(Method::Authenticate))
+    return Method::Authenticate;
+
+  else if (value == GetTrait(Method::Echo))
+    return Method::Echo;
+
+  else if (value == GetTrait(Method::GetRate))
+    return Method::GetRate;
+
+  else if (value == GetTrait(Method::I2PControl))
+    return Method::I2PControl;
+
+  else if (value == GetTrait(Method::RouterInfo))
+    return Method::RouterInfo;
+
+  else if (value == GetTrait(Method::RouterManager))
+    return Method::RouterManager;
+
+  else if (value == GetTrait(Method::NetworkSetting))
+    return Method::NetworkSetting;
+
+  else
+    return Method::Unknown;
+}
+
+std::string I2PControlDataTraits::AbstractMethod::ToJsonString() const
+{
+  SerializeVisitor visitor;
+  std::ostringstream oss;
+  for (auto it = m_Params.begin(); it != m_Params.end(); ++it)
+    {
+      if (it != m_Params.begin())
+        oss << ',';
+      oss << '"' << GetTrait(it->first)
+          << "\":" << boost::apply_visitor(visitor, it->second);
+    }
+  return oss.str();
+}
+
+/**
+ * Authenticate
+ **/
+const std::string I2PControlDataTraits::MethodAuthenticate::GetTrait(
+    std::uint8_t value) const
+{
+  switch (value)
+    {
+      case API:
+        return "API";
+      case Password:
+        return "Password";
+      case Token:
+        return "Token";
+      default:
+        throw std::domain_error("Invalid key " + std::to_string(value));
+    };
+}
+
+std::uint8_t I2PControlDataTraits::MethodAuthenticate::GetTrait(
+    const std::string& value) const noexcept
+{
+  if (value == GetTrait(API))
+    return API;
+
+  else if (value == GetTrait(Password))
+    return Password;
+
+  else if (value == GetTrait(Token))
+    return Token;
+
+  return Unknown;
+}
+
+void I2PControlDataTraits::MethodAuthenticate::ParseRequest(const ptree& tree)
+{
+  Set(API, tree.get<std::size_t>(GetTrait(API)));
+  Set(Password, tree.get<std::string>(GetTrait(Password)));
+}
+
+void I2PControlDataTraits::MethodAuthenticate::ParseResponse(const ptree& tree)
+{
+  Set(API, tree.get<std::size_t>(GetTrait(API)));
+  Set(Token, tree.get<std::string>(GetTrait(Token)));
+}
+
+/**
+ * Echo
+ **/
+const std::string I2PControlDataTraits::MethodEcho::GetTrait(
+    std::uint8_t value) const
+{
+  switch (value)
+    {
+      case Echo:
+        return "Echo";
+      case Result:
+        return "Result";
+      default:
+        throw std::domain_error("Invalid key " + std::to_string(value));
+    };
+}
+
+std::uint8_t I2PControlDataTraits::MethodEcho::GetTrait(
+    const std::string& value) const noexcept
+{
+  if (value == GetTrait(Echo))
+    return Echo;
+
+  else if (value == GetTrait(Result))
+    return Result;
+
+  return Unknown;
+}
+
+void I2PControlDataTraits::MethodEcho::ParseRequest(const ptree& tree)
+{
+  Set(Echo, tree.get<std::string>(GetTrait(Echo)));
+}
+
+void I2PControlDataTraits::MethodEcho::ParseResponse(const ptree& tree)
+{
+  Set(Result, tree.get<std::string>(GetTrait(Result)));
+}
+
+/**
+ * GetRate
+ **/
+const std::string I2PControlDataTraits::MethodGetRate::GetTrait(
+    std::uint8_t value) const
+{
+  switch (value)
+    {
+      case Stat:
+        return "Stat";
+      case Period:
+        return "Period";
+      case Result:
+        return "Result";
+      case Unknown:
+        return "";
+    }
+  throw std::domain_error("Invalid GetRate key " + std::to_string(value));
+}
+
+std::uint8_t I2PControlDataTraits::MethodGetRate::GetTrait(
+    const std::string& value) const noexcept
+{
+  if (value == GetTrait(Stat))
+    return Stat;
+
+  else if (value == GetTrait(Period))
+    return Period;
+
+  else if (value == GetTrait(Result))
+    return Result;
+
+  return Unknown;
+}
+
+void I2PControlDataTraits::MethodGetRate::ParseRequest(const ptree& tree)
+{
+  Set(Stat, tree.get<std::string>(GetTrait(Stat)));
+  Set(Period, tree.get<std::size_t>(GetTrait(Period)));
+}
+
+void I2PControlDataTraits::MethodGetRate::ParseResponse(const ptree& tree)
+{
+  Set(Result, tree.get<double>(GetTrait(Result)));
+}
+
+/**
+ * I2PControl
+ **/
+const std::string I2PControlDataTraits::MethodI2PControl::GetTrait(
+    std::uint8_t value) const
+{
+  switch (value)
+    {
+      case Address:
+        return "i2pcontrol.address";
+      case Password:
+        return "i2pcontrol.password";
+      case Port:
+        return "i2pcontrol.port";
+      case SettingsSaved:
+        return "SettingsSaved";
+      case RestartNeeded:
+        return "RestartNeeded";
+      case Unknown:
+        return "";
+    }
+  throw std::domain_error("Invalid control value " + std::to_string(value));
+}
+
+std::uint8_t I2PControlDataTraits::MethodI2PControl::GetTrait(
+    const std::string& value) const noexcept
+{
+  if (value == GetTrait(Address))
+    return Address;
+
+  else if (value == GetTrait(Password))
+    return Password;
+
+  else if (value == GetTrait(Port))
+    return Port;
+
+  else if (value == GetTrait(SettingsSaved))
+    return SettingsSaved;
+
+  else if (value == GetTrait(RestartNeeded))
+    return RestartNeeded;
+
+  return Unknown;
+}
+
+void I2PControlDataTraits::MethodI2PControl::ParseRequest(const ptree& tree)
+{
+  for (const auto& pair : tree)
+    {
+      if (pair.first == "Token")
+        continue;
+      auto option = GetTrait(pair.first);
+      switch (option)
+        {
+          case Address:
+          case Password:
+          case Port:
+            Set(option, pair.second.get_value<std::string>());
+            break;
+          default:
+            throw std::domain_error("Invalid key " + pair.first);
+        }
+    }
+}
+
+void I2PControlDataTraits::MethodI2PControl::ParseResponse(const ptree& tree)
+{
+  for (const auto& pair : tree)
+    {
+      auto option = GetTrait(pair.first);
+      switch (option)
+        {
+          case Address:
+          case Password:
+          case Port:
+            Set(option, std::string());
+            break;
+          case SettingsSaved:
+          case RestartNeeded:
+            Set(option, pair.second.get_value<bool>());
+            break;
+          default:
+            throw std::domain_error("Invalid key " + pair.first);
+        }
+    }
+}
+
+/**
+ * RouterInfo
+ **/
+const std::string I2PControlDataTraits::MethodRouterInfo::GetTrait(
+    std::uint8_t info) const
+{
+  switch (info)
+    {
+      case Status:
+        return "i2p.router.status";
+      case Uptime:
+        return "i2p.router.uptime";
+      case Version:
+        return "i2p.router.version";
+      case BWIn1S:
+        return "i2p.router.net.bw.inbound.1s";
+      case BWIn15S:
+        return "i2p.router.net.bw.inbound.15s";
+      case BWOut1S:
+        return "i2p.router.net.bw.outbound.1s";
+      case BWOut15S:
+        return "i2p.router.net.bw.outbound.15s";
+      case NetStatus:
+        return "i2p.router.net.status";
+      case TunnelsParticipating:
+        return "i2p.router.net.tunnels.participating";
+      case ActivePeers:
+        return "i2p.router.netdb.activepeers";
+      case FastPeers:
+        return "i2p.router.netdb.fastpeers";
+      case HighCapacityPeers:
+        return "i2p.router.netdb.highcapacitypeers";
+      case IsReseeding:
+        return "i2p.router.netdb.isreseeding";
+      case KnownPeers:
+        return "i2p.router.netdb.knownpeers";
+      // Extra options
+      case DataPath:
+        return "i2p.router.datapath";
+      case Floodfills:
+        return "i2p.router.netdb.floodfills";
+      case LeaseSets:
+        return "i2p.router.netdb.leasesets";
+      // TODO(unassigned): Probably better to use the standard GetRate instead
+      case TunnelsCreationSuccessRate:
+        return "i2p.router.net.tunnels.creationsuccessrate";
+      case TunnelsInList:
+        return "i2p.router.net.tunnels.inbound.list";
+      case TunnelsOutList:
+        return "i2p.router.net.tunnels.outbound.list";
+      case Unknown:
+        return "";
+    }
+  throw std::domain_error("Invalid router info " + std::to_string(info));
+}
+
+std::uint8_t I2PControlDataTraits::MethodRouterInfo::GetTrait(
+    const std::string& value) const noexcept
+{
+  if (value == GetTrait(Status))
+    return Status;
+
+  else if (value == GetTrait(Uptime))
+    return Uptime;
+
+  else if (value == GetTrait(Version))
+    return Version;
+
+  else if (value == GetTrait(BWIn1S))
+    return BWIn1S;
+
+  else if (value == GetTrait(BWIn15S))
+    return BWIn15S;
+
+  else if (value == GetTrait(BWOut1S))
+    return BWOut1S;
+
+  else if (value == GetTrait(BWOut15S))
+    return BWOut15S;
+
+  else if (value == GetTrait(NetStatus))
+    return NetStatus;
+
+  else if (value == GetTrait(TunnelsParticipating))
+    return TunnelsParticipating;
+
+  else if (value == GetTrait(ActivePeers))
+    return ActivePeers;
+
+  else if (value == GetTrait(FastPeers))
+    return FastPeers;
+
+  else if (value == GetTrait(HighCapacityPeers))
+    return HighCapacityPeers;
+
+  else if (value == GetTrait(IsReseeding))
+    return IsReseeding;
+
+  else if (value == GetTrait(KnownPeers))
+    return KnownPeers;
+
+  else if (value == GetTrait(DataPath))
+    return DataPath;
+
+  else if (value == GetTrait(Floodfills))
+    return Floodfills;
+
+  else if (value == GetTrait(LeaseSets))
+    return LeaseSets;
+
+  else if (value == GetTrait(TunnelsCreationSuccessRate))
+    return TunnelsCreationSuccessRate;
+
+  else if (value == GetTrait(TunnelsInList))
+    return TunnelsInList;
+
+  else if (value == GetTrait(TunnelsOutList))
+    return TunnelsOutList;
+
+  return Unknown;
+}
+
+void I2PControlDataTraits::MethodRouterInfo::ParseRequest(const ptree& tree)
+{
+  for (const auto& pair : tree)
+    {
+      if (pair.first == "Token")
+        continue;
+
+      auto info = GetTrait(pair.first);
+      if (info == Unknown)
+        throw std::domain_error("Invalid key " + pair.first);
+
+      Set(info, std::string());
+    }
+}
+
+void I2PControlDataTraits::MethodRouterInfo::ParseResponse(const ptree& tree)
+{
+  for (const auto& pair : tree)
+    {
+      auto option(GetTrait(pair.first));
+      switch (option)
+        {
+          // String values
+          case Status:
+          case Version:
+          case DataPath:
+            Set(option, pair.second.get_value<std::string>());
+            break;
+
+          // Long values
+          case Uptime:
+          case NetStatus:
+          case TunnelsParticipating:
+          case ActivePeers:
+          case FastPeers:
+          case HighCapacityPeers:
+          case KnownPeers:
+          case Floodfills:
+          case LeaseSets:
+            Set(option, pair.second.get_value<std::size_t>());
+            break;
+
+          // float values
+          case BWIn1S:
+          case BWIn15S:
+          case BWOut1S:
+          case BWOut15S:
+          case TunnelsCreationSuccessRate:
+            Set(option, pair.second.get_value<double>());
+            break;
+
+          // boolean
+          case IsReseeding:
+            Set(option, pair.second.get_value<bool>());
+            break;
+
+          // JsonObject
+          case TunnelsInList:
+          case TunnelsOutList:
+            Set(option, JsonObject(pair.second));
+            break;
+
+          // Other
+          case Unknown:
+            throw std::domain_error("Invalid key " + pair.first);
+        }
+    }
+}
+
+/**
+ * RouterManager
+ **/
+const std::string I2PControlDataTraits::MethodRouterManager::GetTrait(
+    std::uint8_t command) const
+{
+  switch (command)
+    {
+      case FindUpdates:
+        return "FindUpdates";
+      case Reseed:
+        return "Reseed";
+      case Restart:
+        return "Restart";
+      case RestartGraceful:
+        return "RestartGraceful";
+      case Shutdown:
+        return "Shutdown";
+      case ShutdownGraceful:
+        return "ShutdownGraceful";
+      case Update:
+        return "Update";
+      case Unknown:
+        return "";
+    }
+  throw std::domain_error(
+      "Invalid router manager command " + std::to_string(command));
+}
+std::uint8_t I2PControlDataTraits::MethodRouterManager::GetTrait(
+    const std::string& value) const noexcept
+{
+  if (value == GetTrait(FindUpdates))
+    return FindUpdates;
+
+  else if (value == GetTrait(Reseed))
+    return Reseed;
+
+  else if (value == GetTrait(Restart))
+    return Restart;
+
+  else if (value == GetTrait(RestartGraceful))
+    return RestartGraceful;
+
+  else if (value == GetTrait(Shutdown))
+    return Shutdown;
+
+  else if (value == GetTrait(ShutdownGraceful))
+    return ShutdownGraceful;
+
+  else if (value == GetTrait(Update))
+    return Update;
+
+  return Unknown;
+}
+
+void I2PControlDataTraits::MethodRouterManager::ParseRequest(const ptree& tree)
+{
+  for (const auto& pair : tree)
+    {
+      if (pair.first == "Token")
+        continue;
+
+      auto info = GetTrait(pair.first);
+      if (info == Unknown)
+        throw std::domain_error("Invalid key " + pair.first);
+
+      Set(info, std::string());
+    }
+}
+
+void I2PControlDataTraits::MethodRouterManager::ParseResponse(const ptree& tree)
+{
+  for (const auto& pair : tree)
+    {
+      auto option(GetTrait(pair.first));
+      switch (option)
+        {
+          case FindUpdates:
+            Set(option, pair.second.get_value<bool>());
+            break;
+
+          case Reseed:
+          case Restart:
+          case RestartGraceful:
+          case Shutdown:
+          case ShutdownGraceful:
+            Set(option, std::string());
+            break;
+
+          case Update:
+            Set(option, pair.second.get_value<std::string>());
+            break;
+
+          case Unknown:
+            throw std::domain_error("Invalid key " + pair.first);
+        }
+    }
+}
+
+/**
+ * NetworkSetting
+ **/
+const std::string I2PControlDataTraits::MethodNetworkSetting::GetTrait(
+    std::uint8_t setting) const
+{
+  switch (setting)
+    {
+      case NTCPPort:
+        return "i2p.router.net.ntcp.port";
+      case NTCPHostName:
+        return "i2p.router.net.ntcp.hostname";
+      case NTCPAutoIP:
+        return "i2p.router.net.ntcp.autoip";
+      case SSUPort:
+        return "i2p.router.net.ssu.port";
+      case SSUHostName:
+        return "i2p.router.net.ssu.hostname";
+      case SSUAutoIP:
+        return "i2p.router.net.ssu.autoip";
+      case SSUDetectedIP:
+        return "i2p.router.net.ssu.detectedip";
+      case UPnP:
+        return "i2p.router.net.upnp";
+      case BWShare:
+        return "i2p.router.net.bw.share";
+      case BWIn:
+        return "i2p.router.net.bw.in";
+      case BWOut:
+        return "i2p.router.net.bw.out";
+      case LaptopMode:
+        return "i2p.router.net.laptopmode";
+      case SettingsSaved:
+        return "SettingsSaved";
+      case RestartNeeded:
+        return "RestartNeeded";
+      case Unknown:
+        return "";
+    }
+  throw std::domain_error("Invalid network setting " + std::to_string(setting));
+}
+
+std::uint8_t I2PControlDataTraits::MethodNetworkSetting::GetTrait(
+    const std::string& value) const noexcept
+{
+  if (value == GetTrait(NTCPPort))
+    return NTCPPort;
+
+  else if (value == GetTrait(NTCPHostName))
+    return NTCPHostName;
+
+  else if (value == GetTrait(NTCPAutoIP))
+    return NTCPAutoIP;
+
+  else if (value == GetTrait(SSUPort))
+    return SSUPort;
+
+  else if (value == GetTrait(SSUHostName))
+    return SSUHostName;
+
+  else if (value == GetTrait(SSUAutoIP))
+    return SSUAutoIP;
+
+  else if (value == GetTrait(SSUDetectedIP))
+    return SSUDetectedIP;
+
+  else if (value == GetTrait(UPnP))
+    return UPnP;
+
+  else if (value == GetTrait(BWShare))
+    return BWShare;
+
+  else if (value == GetTrait(BWIn))
+    return BWIn;
+
+  else if (value == GetTrait(BWOut))
+    return BWOut;
+
+  else if (value == GetTrait(LaptopMode))
+    return LaptopMode;
+
+  else if (value == GetTrait(SettingsSaved))
+    return SettingsSaved;
+
+  else if (value == GetTrait(RestartNeeded))
+    return RestartNeeded;
+
+  return Unknown;
+}
+
+void I2PControlDataTraits::MethodNetworkSetting::ParseRequest(const ptree& tree)
+{
+  for (const auto& pair : tree)
+    {
+      if (pair.first == "Token")
+        continue;
+
+      auto setting = GetTrait(pair.first);
+      if (setting == Unknown)
+        throw std::domain_error("Invalid key " + pair.first);
+
+      const std::string value = pair.second.get_value<std::string>();
+      Set(setting, value == "null" ? std::string() : value);
+    }
+}
+
+void I2PControlDataTraits::MethodNetworkSetting::ParseResponse(
+    const ptree& tree)
+{
+  for (const auto& pair : tree)
+    {
+      auto setting(GetTrait(pair.first));
+      if (setting == Unknown)
+        throw std::domain_error("Invalid key " + pair.first);
+
+      if ((setting == SettingsSaved) || (setting == RestartNeeded))
+        Set(setting, pair.second.get_value<bool>());
+      else
+        Set(setting, pair.second.get_value<std::string>());
+    }
+}
+
+/**
+ * ErrorCode
+ **/
+const std::string I2PControlDataTraits::GetTrait(ErrorCode error) const
+{
+  switch (error)
+    {
+      case ErrorCode::None:
+        return "";
+      case ErrorCode::InvalidRequest:
+        return "Invalid request.";
+      case ErrorCode::MethodNotFound:
+        return "Method not found.";
+      case ErrorCode::InvalidParameters:
+        return "Invalid parameters.";
+      case ErrorCode::InternalError:
+        return "Internal error.";
+      case ErrorCode::ParseError:
+        return "Json parse error.";
+      case ErrorCode::InvalidPassword:
+        return "Invalid password.";
+      case ErrorCode::NoToken:
+        return "No authentication token given.";
+      case ErrorCode::NonexistentToken:
+        return "Nonexistent authentication token given.";
+      case ErrorCode::ExpiredToken:
+        return "Expired authentication token given.";
+      case ErrorCode::UnspecifiedVersion:
+        return "Version not specified.";
+      case ErrorCode::UnsupportedVersion:
+        return "Version not supported.";
+    }
+  throw std::domain_error(
+      "Invalid error " + std::to_string(core::GetType(error)));
+}
+
+I2PControlDataTraits::ErrorCode I2PControlDataTraits::ErrorFromInt(
+    int error) const
+{
+  switch ((ErrorCode)error)
+    {
+      case ErrorCode::None:
+      case ErrorCode::InvalidRequest:
+      case ErrorCode::MethodNotFound:
+      case ErrorCode::InvalidParameters:
+      case ErrorCode::InternalError:
+      case ErrorCode::ParseError:
+      case ErrorCode::InvalidPassword:
+      case ErrorCode::NoToken:
+      case ErrorCode::NonexistentToken:
+      case ErrorCode::ExpiredToken:
+      case ErrorCode::UnspecifiedVersion:
+      case ErrorCode::UnsupportedVersion:
+        return static_cast<ErrorCode>(error);
+
+      default:
+        throw std::domain_error("Invalid error " + std::to_string(error));
+    }
+}
+
+/**
+ * NetStatus
+ **/
+const std::string I2PControlDataTraits::GetTrait(NetStatus status) const
+{
+  switch (status)
+    {
+      case NetStatus::Ok:
+        return "OK";
+      case NetStatus::Testing:
+        return "TESTING";
+      case NetStatus::Firewalled:
+        return "FIREWALLED";
+      case NetStatus::Hidden:
+        return "HIDDEN";
+      case NetStatus::WarnFirewalledAndFast:
+        return "WARN_FIREWALLED_AND_FAST";
+      case NetStatus::WarnFirewalledAndFloodfill:
+        return "WARN_FIREWALLED_AND_FLOODFILL";
+      case NetStatus::WarnFirewalledAndInboundTcp:
+        return "WARN_FIREWALLED_WITH_INBOUND_TCP";
+      case NetStatus::WarnFirewalledWithUDPDisabled:
+        return "WARN_FIREWALLED_WITH_UDP_DISABLED";
+      case NetStatus::ErrorI2CP:
+        return "ERROR_I2CP";
+      case NetStatus::ErrorClockSkew:
+        return "ERROR_CLOCK_SKEW";
+      case NetStatus::ErrorPrivateTcpAddress:
+        return "ERROR_PRIVATE_TCP_ADDRESS";
+      case NetStatus::ErrorSymmetricNat:
+        return "ERROR_SYMMETRIC_NAT";
+      case NetStatus::ErrorUDPPortInUse:
+        return "ERROR_UDP_PORT_IN_USE";
+      case NetStatus::ErrorNoActivePeers:
+        return "ERROR_NO_ACTIVE_PEERS_CHECK_CONNECTION_AND_FIREWALL";
+      case NetStatus::ErrorUDPDisabledAndTcpUnset:
+        return "ERROR_UDP_DISABLED_AND_TCP_UNSET";
+    }
+  throw std::domain_error(
+      "Invalid net status " + std::to_string(core::GetType(status)));
+}
+
+I2PControlDataTraits::NetStatus I2PControlDataTraits::NetStatusFromLong(
+    std::size_t status) const
+{
+  switch ((NetStatus)status)
+    {
+      case NetStatus::Ok:
+      case NetStatus::Testing:
+      case NetStatus::Firewalled:
+      case NetStatus::Hidden:
+      case NetStatus::WarnFirewalledAndFast:
+      case NetStatus::WarnFirewalledAndFloodfill:
+      case NetStatus::WarnFirewalledAndInboundTcp:
+      case NetStatus::WarnFirewalledWithUDPDisabled:
+      case NetStatus::ErrorI2CP:
+      case NetStatus::ErrorClockSkew:
+      case NetStatus::ErrorPrivateTcpAddress:
+      case NetStatus::ErrorSymmetricNat:
+      case NetStatus::ErrorUDPPortInUse:
+      case NetStatus::ErrorNoActivePeers:
+      case NetStatus::ErrorUDPDisabledAndTcpUnset:
+        return static_cast<NetStatus>(status);
+
+      default:
+        throw std::domain_error("Invalid net status " + std::to_string(status));
+    }
+}
+
+/**
+ * I2PControlData
+ **/
+void I2PControlData::SetID(const ValueType& id)
+{
+  m_ID = id;
+}
+
+const I2PControlData::ValueType& I2PControlData::GetID() const
+{
+  return m_ID;
+}
+
+void I2PControlData::SetVersion(const std::string& version)
+{
+  m_Version = version;
+}
+
+const std::string& I2PControlData::GetVersion() const
+{
+  return m_Version;
+}
+
+void I2PControlData::SetMethod(Method method)
+{
+  switch (method)
+    {
+      case Method::Authenticate:
+        m_Method.reset(new MethodAuthenticate());
+        break;
+      case Method::Echo:
+        m_Method.reset(new MethodEcho());
+        break;
+      case Method::GetRate:
+        m_Method.reset(new MethodGetRate());
+        break;
+      case Method::I2PControl:
+        m_Method.reset(new MethodI2PControl());
+        break;
+      case Method::RouterInfo:
+        m_Method.reset(new MethodRouterInfo());
+        break;
+      case Method::RouterManager:
+        m_Method.reset(new MethodRouterManager());
+        break;
+      case Method::NetworkSetting:
+        m_Method.reset(new MethodNetworkSetting());
+        break;
+      default:
+        throw std::runtime_error("Invalid method");
+    }
+}
+
+void I2PControlData::SetParam(std::uint8_t key, const ValueType& value)
+{
+  CheckInitialized();
+  m_Method->Set(key, value);
+}
+
+void I2PControlData::SetParam(std::string key, const ValueType& value)
+{
+  CheckInitialized();
+  m_Method->Set(m_Method->GetTrait(key), value);
+}
+
+const std::string I2PControlData::KeyToString(std::uint8_t key)
+{
+  CheckInitialized();
+  return m_Method->GetTrait(key);
+}
+
+void I2PControlData::Parse(const ptree& tree)
+{
+  auto id = tree.get<std::string>("id");
+  if (boost::starts_with(id, "\""))
+    SetID(id);
+  else
+    SetID(tree.get<std::size_t>("id"));
+  // Parse common parameter jsonrpc
+  SetVersion(tree.get<std::string>("jsonrpc"));
+}
+
+/**
+ * I2PControlRequest
+ **/
+void I2PControlRequest::SetToken(const std::string& token)
+{
+  m_Token = token;
+}
+
+std::string I2PControlRequest::GetToken() const
+{
+  return m_Token;
+}
+
+std::string I2PControlRequest::ToJsonString() const
+{
+  std::ostringstream oss;
+  SerializeVisitor visitor;
+
+  oss << "{\"id\":" << boost::apply_visitor(visitor, m_ID) << ",\"method\":\""
+      << GetTrait(m_Method->Which()) << "\",\"params\":{";
+
+  if (!m_Token.empty())
+    oss << "\"Token\":\"" << m_Token << "\",";
+
+  if (m_Method)
+    oss << m_Method->ToJsonString();
+
+  oss << "},\"jsonrpc\":\"" << m_Version << "\"}";
+  return oss.str();
+}
+
+void I2PControlRequest::Parse(std::stringstream& stream)
+{
+  boost::property_tree::ptree tree;
+  boost::property_tree::read_json(stream, tree);
+  I2PControlData::Parse(tree);
+  // Check for error
+  auto method(GetMethodFromString(tree.get<std::string>("method")));
+  if (method == Method::Unknown)
+    throw std::logic_error("Invalid method");
+  SetMethod(method);
+
+  auto params = tree.get_child("params");
+  auto token = params.get_child_optional("Token");
+  if (token)
+    SetToken(token->get_value<std::string>());
+  m_Method->ParseRequest(params);
+}
+
+/**
+ * I2PControlResponse
+ **/
+I2PControlResponse::ErrorCode I2PControlResponse::GetError() const
+{
+  return m_Error;
+}
+
+std::string I2PControlResponse::GetErrorMsg() const
+{
+  return GetTrait(m_Error);
+}
+
+void I2PControlResponse::SetError(ErrorCode code)
+{
+  m_Error = code;
+}
+
+std::string I2PControlResponse::ToJsonString() const
+{
+  std::ostringstream oss;
+  SerializeVisitor visitor;
+
+  oss << "{\"id\":" << boost::apply_visitor(visitor, m_ID);
+
+  if (m_Method)
+    oss << ",\"result\":{" << m_Method->ToJsonString() << "}";
+
+  oss << ",\"jsonrpc\":\"" << m_Version << "\"";
+
+  if (m_Error != ErrorCode::None)
+    oss << ",\"error\":{\"code\":" << static_cast<int>(m_Error)
+        << ",\"message\":\"" << GetTrait(m_Error) << "\""
+        << "}";
+
+  oss << "}";
+  return oss.str();
+}
+
+void I2PControlResponse::Parse(Method method, std::stringstream& stream)
+{
+  boost::property_tree::ptree tree;
+  boost::property_tree::read_json(stream, tree);
+  I2PControlData::Parse(tree);
+  SetMethod(method);
+  // Check for error
+  auto error = tree.get_child_optional("error");
+  if (error)
+    {
+      LOG(debug)
+          << "I2PControlResponseParser: server responded with explicit error";
+      SetError(ErrorFromInt(error->get<int>("code")));
+      return;
+    }
+  m_Method->ParseResponse(tree.get_child("result"));
+}
+
+}  // namespace client
+}  // namespace kovri

--- a/src/client/api/i2p_control/data.h
+++ b/src/client/api/i2p_control/data.h
@@ -1,0 +1,490 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ *                                                                                            //
+ */
+
+#ifndef SRC_CLIENT_API_I2P_CONTROL_DATA_H_
+#define SRC_CLIENT_API_I2P_CONTROL_DATA_H_
+
+#include <boost/asio.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/variant.hpp>
+
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "client/util/json.h"
+#include "core/util/byte_stream.h"
+#include "core/util/log.h"
+
+// Note: Spec at https://geti2p.net/en/docs/api/i2pcontrol
+
+namespace kovri
+{
+namespace client
+{
+struct I2PControlDataTraits
+{
+  // For convenience
+  typedef boost::variant<bool, std::size_t, double, std::string, JsonObject>
+      ValueType;
+  typedef boost::property_tree::ptree ptree;
+
+  /// @enum Method
+  /// @brief I2PControl supported methods
+  enum struct Method : std::uint8_t
+  {
+    Authenticate,
+    Echo,
+    GetRate,
+    I2PControl,
+    RouterInfo,
+    RouterManager,
+    NetworkSetting,
+    Unknown
+  };
+
+  /// @return String value of given enumerated method
+  /// @param trait key used for trait string value
+  /// @throw std::domain_error on invalid value
+  const std::string GetTrait(Method method) const;
+
+  /// @return Enumerated method trait
+  /// @param value String value of potential trait given
+  Method GetMethodFromString(const std::string& value) const noexcept;
+
+  /// @class AbstractMethod
+  /// @brief Base class for specific methods
+  class AbstractMethod
+  {
+   public:
+    /// @return String value of given enumerated method
+    /// @param trait key used for trait string value
+    /// @throw std::domain_error if invalid key
+    virtual const std::string GetTrait(std::uint8_t trait) const = 0;
+
+    /// @return Enumerated key trait
+    /// @param value String value of potential trait given
+    virtual std::uint8_t GetTrait(const std::string& value) const noexcept = 0;
+
+    /// @return Enumerated Method implemented
+    virtual Method Which(void) const = 0;
+
+    /// @brief Parse an I2P Control request
+    virtual void ParseRequest(const ptree&) = 0;
+
+    /// @brief Parse an I2P Control response
+    virtual void ParseResponse(const ptree&) = 0;
+
+    /// @return param with specific type
+    /// @param key container's key
+    /// @throw std::domain_error if invalid key
+    /// @throw std::out_of_range if value not present
+    /// @throw boost::bad_get if type mismatch
+    template <typename Type>
+    Type Get(std::uint8_t key) const
+    {
+      return boost::get<Type>(m_Params.at(key));
+    }
+
+    /// @brief Insert value with associated key
+    void Set(std::uint8_t key, const ValueType& value)
+    {
+      m_Params[key] = value;
+    }
+
+    /// @return Json serialization of m_Params
+    std::string ToJsonString() const;
+
+   private:
+    std::map<std::uint8_t, ValueType> m_Params{};
+
+   public:
+    /// @return all stored params
+    const decltype(m_Params)& Get() const
+    {
+      return m_Params;
+    }
+  };
+
+  struct MethodAuthenticate final : public AbstractMethod
+  {
+    enum Trait : std::uint8_t
+    {
+      API,
+      Password,
+      Token,
+      Unknown
+    };
+    Method Which() const
+    {
+      return Method::Authenticate;
+    }
+    const std::string GetTrait(std::uint8_t value) const;
+    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    void ParseRequest(const ptree& tree);
+    void ParseResponse(const ptree& tree);
+  };
+
+  struct MethodEcho final : public AbstractMethod
+  {
+    enum Trait : std::uint8_t
+    {
+      Echo,
+      Result,
+      Unknown
+    };
+    Method Which() const
+    {
+      return Method::Echo;
+    }
+    const std::string GetTrait(std::uint8_t value) const;
+    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    void ParseRequest(const ptree& tree);
+    void ParseResponse(const ptree& tree);
+  };
+
+  struct MethodGetRate final : public AbstractMethod
+  {
+    enum Trait : std::uint8_t
+    {
+      Stat,
+      Period,
+      Result,
+      Unknown
+    };
+    Method Which() const
+    {
+      return Method::GetRate;
+    }
+    const std::string GetTrait(std::uint8_t value) const;
+    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    void ParseRequest(const ptree& tree);
+    void ParseResponse(const ptree& tree);
+  };
+
+  struct MethodI2PControl final : public AbstractMethod
+  {
+    enum Trait : std::uint8_t
+    {
+      Address,
+      Password,
+      Port,
+      SettingsSaved,
+      RestartNeeded,
+      Unknown
+    };
+    Method Which() const
+    {
+      return Method::I2PControl;
+    }
+    const std::string GetTrait(std::uint8_t value) const;
+    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    void ParseRequest(const ptree& tree);
+    void ParseResponse(const ptree& tree);
+  };
+
+  struct MethodRouterInfo final : public AbstractMethod
+  {
+    enum Trait : std::uint8_t
+    {
+      // Options in spec
+      Status,
+      Uptime,
+      Version,
+      BWIn1S,
+      BWIn15S,
+      BWOut1S,
+      BWOut15S,
+      NetStatus,
+      TunnelsParticipating,
+      ActivePeers,
+      FastPeers,
+      HighCapacityPeers,
+      IsReseeding,
+      KnownPeers,
+      // Extra options
+      DataPath,
+      Floodfills,
+      LeaseSets,
+      TunnelsCreationSuccessRate,
+      TunnelsInList,
+      TunnelsOutList,
+      Unknown,
+    };
+    Method Which() const
+    {
+      return Method::RouterInfo;
+    }
+    const std::string GetTrait(std::uint8_t value) const;
+    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    void ParseRequest(const ptree& tree);
+    void ParseResponse(const ptree& tree);
+  };
+
+  struct MethodRouterManager final : public AbstractMethod
+  {
+    enum Trait : std::uint8_t
+    {
+      FindUpdates,
+      Reseed,
+      Restart,
+      RestartGraceful,
+      Shutdown,
+      ShutdownGraceful,
+      Update,
+      Unknown
+    };
+    Method Which() const
+    {
+      return Method::RouterManager;
+    }
+    const std::string GetTrait(std::uint8_t value) const;
+    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    void ParseRequest(const ptree& tree);
+    void ParseResponse(const ptree& tree);
+  };
+
+  struct MethodNetworkSetting final : public AbstractMethod
+  {
+    enum Trait : std::uint8_t
+    {
+      NTCPPort,
+      NTCPHostName,
+      NTCPAutoIP,
+      SSUPort,
+      SSUHostName,
+      SSUAutoIP,
+      SSUDetectedIP,
+      UPnP,
+      BWShare,
+      BWIn,
+      BWOut,
+      LaptopMode,
+      SettingsSaved,
+      RestartNeeded,
+      Unknown
+    };
+    Method Which() const
+    {
+      return Method::NetworkSetting;
+    }
+    const std::string GetTrait(std::uint8_t value) const;
+    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    void ParseRequest(const ptree& tree);
+    void ParseResponse(const ptree& tree);
+  };
+
+  /// @enum ErrorCode
+  /// @brief Error codes
+  enum struct ErrorCode : std::int16_t
+  {
+    None = 0,
+    // JSON-RPC2
+    InvalidRequest = -32600,
+    MethodNotFound = -32601,
+    InvalidParameters = -32602,
+    InternalError = -32603,
+    ParseError = -32700,
+    // I2PControl specific
+    InvalidPassword = -32001,
+    NoToken = -32002,
+    NonexistentToken = -32003,
+    ExpiredToken = -32004,
+    UnspecifiedVersion = -32005,
+    UnsupportedVersion = -32006
+  };
+
+  /// @return String value of given router manager trait
+  /// @param trait key used for trait string value
+  /// @throw std::domain_error on invalid value
+  const std::string GetTrait(ErrorCode error) const;
+
+  /// @return ErrorCode from integer as specified in protocol
+  /// @throw std::domain_error on invalid value
+  ErrorCode ErrorFromInt(int error) const;
+
+  /// @enum NetStatus
+  /// @brief Network status
+  enum struct NetStatus : std::uint8_t
+  {
+    Ok = 0,
+    Testing = 1,
+    Firewalled = 2,
+    Hidden = 3,
+    WarnFirewalledAndFast = 4,
+    WarnFirewalledAndFloodfill = 5,
+    WarnFirewalledAndInboundTcp = 6,
+    WarnFirewalledWithUDPDisabled = 7,
+    ErrorI2CP = 8,
+    ErrorClockSkew = 9,
+    ErrorPrivateTcpAddress = 10,
+    ErrorSymmetricNat = 11,
+    ErrorUDPPortInUse = 12,
+    ErrorNoActivePeers = 13,
+    ErrorUDPDisabledAndTcpUnset = 14,
+  };
+
+  /// @return String value of given NetStatus
+  /// @param trait key used for trait string value
+  /// @throw std::domain_error on invalid value
+  const std::string GetTrait(NetStatus status) const;
+
+  /// @return NetStatus from integer as specified in protocol
+  /// @throw std::domain_error on invalid value
+  NetStatus NetStatusFromLong(std::size_t error) const;
+};
+
+/// @class I2PControlData
+/// @brief Base class for a request and a response
+class I2PControlData : public I2PControlDataTraits
+{
+ public:
+  /// @brief Set current ID
+  void SetID(const ValueType& id);
+
+  /// @return Current ID
+  const ValueType& GetID() const;
+
+  /// @brief Set json rpc version
+  void SetVersion(const std::string& version);
+
+  /// @return Json rpc version
+  const std::string& GetVersion() const;
+
+  /// @brief Sets current method
+  void SetMethod(Method method);
+
+  /// @return name of the method
+  Method GetMethod(void) const
+  {
+    return m_Method ? m_Method->Which() : Method::Unknown;
+  }
+
+  /// @return param associated with enumerated key
+  template <typename Type>
+  Type GetParam(std::uint8_t key) const
+  {
+    CheckInitialized();
+    return m_Method->Get<Type>(key);
+  }
+
+  /// @return param associated with string key
+  template <typename Type>
+  Type GetParam(const std::string& key) const
+  {
+    CheckInitialized();
+    return m_Method->Get<Type>(m_Method->GetTrait(key));
+  }
+
+  /// @brief Insert value associated with enumerated key
+  void SetParam(std::uint8_t key, const ValueType& value);
+
+  /// @brief Insert value associated with string key
+  void SetParam(std::string key, const ValueType& value);
+
+  /// @return String representation of key
+  const std::string KeyToString(std::uint8_t key);
+
+ protected:
+  /// @brief Parse common parameters
+  void Parse(const ptree&);
+
+  std::unique_ptr<AbstractMethod> m_Method;
+  ValueType m_ID{std::size_t(0)};
+  std::string m_Version{"2.0"};
+
+ private:
+  /// @brief Ensure method has been initialized
+  void CheckInitialized() const
+  {
+    if (!m_Method)
+      throw std::runtime_error("Method not initialized");
+  }
+
+ public:
+  /// @return all stored params
+  decltype(m_Method->Get()) GetParams() const
+  {
+    CheckInitialized();
+    return m_Method->Get();
+  }
+};
+
+/// @class I2PControlRequest
+/// @brief represents an I2PControl request
+class I2PControlRequest final : public I2PControlData
+{
+ public:
+  /// @brief Sets the current token
+  void SetToken(const std::string& token);
+
+  /// @return current token
+  std::string GetToken(void) const;
+
+  /// @return Json serialization
+  std::string ToJsonString() const;
+
+  /// @brief Parse an I2P control request
+  void Parse(std::stringstream& message);
+
+ private:
+  std::string m_Token;
+};
+
+/// @class I2PControlResponse
+/// @brief represents an I2PControl response
+class I2PControlResponse final : public I2PControlData
+{
+ public:
+  /// @brief Sets current error code
+  void SetError(ErrorCode code);
+
+  /// @return Current error code
+  ErrorCode GetError(void) const;
+
+  /// @return Message associated with current error
+  std::string GetErrorMsg() const;
+
+  /// @return Json serialization
+  std::string ToJsonString() const;
+
+  /// @brief Parse an I2P control response
+  void Parse(Method, std::stringstream& message);
+
+ private:
+  ErrorCode m_Error{ErrorCode::None};
+};
+
+}  // namespace client
+}  // namespace kovri
+
+#endif  // SRC_CLIENT_API_I2P_CONTROL_DATA_H_

--- a/src/client/api/i2p_control/server.cc
+++ b/src/client/api/i2p_control/server.cc
@@ -165,9 +165,9 @@ void I2PControlService::HandleRequestReceived(
       }
     }
     LOG(debug) << "I2PControlService: creating response";
-    I2PControlSession::Response response = m_Session->HandleRequest(ss);
+    auto response = m_Session->HandleRequest(ss);
     LOG(debug) << "I2PControlService: sending response";
-    SendResponse(socket, buf, response.ToJsonString(), is_html);
+    SendResponse(socket, buf, response->ToJsonString(), is_html);
   } catch (const std::exception& ex) {
     LOG(error) << "I2PControlService: handle request exception: " << ex.what();
   } catch (...) {

--- a/src/client/api/i2p_control/session.cc
+++ b/src/client/api/i2p_control/session.cc
@@ -54,44 +54,6 @@
 namespace kovri {
 namespace client {
 
-JsonObject::JsonObject(
-    const std::string& value)
-    : m_Children(),
-      m_Value("\"" + value + "\"") {}
-
-JsonObject::JsonObject(
-    int value)
-    : m_Children(),
-      m_Value(std::to_string(value)) {}
-
-JsonObject::JsonObject(
-    double v)
-    : m_Children(),
-      m_Value() {
-        std::ostringstream oss;
-        oss << std::fixed << std::setprecision(2) << v;
-        m_Value = oss.str();
-}
-
-JsonObject& JsonObject::operator[](
-    const std::string& key) {
-  return m_Children[key];
-}
-
-std::string JsonObject::ToString() const {
-  if (m_Children.empty())
-    return m_Value;
-  std::ostringstream oss;
-  oss << '{';
-  for (auto it = m_Children.begin(); it != m_Children.end(); ++it) {
-    if (it != m_Children.begin())
-      oss << ',';
-    oss << '"' << it->first << "\":" << it->second.ToString();
-  }
-  oss << '}';
-  return oss.str();
-}
-
 JsonObject TunnelToJsonObject(
     kovri::core::Tunnel* tunnel) {
   JsonObject obj;

--- a/src/client/api/i2p_control/session.cc
+++ b/src/client/api/i2p_control/session.cc
@@ -33,9 +33,7 @@
 #include "client/api/i2p_control/session.h"
 
 #include <boost/property_tree/json_parser.hpp>
-
-#include <iomanip>
-#include <sstream>
+#include <memory>
 
 #include "client/context.h"
 
@@ -53,7 +51,6 @@
 
 namespace kovri {
 namespace client {
-
 JsonObject TunnelToJsonObject(
     kovri::core::Tunnel* tunnel) {
   JsonObject obj;
@@ -68,94 +65,6 @@ JsonObject TunnelToJsonObject(
   return obj;
 }
 
-I2PControlSession::Response::Response(
-    const std::string& version)
-    : m_ID(),
-      m_Version(version),
-      m_Error(ErrorCode::e_None),
-      m_Params() {}
-
-std::string I2PControlSession::Response::ToJsonString() const {
-  std::ostringstream oss;
-  oss << "{\"id\":" << m_ID << ",\"result\":{";
-  for (auto it = m_Params.begin(); it != m_Params.end(); ++it) {
-    if (it != m_Params.begin())
-      oss << ',';
-    oss << '"' << it->first << "\":" << it->second;
-  }
-  oss << "},\"jsonrpc\":\"" << m_Version << '"';
-  if (m_Error != ErrorCode::e_None)
-    oss << ",\"error\":{\"code\":" << -static_cast<int>(m_Error)
-      << ",\"message\":\"" << GetErrorMsg() << "\"" << "}";
-  oss << "}";
-  return oss.str();
-}
-
-std::string I2PControlSession::Response::GetErrorMsg() const {
-  switch (m_Error) {
-    case ErrorCode::e_MethodNotFound:
-      return "Method not found.";
-    case ErrorCode::e_InvalidParameters:
-      return "Invalid parameters.";
-    case ErrorCode::e_InvalidRequest:
-      return "Invalid request.";
-    case ErrorCode::e_ParseError:
-      return "Json parse error.";
-    case ErrorCode::e_InvalidPassword:
-      return "Invalid password.";
-    case ErrorCode::e_NoToken:
-      return "No authentication token given.";
-    case ErrorCode::e_NonexistentToken:
-      return "Nonexistent authentication token given.";
-    case ErrorCode::e_ExpiredToken:
-      return "Expired authentication token given.";
-    case ErrorCode::e_UnspecifiedVersion:
-      return "Version not specified.";
-    case ErrorCode::e_UnsupportedVersion:
-      return "Version not supported.";
-    default:
-      return "";
-  }
-}
-
-void I2PControlSession::Response::SetParam(
-    const std::string& param,
-    const std::string& value) {
-  m_Params[param] = value.empty() ?
-    "null" :
-    "\"" + value + "\"";
-}
-
-void I2PControlSession::Response::SetParam(
-    const std::string& param,
-    std::size_t value) {
-  m_Params[param] = std::to_string(value);
-}
-
-void I2PControlSession::Response::SetParam(
-    const std::string& param,
-    double value) {
-  std::ostringstream oss;
-  oss << std::fixed << std::setprecision(2) << value;
-  m_Params[param] = oss.str();
-}
-
-void I2PControlSession::Response::SetParam(
-    const std::string& param,
-    const JsonObject& value) {
-  m_Params[param] = value.ToString();
-}
-
-void I2PControlSession::Response::SetError(
-    ErrorCode code) {
-  m_Error = code;
-}
-
-void I2PControlSession::Response::SetID(
-    const std::string& id) {
-  m_ID = id;
-}
-
 I2PControlSession::I2PControlSession(
   boost::asio::io_service& ios,
   const std::string& pass)
@@ -166,79 +75,29 @@ I2PControlSession::I2PControlSession(
       m_ExpireTokensTimer(ios) {
 
   // Method handlers
-  m_MethodHandlers[METHOD_AUTHENTICATE] =
-    &I2PControlSession::HandleAuthenticate;
+  m_MethodHandlers[Method::Authenticate] =
+      &I2PControlSession::HandleAuthenticate;
 
-  m_MethodHandlers[METHOD_ECHO] =
-    &I2PControlSession::HandleEcho;
+  m_MethodHandlers[Method::Echo] = &I2PControlSession::HandleEcho;
 
-  m_MethodHandlers[METHOD_I2PCONTROL] =
-    &I2PControlSession::HandleI2PControl;
+  // TODO(unassigned): method GetRate
 
-  m_MethodHandlers[METHOD_ROUTER_INFO] =
-    &I2PControlSession::HandleRouterInfo;
+  m_MethodHandlers[Method::I2PControl] = &I2PControlSession::HandleI2PControl;
 
-  m_MethodHandlers[METHOD_ROUTER_MANAGER] =
-    &I2PControlSession::HandleRouterManager;
+  m_MethodHandlers[Method::RouterInfo] = &I2PControlSession::HandleRouterInfo;
 
-  m_MethodHandlers[METHOD_NETWORK_SETTING] =
-    &I2PControlSession::HandleNetworkSetting;
-
-  // RouterInfo handlers
-  m_RouterInfoHandlers[ROUTER_INFO_UPTIME] =
-    &I2PControlSession::HandleUptime;
-
-  m_RouterInfoHandlers[ROUTER_INFO_VERSION] =
-    &I2PControlSession::HandleVersion;
-
-  m_RouterInfoHandlers[ROUTER_INFO_STATUS] =
-    &I2PControlSession::HandleStatus;
-
-  m_RouterInfoHandlers[ROUTER_INFO_DATAPATH] =
-    &I2PControlSession::HandleDatapath;
-
-  m_RouterInfoHandlers[ROUTER_INFO_NETDB_KNOWNPEERS] =
-    &I2PControlSession::HandleNetDbKnownPeers;
-
-  m_RouterInfoHandlers[ROUTER_INFO_NETDB_ACTIVEPEERS] =
-    &I2PControlSession::HandleNetDbActivePeers;
-
-  m_RouterInfoHandlers[ROUTER_INFO_NETDB_LEASESETS] =
-    &I2PControlSession::HandleNetDbLeaseSets;
-
-  m_RouterInfoHandlers[ROUTER_INFO_NETDB_FLOODFILLS] =
-    &I2PControlSession::HandleNetDbFloodfills;
-
-  m_RouterInfoHandlers[ROUTER_INFO_NET_STATUS] =
-    &I2PControlSession::HandleNetStatus;
-
-  m_RouterInfoHandlers[ROUTER_INFO_TUNNELS_PARTICIPATING] =
-    &I2PControlSession::HandleTunnelsParticipating;
-
-  m_RouterInfoHandlers[ROUTER_INFO_TUNNELS_CREATION_SUCCESS] =
-    &I2PControlSession::HandleTunnelsCreationSuccess;
-
-  m_RouterInfoHandlers[ROUTER_INFO_TUNNELS_IN_LIST] =
-    &I2PControlSession::HandleTunnelsInList;
-
-  m_RouterInfoHandlers[ROUTER_INFO_TUNNELS_OUT_LIST] =
-    &I2PControlSession::HandleTunnelsOutList;
-
-  m_RouterInfoHandlers[ROUTER_INFO_BW_IB_1S] =
-    &I2PControlSession::HandleInBandwidth1S;
-
-  m_RouterInfoHandlers[ROUTER_INFO_BW_OB_1S] =
-    &I2PControlSession::HandleOutBandwidth1S;
+  m_MethodHandlers[Method::RouterManager] =
+      &I2PControlSession::HandleRouterManager;
 
   // RouterManager handlers
-  m_RouterManagerHandlers[ROUTER_MANAGER_SHUTDOWN] =
-    &I2PControlSession::HandleShutdown;
+  m_RouterManagerHandlers[RouterManager::Shutdown] =
+      &I2PControlSession::HandleShutdown;
 
-  m_RouterManagerHandlers[ROUTER_MANAGER_SHUTDOWN_GRACEFUL] =
-    &I2PControlSession::HandleShutdownGraceful;
+  m_RouterManagerHandlers[RouterManager::ShutdownGraceful] =
+      &I2PControlSession::HandleShutdownGraceful;
 
-  m_RouterManagerHandlers[ROUTER_MANAGER_RESEED] =
-    &I2PControlSession::HandleReseed;
+  m_RouterManagerHandlers[RouterManager::Reseed] =
+      &I2PControlSession::HandleReseed;
 }
 
 void I2PControlSession::Start() {
@@ -251,56 +110,69 @@ void I2PControlSession::Stop() {
   m_ExpireTokensTimer.cancel(e);
 }
 
-I2PControlSession::Response I2PControlSession::HandleRequest(
-    std::stringstream& request) {
-  boost::property_tree::ptree pt;
+std::unique_ptr<I2PControlResponse> I2PControlSession::HandleRequest(
+    std::stringstream& stream)
+{
   LOG(debug) << "I2PControlSession: reading json request";
-  boost::property_tree::read_json(request, pt);
-  Response response;
+  auto response = std::make_unique<I2PControlResponse>();
   try {
-    response.SetID(pt.get<std::string>(PROPERTY_ID));
-    std::string method = pt.get<std::string>(PROPERTY_METHOD);
+    // Parse request
+    I2PControlRequest request;
+    request.Parse(stream);
+    // Build response
+    response->SetID(request.GetID());
+    auto method = request.GetMethod();
     auto it = m_MethodHandlers.find(method);
     if (it == m_MethodHandlers.end()) {  // Not found
-      LOG(warning) << "I2PControlSession: unknown I2PControl method " << method;
-      response.SetError(ErrorCode::e_MethodNotFound);
-      return response;
+        LOG(error) << "I2PControlSession: unknown or unimplemented method "
+                     << core::GetType(method);
+        response->SetError(ErrorCode::MethodNotFound);
+        return response;
     }
-    ptree params = pt.get_child(PROPERTY_PARAMS);
-    if (method != METHOD_AUTHENTICATE &&
-        !Authenticate(params, response)) {
-      LOG(warning) << "I2PControlSession: invalid token presented";
-      return response;
-    }
+    response->SetMethod(method);
+
+    if (method != Method::Authenticate
+        && !Authenticate(request, response.get()))
+      {
+        LOG(warning) << "I2PControlSession: invalid token presented";
+        return response;
+      }
     LOG(debug) << "I2PControlSession: calling handler";
-    (this->*(it->second))(params, response);
+    (this->*(it->second))(request, response.get());
   } catch (const boost::property_tree::ptree_error&) {
-    response.SetError(ErrorCode::e_ParseError);
+      response->SetError(ErrorCode::ParseError);
+  } catch (const std::logic_error&) {
+      response->SetError(ErrorCode::ParseError);
+  } catch (const boost::bad_get&) {
+      response->SetError(ErrorCode::ParseError);
   } catch (...) {
-    response.SetError(ErrorCode::e_InternalError);
+      response->SetError(ErrorCode::InternalError);
   }
   return response;
 }
 
 bool I2PControlSession::Authenticate(
-    const ptree& pt,
-    Response& response) {
-  try {
-    std::string token = pt.get<std::string>(PARAM_TOKEN);
-    std::lock_guard<std::mutex> lock(m_TokensMutex);
-    auto it = m_Tokens.find(token);
-    if (it == m_Tokens.end()) {
-      response.SetError(ErrorCode::e_NonexistentToken);
-      return false;
-    } else if (kovri::core::GetSecondsSinceEpoch() - it->second >
-        TOKEN_LIFETIME) {
-      response.SetError(ErrorCode::e_ExpiredToken);
+    const I2PControlRequest& request,
+    I2PControlResponse* response)
+{
+  std::lock_guard<std::mutex> lock(m_TokensMutex);
+  auto token = request.GetToken();
+  if (token.empty())
+    {
+      response->SetError(ErrorCode::NoToken);
       return false;
     }
-  } catch (const boost::property_tree::ptree_error&) {
-    response.SetError(ErrorCode::e_NoToken);
-    return false;
-  }
+  auto it = m_Tokens.find(token);
+  if (it == m_Tokens.end())
+    {
+      response->SetError(ErrorCode::NonexistentToken);
+      return false;
+    }
+  else if (kovri::core::GetSecondsSinceEpoch() - it->second > TOKEN_LIFETIME)
+    {
+      response->SetError(ErrorCode::ExpiredToken);
+      return false;
+    }
   return true;
 }
 
@@ -318,11 +190,13 @@ std::string I2PControlSession::GenerateToken() const {
 }
 
 void I2PControlSession::HandleAuthenticate(
-    const ptree& pt,
-    Response& response) {
-  const std::size_t api = pt.get<std::size_t>(PARAM_API);
-  const std::string given_pass = pt.get<std::string>(
-      PARAM_PASSWORD);
+    const Request& request,
+    Response* response)
+{
+  typedef I2PControlData::MethodAuthenticate Auth;
+
+  const auto api = request.GetParam<std::size_t>(Auth::API);
+  const auto given_pass = request.GetParam<std::string>(Auth::Password);
   LOG(debug)
     << "I2PControlSession: Authenticate API = " << api
     << " Password = " << given_pass;
@@ -330,12 +204,12 @@ void I2PControlSession::HandleAuthenticate(
     LOG(error)
       << "I2PControlSession: invalid password "
       << given_pass << " expected " << m_Password;
-    response.SetError(ErrorCode::e_InvalidPassword);
+    response->SetError(ErrorCode::InvalidPassword);
     return;
   }
   const std::string token = GenerateToken();
-  response.SetParam(PARAM_API, api);
-  response.SetParam(PARAM_TOKEN, token);
+  response->SetParam(Auth::API, api);
+  response->SetParam(Auth::Token, token);
   std::lock_guard<std::mutex> lock(m_TokensMutex);
   m_Tokens.insert(
       std::make_pair(
@@ -343,145 +217,141 @@ void I2PControlSession::HandleAuthenticate(
         kovri::core::GetSecondsSinceEpoch()));
 }
 
-void I2PControlSession::HandleEcho(
-    const ptree& pt,
-    Response& response) {
-  const std::string echo = pt.get<std::string>(PARAM_ECHO);
+void I2PControlSession::HandleEcho(const Request& request, Response* response)
+{
+  typedef I2PControlData::MethodEcho Keys;
+  const std::string echo = request.GetParam<std::string>(Keys::Echo);
   LOG(debug) << "I2PControlSession: Echo = " << echo;
-  response.SetParam(PARAM_RESULT, echo);
+  response->SetParam(Keys::Result, echo);
 }
 
-void I2PControlSession::HandleI2PControl(
-    const ptree&,
-    Response&) {
-  // TODO(unassigned): implement
+void I2PControlSession::HandleI2PControl(const Request&, Response*)
+{
+  // TODO(unassigned): implement method I2PControl
   LOG(debug) << "I2PControlSession: I2PControl";
 }
 
 void I2PControlSession::HandleRouterInfo(
-    const ptree& pt,
-    Response& response) {
+    const Request& request,
+    Response* response)
+{
+  typedef I2PControlData::MethodRouterInfo RouterInfo;
   LOG(debug) << "I2PControlSession: HandleRouterInfo()";
-  for (const auto& pair : pt) {
-    if (pair.first == PARAM_TOKEN)
-      continue;
-    LOG(debug) << "I2PControlSession: " << pair.first;
-    auto it = m_RouterInfoHandlers.find(pair.first);
-    if (it != m_RouterInfoHandlers.end()) {
-      (this->*(it->second))(response);
-    } else {
-      LOG(error)
-        << "I2PControlSession: " << __func__ << ": unknown request " << pair.first;
-      response.SetError(ErrorCode::e_InvalidRequest);
+  for (const auto& pair : request.GetParams())
+    {
+      switch (pair.first)
+        {
+          case RouterInfo::Status:  // TODO(unassigned): implement
+            response->SetParam(pair.first, std::string("???"));
+            break;
+
+          case RouterInfo::Uptime:
+            response->SetParam(
+                pair.first,
+                static_cast<std::size_t>(kovri::context.GetUptime()) * 1000);
+            break;
+
+          case RouterInfo::Version:
+            response->SetParam(
+                pair.first,
+                std::string(KOVRI_VERSION) + "-" + KOVRI_GIT_REVISION + "-"
+                    + KOVRI_CODENAME);
+            break;
+
+          case RouterInfo::BWIn1S:
+            response->SetParam(
+                pair.first,
+                static_cast<double>(kovri::core::transports.GetInBandwidth()));
+            break;
+
+          case RouterInfo::BWOut1S:
+            response->SetParam(
+                pair.first,
+                static_cast<double>(kovri::core::transports.GetOutBandwidth()));
+            break;
+
+          case RouterInfo::NetStatus:
+            response->SetParam(
+                pair.first,
+                static_cast<std::size_t>(kovri::context.GetStatus()));
+            break;
+
+          case RouterInfo::TunnelsParticipating:
+            response->SetParam(
+                pair.first, core::tunnels.GetTransitTunnels().size());
+            break;
+
+          case RouterInfo::ActivePeers:
+            response->SetParam(pair.first, core::transports.GetPeers().size());
+            break;
+
+          case RouterInfo::KnownPeers:
+            response->SetParam(pair.first, core::netdb.GetNumRouters());
+            break;
+
+          // Extra pair.firsts
+          case RouterInfo::DataPath:
+            response->SetParam(pair.first, core::GetCorePath().string());
+            break;
+
+          case RouterInfo::Floodfills:
+            response->SetParam(pair.first, core::netdb.GetNumFloodfills());
+            break;
+
+          case RouterInfo::LeaseSets:
+            response->SetParam(pair.first, core::netdb.GetNumLeaseSets());
+            break;
+
+          case RouterInfo::TunnelsCreationSuccessRate:
+            response->SetParam(
+                pair.first,
+                static_cast<std::size_t>(
+                    core::tunnels.GetTunnelCreationSuccessRate()));
+            break;
+
+          case RouterInfo::TunnelsInList:
+            HandleTunnelsInList(response);
+            break;
+
+          case RouterInfo::TunnelsOutList:
+            HandleTunnelsOutList(response);
+            break;
+
+          case RouterInfo::BWIn15S:
+          case RouterInfo::BWOut15S:
+          case RouterInfo::FastPeers:
+          case RouterInfo::HighCapacityPeers:
+          case RouterInfo::IsReseeding:
+          // TODO(unassigned): implement these indicators
+          default:
+            throw std::runtime_error("Indicator not implemented");
+        }
     }
-  }
 }
 
 void I2PControlSession::HandleRouterManager(
-    const ptree& pt,
-    Response& response) {
+    const Request& request,
+    Response* response)
+{
   LOG(debug) << "I2PControlSession: " << __func__;
-  for (const auto& pair : pt) {
-    if (pair.first == PARAM_TOKEN)
-      continue;
-    LOG(debug) << pair.first;
-    auto it = m_RouterManagerHandlers.find(pair.first);
-    if (it != m_RouterManagerHandlers.end()) {
-      (this->*(it->second))(response);
-    } else {
-      LOG(error)
-        << "I2PControlSession: " << __func__ << ": unknown request " << pair.first;
-      response.SetError(ErrorCode::e_InvalidRequest);
+  for (const auto& pair : request.GetParams())
+    {
+      auto it = m_RouterManagerHandlers.find(pair.first);
+      if (it != m_RouterManagerHandlers.end())
+        {
+          (this->*(it->second))(response);
+        }
+      else
+        {
+          LOG(error) << "I2PControlSession: " << __func__
+                     << ": unknown request " << std::to_string(pair.first);
+          response->SetError(ErrorCode::InvalidRequest);
+        }
     }
-  }
 }
 
-void I2PControlSession::HandleNetworkSetting(
-    const ptree&,
-    Response&) {
-  // TODO(unassigned): implement
-}
-
-void I2PControlSession::HandleUptime(
-    Response& response) {
-  response.SetParam(
-      ROUTER_INFO_UPTIME,
-      static_cast<std::size_t>(kovri::context.GetUptime()) * 1000);
-}
-
-void I2PControlSession::HandleVersion(
-    Response& response) {
-  response.SetParam(
-      ROUTER_INFO_VERSION,
-      KOVRI_VERSION);
-}
-
-void I2PControlSession::HandleStatus(
-    Response& response) {
-  // TODO(unassigned): implement
-  response.SetParam(
-      ROUTER_INFO_STATUS,
-      "???");
-}
-
-void I2PControlSession::HandleDatapath(
-    Response& response) {
-  response.SetParam(
-      ROUTER_INFO_DATAPATH,
-      core::GetCorePath().string());
-}
-
-void I2PControlSession::HandleNetDbKnownPeers(
-    Response& response) {
-  response.SetParam(
-      ROUTER_INFO_NETDB_KNOWNPEERS,
-      core::netdb.GetNumRouters());
-}
-
-void I2PControlSession::HandleNetDbActivePeers(
-    Response& response) {
-  response.SetParam(
-      ROUTER_INFO_NETDB_ACTIVEPEERS,
-      core::transports.GetPeers().size());
-}
-
-void I2PControlSession::HandleNetDbFloodfills(
-    Response& response) {
-  response.SetParam(
-      ROUTER_INFO_NETDB_FLOODFILLS,
-      core::netdb.GetNumFloodfills());
-}
-
-void I2PControlSession::HandleNetDbLeaseSets(
-    Response& response) {
-  response.SetParam(
-      ROUTER_INFO_NETDB_LEASESETS,
-      core::netdb.GetNumLeaseSets());
-}
-
-void I2PControlSession::HandleNetStatus(
-    Response& response) {
-  response.SetParam(
-      ROUTER_INFO_NET_STATUS,
-      static_cast<std::size_t>(kovri::context.GetStatus()));
-}
-
-void I2PControlSession::HandleTunnelsParticipating(
-    Response& response) {
-  response.SetParam(
-      ROUTER_INFO_TUNNELS_PARTICIPATING,
-      core::tunnels.GetTransitTunnels().size());
-}
-
-void I2PControlSession::HandleTunnelsCreationSuccess(
-    Response& response) {
-  response.SetParam(
-      ROUTER_INFO_TUNNELS_CREATION_SUCCESS,
-      static_cast<std::size_t>(core::tunnels.GetTunnelCreationSuccessRate()));
-}
-
-void I2PControlSession::HandleTunnelsInList(
-    Response& response) {
+void I2PControlSession::HandleTunnelsInList(Response* response)
+{
   JsonObject list;
   for (auto pair : kovri::core::tunnels.GetInboundTunnels()) {
     const std::string id = std::to_string(pair.first);
@@ -489,13 +359,11 @@ void I2PControlSession::HandleTunnelsInList(
     list[id]["bytes"] = JsonObject(
       static_cast<int>(pair.second->GetNumReceivedBytes()));
   }
-  response.SetParam(
-      ROUTER_INFO_TUNNELS_IN_LIST,
-      list);
+  response->SetParam(I2PControlData::MethodRouterInfo::TunnelsInList, list);
 }
 
-void I2PControlSession::HandleTunnelsOutList(
-    Response& response) {
+void I2PControlSession::HandleTunnelsOutList(Response* response)
+{
   JsonObject list;
   for (auto tunnel : kovri::core::tunnels.GetOutboundTunnels()) {
     const std::string id = std::to_string(
@@ -504,29 +372,13 @@ void I2PControlSession::HandleTunnelsOutList(
     list[id]["bytes"] = JsonObject(
         static_cast<int>(tunnel->GetNumSentBytes()));
   }
-  response.SetParam(
-      ROUTER_INFO_TUNNELS_OUT_LIST,
-      list);
+  response->SetParam(I2PControlData::MethodRouterInfo::TunnelsOutList, list);
 }
 
-void I2PControlSession::HandleInBandwidth1S(
-    Response& response) {
-  response.SetParam(
-      ROUTER_INFO_BW_IB_1S,
-      static_cast<double>(kovri::core::transports.GetInBandwidth()));
-}
-
-void I2PControlSession::HandleOutBandwidth1S(
-    Response& response) {
-  response.SetParam(
-      ROUTER_INFO_BW_OB_1S,
-      static_cast<double>(kovri::core::transports.GetOutBandwidth()));
-}
-
-void I2PControlSession::HandleShutdown(
-    Response& response) {
+void I2PControlSession::HandleShutdown(Response* response)
+{
   LOG(info) << "I2PControlSession: shutdown requested";
-  response.SetParam(ROUTER_MANAGER_SHUTDOWN, "");
+  response->SetParam(RouterManager::Shutdown, "");
   // 1 second to make sure response has been sent
   m_ShutdownTimer.expires_from_now(
       boost::posix_time::seconds(1));
@@ -538,8 +390,8 @@ void I2PControlSession::HandleShutdown(
       });
 }
 
-void I2PControlSession::HandleShutdownGraceful(
-    Response& response) {
+void I2PControlSession::HandleShutdownGraceful(Response* response)
+{
   // Stop accepting tunnels
   kovri::context.SetAcceptsTunnels(false);
   // Get tunnel expiry time
@@ -548,9 +400,7 @@ void I2PControlSession::HandleShutdownGraceful(
     << "I2PControlSession: graceful shutdown requested."
     << "Will shutdown after " << timeout << " seconds";
   // Initiate graceful shutdown
-  response.SetParam(
-      ROUTER_MANAGER_SHUTDOWN_GRACEFUL,
-      "");
+  response->SetParam(RouterManager::ShutdownGraceful, "");
   m_ShutdownTimer.expires_from_now(
       boost::posix_time::seconds(
         timeout + 1));
@@ -562,10 +412,10 @@ void I2PControlSession::HandleShutdownGraceful(
       });
 }
 
-void I2PControlSession::HandleReseed(
-    Response& response) {
+void I2PControlSession::HandleReseed(Response* response)
+{
   LOG(info) << "I2PControlSession: reseed requested";
-  response.SetParam(ROUTER_MANAGER_SHUTDOWN, "");
+  response->SetParam(RouterManager::Reseed, "");
   Reseed reseed;
   if (!reseed.Start())
     LOG(error) << "I2PControlSession: reseed failed";

--- a/src/client/api/i2p_control/session.h
+++ b/src/client/api/i2p_control/session.h
@@ -41,6 +41,7 @@
 #include <mutex>
 #include <string>
 
+#include "client/util/json.h"
 #include "core/router/tunnel/impl.h"
 
 namespace kovri {
@@ -126,33 +127,6 @@ const char ROUTER_INFO_BW_OB_1S[] =
 const char ROUTER_MANAGER_SHUTDOWN[] = "Shutdown";
 const char ROUTER_MANAGER_SHUTDOWN_GRACEFUL[] = "ShutdownGraceful";
 const char ROUTER_MANAGER_RESEED[] = "Reseed";
-
-/**
- * @class JsonObject
- * @brief Represents a Json object, provides functionality to convert to string.
- */
-class JsonObject {
- public:
-  JsonObject() = default;
-
-  explicit JsonObject(
-      const std::string& value);
-
-  explicit JsonObject(
-      int value);
-
-  explicit JsonObject(
-      double value);
-
-  JsonObject& operator[](
-      const std::string& key);
-
-  std::string ToString() const;
-
- private:
-  std::map<std::string, JsonObject> m_Children;
-  std::string m_Value;
-};
 
 JsonObject TunnelToJsonObject(
     kovri::core::Tunnel* tunnel);

--- a/src/client/util/json.cc
+++ b/src/client/util/json.cc
@@ -42,10 +42,10 @@ JsonObject::JsonObject(
     : m_Children(),
       m_Value("\"" + value + "\"") {}
 
-JsonObject::JsonObject(
-    int value)
-    : m_Children(),
-      m_Value(std::to_string(value)) {}
+JsonObject::JsonObject(int value)
+    : m_Children(), m_Value("\"" + std::to_string(value) + "\"")
+{
+}
 
 JsonObject::JsonObject(
     double v)
@@ -53,7 +53,19 @@ JsonObject::JsonObject(
       m_Value() {
         std::ostringstream oss;
         oss << std::fixed << std::setprecision(2) << v;
-        m_Value = oss.str();
+        m_Value = "\"" + oss.str() + "\"";
+}
+
+JsonObject::JsonObject(const ptree& node)
+{
+  m_Value = node.get_value<std::string>();
+  if (m_Value == "null")
+    m_Value = "";
+  else
+    m_Value = "\"" + m_Value + "\"";
+
+  for (const auto& child : node)
+    m_Children[child.first] = JsonObject(child.second);
 }
 
 JsonObject& JsonObject::operator[](

--- a/src/client/util/json.cc
+++ b/src/client/util/json.cc
@@ -1,0 +1,79 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ *                                                                                            //
+ */
+
+#include "client/util/json.h"
+
+#include <iomanip>
+
+namespace kovri
+{
+namespace client
+{
+JsonObject::JsonObject(
+    const std::string& value)
+    : m_Children(),
+      m_Value("\"" + value + "\"") {}
+
+JsonObject::JsonObject(
+    int value)
+    : m_Children(),
+      m_Value(std::to_string(value)) {}
+
+JsonObject::JsonObject(
+    double v)
+    : m_Children(),
+      m_Value() {
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(2) << v;
+        m_Value = oss.str();
+}
+
+JsonObject& JsonObject::operator[](
+    const std::string& key) {
+  return m_Children[key];
+}
+
+std::string JsonObject::ToString() const {
+  if (m_Children.empty())
+    return m_Value;
+  std::ostringstream oss;
+  oss << '{';
+  for (auto it = m_Children.begin(); it != m_Children.end(); ++it) {
+    if (it != m_Children.begin())
+      oss << ',';
+    oss << '"' << it->first << "\":" << it->second.ToString();
+  }
+  oss << '}';
+  return oss.str();
+}
+
+}  // namespace client
+}  // namespace kovri

--- a/src/client/util/json.cc
+++ b/src/client/util/json.cc
@@ -61,6 +61,27 @@ JsonObject& JsonObject::operator[](
   return m_Children[key];
 }
 
+bool JsonObject::operator==(const JsonObject& other) const
+{
+  return ToString() == other.ToString();
+}
+
+bool JsonObject::operator<(const JsonObject& other) const
+{
+  return m_Value == other.GetValue();
+}
+
+std::ostream& operator<<(std::ostream& os, const JsonObject& object)
+{
+  os << object.ToString();
+  return os;
+}
+
+const std::string& JsonObject::GetValue() const
+{
+  return m_Value;
+}
+
 std::string JsonObject::ToString() const {
   if (m_Children.empty())
     return m_Value;

--- a/src/client/util/json.h
+++ b/src/client/util/json.h
@@ -47,6 +47,8 @@ namespace client
  * @brief Represents a Json object, provides functionality to convert to string.
  */
 class JsonObject {
+  typedef boost::property_tree::ptree ptree;
+
  public:
   JsonObject() = default;
 
@@ -58,6 +60,8 @@ class JsonObject {
 
   explicit JsonObject(
       double value);
+
+  explicit JsonObject(const ptree& value);
 
   JsonObject& operator[](
       const std::string& key);

--- a/src/client/util/json.h
+++ b/src/client/util/json.h
@@ -1,0 +1,75 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ *                                                                                            //
+ */
+
+#ifndef SRC_CLIENT_UTIL_JSON_H_
+#define SRC_CLIENT_UTIL_JSON_H_
+
+#include <boost/property_tree/ptree.hpp>
+
+#include <map>
+#include <sstream>
+#include <string>
+
+namespace kovri
+{
+namespace client
+{
+/**
+ * @class JsonObject
+ * @brief Represents a Json object, provides functionality to convert to string.
+ */
+class JsonObject {
+ public:
+  JsonObject() = default;
+
+  explicit JsonObject(
+      const std::string& value);
+
+  explicit JsonObject(
+      int value);
+
+  explicit JsonObject(
+      double value);
+
+  JsonObject& operator[](
+      const std::string& key);
+
+  std::string ToString() const;
+
+ private:
+  std::map<std::string, JsonObject> m_Children;
+  std::string m_Value;
+};
+
+}  // namespace client
+}  // namespace kovri
+
+#endif  // SRC_CLIENT_UTIL_JSON_H_

--- a/src/client/util/json.h
+++ b/src/client/util/json.h
@@ -62,12 +62,24 @@ class JsonObject {
   JsonObject& operator[](
       const std::string& key);
 
+  // @return JsonObject associated with key
+  const JsonObject& Get(const std::string& key) const;
+
+  // @return current node value
+  const std::string& GetValue() const;
+
   std::string ToString() const;
+
+  // For usage with boost::variant
+  bool operator==(const JsonObject&) const;
+  bool operator<(const JsonObject&) const;
 
  private:
   std::map<std::string, JsonObject> m_Children;
   std::string m_Value;
 };
+
+std::ostream& operator<<(std::ostream& os, const JsonObject&);
 
 }  // namespace client
 }  // namespace kovri

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -12,6 +12,7 @@ set(UTIL_SRC
 if(WITH_FUZZ_TESTS)
   include_directories("${Fuzzer_INCLUDE_DIR}")
   list(APPEND UTIL_SRC
+    "../../tests/fuzz_tests/i2pcontrol.cc"
     "../../tests/fuzz_tests/lease_set.cc"
     "../../tests/fuzz_tests/routerinfo.cc"
     "../../tests/fuzz_tests/su3.cc"

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,11 +1,13 @@
 include_directories("../")
 
 set(UTIL_SRC
-  "su3file.cc"
-  "routerinfo.cc"
   "base.cc"
   "benchmark.cc"
-  "main.cc")
+  "i2pcontrol_client.cc"
+  "i2pcontrol.cc"
+  "main.cc"
+  "routerinfo.cc"
+  "su3file.cc")
 
 if(WITH_FUZZ_TESTS)
   include_directories("${Fuzzer_INCLUDE_DIR}")

--- a/src/util/fuzz.cc
+++ b/src/util/fuzz.cc
@@ -35,6 +35,7 @@
 
 #include "core/util/log.h"
 
+#include "tests/fuzz_tests/i2pcontrol.h"
 #include "tests/fuzz_tests/lease_set.h"
 #include "tests/fuzz_tests/routerinfo.h"
 #include "tests/fuzz_tests/su3.h"
@@ -99,6 +100,7 @@ FuzzCommand::FuzzCommand()
 void FuzzCommand::PrintAvailableTargets() const
 {
   LOG(info) << "Available targets : ";
+  LOG(info) << "\ti2pcontrol";
   LOG(info) << "\tleaseset";
   LOG(info) << "\trouterinfo";
   LOG(info) << "\tsu3";
@@ -177,6 +179,10 @@ bool FuzzCommand::Impl(
   else if (target == "leaseset")
     {
       CurrentTarget = new kovri::fuzz::LeaseSet();
+    }
+  else if (target == "i2pcontrol")
+    {
+      CurrentTarget = new kovri::fuzz::I2PControl();
     }
   else
     {

--- a/src/util/i2pcontrol.cc
+++ b/src/util/i2pcontrol.cc
@@ -1,0 +1,388 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ */
+
+#include "util/i2pcontrol.h"
+#include <assert.h>
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include "core/util/exception.h"
+#include "core/util/log.h"
+
+namespace core = kovri::core;
+
+/**
+ * @class PrintVisitor
+ * @brief Print value to string
+ **/
+struct PrintVisitor final : public boost::static_visitor<std::string>
+{
+  std::string operator()(bool value) const
+  {
+    return value ? "true" : "false";
+  }
+
+  std::string operator()(const std::size_t& value) const
+  {
+    return std::to_string(value);
+  }
+
+  std::string operator()(const double& value) const
+  {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2) << value;
+    return oss.str();
+  }
+
+  std::string operator()(const std::string& value) const
+  {
+    return value;
+  }
+
+  std::string operator()(const client::JsonObject& value) const
+  {
+    return value.ToString();
+  }
+};
+
+I2PControlCommand::I2PControlCommand()
+{
+  bpo::options_description options("Connection options");
+  options.add_options()(
+      "host", bpo::value<std::string>()->default_value("127.0.0.1"))(
+      "port", bpo::value<int>()->default_value(7650))(
+      "password", bpo::value<std::string>()->default_value("itoopie"));
+  m_Options.add(options);
+
+  bpo::options_description shortcuts("Shortcuts");
+  shortcuts.add_options()(
+      "command", bpo::value<std::string>()->default_value(""));
+  m_Options.add(shortcuts);
+
+  bpo::options_description raw_options("Low level options");
+  raw_options.add_options()(
+      "method,m", bpo::value<std::string>()->default_value("RouterInfo"))(
+      "key,k", bpo::value<std::string>()->default_value(""))(
+      "value,v", bpo::value<std::string>()->default_value(""));
+  m_Options.add(raw_options);
+}
+
+void I2PControlCommand::PrintUsage(const std::string& name) const
+{
+  LOG(info) << "Syntax: " << name << m_Options;
+  LOG(info) << "Available commands: ";
+  LOG(info) << "\tstatus";
+  LOG(info) << "\tversion";
+  LOG(info) << "\tuptime";
+  LOG(info) << "\treseed";
+  LOG(info) << "\tshutdown";
+  LOG(info) << "\tforce-shutdown";
+}
+
+bool I2PControlCommand::Impl(
+    const std::string&,
+    const std::vector<std::string>& args)
+{
+  m_Service = std::make_shared<boost::asio::io_service>();
+  m_Client = std::make_unique<client::I2PControlClient>(m_Service);
+  try
+    {
+      std::vector<std::string> inputs;
+      bpo::positional_options_description pos;
+      pos.add("command", -1);
+
+      bpo::variables_map vm;
+      bpo::parsed_options parsed = bpo::command_line_parser(args)
+                                       .options(m_Options)
+                                       .positional(pos)
+                                       .run();
+      bpo::store(parsed, vm);
+      bpo::notify(vm);
+
+      // Host connection params
+      auto request = std::make_shared<client::I2PControlRequest>();
+      ProcessConfig(vm, request);
+
+      // Authenticate
+      m_Client->AsyncConnect(
+          [this,
+           request](std::unique_ptr<client::I2PControlResponse> auth_response) {
+            // Received response of authentication
+            if (auth_response->GetError() != Response::ErrorCode::None)
+              {
+                throw std::runtime_error(
+                    "Authentification failed : "
+                    + auth_response->GetErrorMsg());
+              }
+            // Successfully authenticated, send request
+            m_Client->AsyncSendRequest(
+                request,
+                [this, request](
+                    std::unique_ptr<client::I2PControlResponse> response) {
+                  // Received response
+                  HandleResponse(request, std::move(response));
+                  // Nothing more to do
+                  m_Service->stop();
+                });
+          });
+      m_Service->run();
+    }
+  catch (...)
+    {
+      core::Exception ex(GetName().c_str());
+      ex.Dispatch(__func__);
+      return false;
+    }
+  return true;
+}
+
+void I2PControlCommand::ProcessConfig(
+    const bpo::variables_map& vm,
+    std::shared_ptr<Request> request)
+{
+  typedef Request::MethodRouterInfo RouterInfo;
+  typedef Request::MethodRouterManager RouterManager;
+
+  // Connection parameters
+  m_Client->SetHost(vm["host"].as<std::string>());
+  m_Client->SetPort(vm["port"].as<int>());
+  m_Client->SetPassword(vm["password"].as<std::string>());
+
+  // Process Shortcuts first
+  m_Command = vm["command"].as<std::string>();
+  if (m_Command == "status")
+    {
+      request->SetMethod(Method::RouterInfo);
+      request->SetParam(RouterInfo::Status, std::string());
+      return;
+    }
+  else if (m_Command == "version")
+    {
+      request->SetMethod(Method::RouterInfo);
+      request->SetParam(RouterInfo::Version, std::string());
+      return;
+    }
+  else if (m_Command == "uptime")
+    {
+      request->SetMethod(Method::RouterInfo);
+      request->SetParam(RouterInfo::Uptime, std::string());
+      return;
+    }
+  else if (m_Command == "reseed")
+    {
+      request->SetMethod(Method::RouterManager);
+      request->SetParam(RouterManager::Reseed, std::string());
+      return;
+    }
+  else if (m_Command == "shutdown")
+    {
+      request->SetMethod(Method::RouterManager);
+      request->SetParam(RouterManager::ShutdownGraceful, std::string());
+      return;
+    }
+  else if (m_Command == "force-shutdown")
+    {
+      request->SetMethod(Method::RouterManager);
+      request->SetParam(RouterManager::Shutdown, std::string());
+      return;
+    }
+  else if (!m_Command.empty())
+    {
+      throw std::runtime_error("Invalid command " + m_Command);
+    }
+
+  // If no shortcut, try low level options
+  auto method_string = vm["method"].as<std::string>();
+  auto method = request->GetMethodFromString(method_string);
+  request->SetMethod(method);
+
+  auto key = vm["key"].as<std::string>();
+  auto value = vm["value"].as<std::string>();
+
+  switch (method)
+    {
+      case Method::Authenticate:
+        throw std::invalid_argument("Invalid method: use option password");
+
+      case Method::Echo:
+        if (!key.empty())
+          throw std::invalid_argument("Invalid key: leave empty");
+        request->SetParam(Request::MethodEcho::Echo, value);
+        break;
+
+      case Method::GetRate:
+        request->SetParam(Request::MethodGetRate::Stat, key);
+        request->SetParam(
+            Request::MethodGetRate::Period, std::size_t(std::stoi(value)));
+        break;
+
+      case Method::I2PControl:
+      case Method::RouterManager:
+      case Method::NetworkSetting:
+        request->SetParam(key, value);
+        break;
+
+      case Method::RouterInfo:
+        {
+          if (!value.empty())
+            throw std::invalid_argument("Command RouterInfo takes no value");
+          request->SetParam(key, std::string());
+        }
+        break;
+
+      case Method::Unknown:
+        throw std::invalid_argument(
+            "Invalid method " + vm["method"].as<std::string>());
+    }
+}
+
+void I2PControlCommand::ProcessRouterManager(
+    const Response& response,
+    const std::string& name,
+    std::uint8_t key)
+{
+  auto const& params = response.GetParams();
+  auto end = params.end();
+  if (params.find(key) == end)
+    LOG(error) << "ControlCommand: no " << name << " key in response";
+  else
+    LOG(info) << "ControlCommand: " << name << " initiated";
+}
+
+void I2PControlCommand::HandleResponse(
+    std::shared_ptr<Request> request,
+    std::unique_ptr<Response> response)
+{
+  typedef Request::MethodRouterInfo RouterInfo;
+  typedef Request::MethodRouterManager RouterManager;
+  typedef Request::MethodI2PControl I2PControl;
+
+  LOG(debug) << "I2PControlCommand: response received";
+  if (response->GetError() != Response::ErrorCode::None)
+    {
+      LOG(error) << "I2PControlCommand: server responded with error: "
+                 << response->GetErrorMsg();
+      return;
+    }
+
+  // Process shortucts responses
+  if (m_Command == "status")
+    {
+      LOG(info) << "Status: "
+                << response->GetParam<std::string>(RouterInfo::Status);
+      return;
+    }
+  else if (m_Command == "version")
+    {
+      LOG(info) << "Version: "
+                << response->GetParam<std::string>(RouterInfo::Version);
+      return;
+    }
+  else if (m_Command == "uptime")
+    {
+      LOG(info) << "Server uptime: "
+                << std::to_string(
+                       response->GetParam<std::size_t>(RouterInfo::Uptime)
+                       / 1000)
+                << " seconds";
+      return;
+    }
+  else if (m_Command == "reseed")
+    {
+      return ProcessRouterManager(*response, m_Command, RouterManager::Reseed);
+    }
+  else if (m_Command == "shutdown")
+    {
+      return ProcessRouterManager(
+          *response, m_Command, RouterManager::ShutdownGraceful);
+    }
+  else if (m_Command == "force-shutdown")
+    {
+      return ProcessRouterManager(
+          *response, m_Command, RouterManager::Shutdown);
+    }
+  else if (!m_Command.empty())
+    {
+      throw std::runtime_error("Missing implementation");
+    }
+
+  // Process raw responses
+  switch (request->GetMethod())
+    {
+      case Method::Echo:
+        LOG(info) << "Echo: "
+                  << response->GetParam<std::string>(
+                         Request::MethodEcho::Result);
+        break;
+
+      case Method::I2PControl:
+        for (const auto& pair : response->GetParams())
+          {
+            switch (pair.first)
+              {
+                case I2PControl::Address:
+                  LOG(info) << "Address changed";
+                  break;
+                case I2PControl::Password:
+                  LOG(info) << "Password changed";
+                  break;
+                case I2PControl::Port:
+                  LOG(info) << "Port changed";
+                  break;
+
+                case I2PControl::SettingsSaved:
+                case I2PControl::RestartNeeded:
+                  LOG(info)
+                      << response->KeyToString(pair.first) << " : "
+                      << boost::apply_visitor(PrintVisitor(), pair.second);
+                  break;
+
+                default:
+                  throw std::runtime_error("Invalid I2PControl key");
+              }
+          }
+        break;
+
+      case Method::GetRate:
+      case Method::RouterInfo:
+      case Method::RouterManager:
+      case Method::NetworkSetting:
+        for (const auto& pair : response->GetParams())
+          {
+            LOG(info) << response->KeyToString(pair.first) << " : "
+                      << boost::apply_visitor(PrintVisitor(), pair.second);
+          }
+        break;
+
+      default:
+        throw std::runtime_error("Missing implementation");
+    }
+}

--- a/src/util/i2pcontrol.h
+++ b/src/util/i2pcontrol.h
@@ -1,0 +1,92 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ */
+
+#ifndef SRC_UTIL_I2PCONTROL_H_
+#define SRC_UTIL_I2PCONTROL_H_
+
+#include <boost/asio/io_service.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+#include "util/command.h"
+#include "util/i2pcontrol_client.h"
+
+namespace bpo = boost::program_options;
+namespace client = kovri::client;
+
+/**
+ * @class I2PControlCommand
+ * @brief specialization of Command for I2PControl
+ */
+
+class I2PControlCommand : public Command
+{
+ public:
+  I2PControlCommand();
+  virtual void PrintUsage(const std::string& cmd_name) const;
+  virtual bool Impl(const std::string&, const std::vector<std::string>&);
+  virtual std::string GetName(void) const
+  {
+    return "control";
+  }
+
+ protected:
+  typedef client::I2PControlRequest Request;
+  typedef client::I2PControlResponse Response;
+  typedef Request::Method Method;
+
+  // @brief Populate request from variable map
+  // @param map User parameters
+  // @param request Request to populate
+  virtual void ProcessConfig(
+      const bpo::variables_map& map,
+      std::shared_ptr<Request> request);
+
+  // @brief Process received response
+  // @param request Original request
+  // @param response Parsed response from an I2PControl server
+  virtual void HandleResponse(
+      std::shared_ptr<Request> request,
+      std::unique_ptr<Response> response);
+
+  bpo::options_description m_Options;
+  std::string m_Command;
+  std::shared_ptr<boost::asio::io_service> m_Service;
+  std::unique_ptr<client::I2PControlClient> m_Client;
+
+ private:
+  void ProcessRouterManager(
+      const Response& response,
+      const std::string& name,
+      std::uint8_t key);
+};
+
+#endif  // SRC_UTIL_I2PCONTROL_H_

--- a/src/util/i2pcontrol_client.cc
+++ b/src/util/i2pcontrol_client.cc
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ *    conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *    of conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "util/i2pcontrol_client.h"
+
+#include <boost/network/uri.hpp>
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <utility>
+
+#include "core/util/byte_stream.h"
+
+namespace asio = boost::asio;
+namespace core = kovri::core;
+namespace http = boost::network::http;
+
+namespace kovri
+{
+namespace client
+{
+I2PControlClient::I2PControlClient(std::shared_ptr<asio::io_service> service)
+    : m_Service(service)
+{
+  http::client::options options;
+  options.io_service(m_Service);
+  m_Client = std::make_unique<http::client>(options);
+}
+
+void I2PControlClient::SetHost(const std::string& host)
+{
+  m_Host = host;
+}
+
+void I2PControlClient::SetPort(std::uint16_t port)
+{
+  m_Port = port;
+}
+
+void I2PControlClient::SetPassword(const std::string& password)
+{
+  m_Password = password;
+}
+
+void I2PControlClient::AsyncConnect(
+    std::function<void(std::unique_ptr<Response>)> callback)
+{
+  auto request = std::make_shared<Request>();
+  request->SetID(std::size_t(0));
+  request->SetMethod(Method::Authenticate);
+  request->SetParam(Request::MethodAuthenticate::API, std::size_t(1));
+  request->SetParam(Request::MethodAuthenticate::Password, m_Password);
+
+  ProcessAsyncSendRequest(
+      request, [this, callback](std::unique_ptr<Response> response) {
+        if (response->GetError() == Response::ErrorCode::None)  // Store token
+          {
+            LOG(debug) << "I2PControlClient: Authentication successful";
+            m_Token = response->GetParam<std::string>(
+                Request::MethodAuthenticate::Token);
+          }
+        else
+          {
+            LOG(debug) << "I2PControlClient: Authentication failed!";
+          }
+        callback(std::move(response));
+      });
+}
+
+void I2PControlClient::AsyncSendRequest(
+    std::shared_ptr<Request> request,
+    std::function<void(std::unique_ptr<Response>)> callback)
+{
+  // First try
+  ProcessAsyncSendRequest(
+      request, [this, request, callback](std::unique_ptr<Response> response) {
+        // Received response
+        switch (response->GetError())
+          {
+            case ErrorCode::NonexistentToken:
+            case ErrorCode::ExpiredToken:
+              // Auto re-authenticate
+              AsyncConnect(
+                  [this, request, callback](std::unique_ptr<Response>) {
+                    // Try one last time
+                    ProcessAsyncSendRequest(request, callback);
+                  });
+              break;
+            default:
+              callback(std::move(response));
+              break;
+          }
+      });
+}
+
+void I2PControlClient::ProcessAsyncSendRequest(
+    std::shared_ptr<Request> request,
+    std::function<void(std::unique_ptr<Response>)> callback)
+{
+  namespace uri = boost::network::uri;
+  uri::uri url;
+  url << uri::scheme("http") << uri::host(m_Host) << uri::port(m_Port);
+  http::client::request http_request(url);
+
+  if (request->GetMethod() != Method::Authenticate)
+    request->SetToken(m_Token);
+
+  auto stream = std::make_shared<std::stringstream>();
+  m_Client->post(
+      http_request,
+      request->ToJsonString(),
+      "application/json",
+      std::bind(
+          &I2PControlClient::HandleHTTPResponse,
+          this,
+          std::placeholders::_1,
+          std::placeholders::_2,
+          request,
+          stream,
+          callback));
+}
+
+void I2PControlClient::HandleHTTPResponse(
+    boost::iterator_range<char const*> const& range,
+    boost::system::error_code const& error,
+    std::shared_ptr<Request> request,
+    std::shared_ptr<std::stringstream> stream,
+    std::function<void(std::unique_ptr<Response>)> callback)
+{
+  if (error && error != asio::error::eof)  // Connection closed cleanly by peer.
+    throw boost::system::system_error(error);  // Some other error.
+
+  *stream << std::string(boost::begin(range), boost::end(range));
+  if (error == asio::error::eof)
+    {
+      LOG(trace) << "I2PControlClient: received " << stream->str();
+      auto response = std::make_unique<Response>();
+      response->Parse(request->GetMethod(), *stream);
+      callback(std::move(response));
+    }
+}
+
+}  // namespace client
+}  // namespace kovri

--- a/src/util/i2pcontrol_client.h
+++ b/src/util/i2pcontrol_client.h
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ *    conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *    of conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_UTIL_I2PCONTROL_CLIENT_H_
+#define SRC_UTIL_I2PCONTROL_CLIENT_H_
+
+#include <boost/network/include/http/client.hpp>
+
+#include <memory>
+#include <string>
+
+#include "client/api/i2p_control/data.h"
+
+// Note: Credit goes to EinMByte.
+// This is heavily inspired from i2pcontrol_client.h in qtoopie.
+
+namespace kovri
+{
+namespace client
+{
+/**
+ * @brief Provides functiality to communicate with an I2PControl server over HTTP.
+ */
+class I2PControlClient final
+{
+ public:
+  // @brief I2PControlClient constructor
+  // @param url the location of the HTTP document providing the JSONRPC API.
+  explicit I2PControlClient(std::shared_ptr<boost::asio::io_service>);
+
+  // @brief Starts the ::I2PControlClient.
+  // @param callback the function to be called when the client is connected
+  // @throw std::exception on error
+  void AsyncConnect(
+      std::function<void(std::unique_ptr<I2PControlResponse>)> callback);
+
+  // @brief Sends a request to the I2PControl server.
+  // @details automatically sets the token for non auth request
+  // @details automatically reconnects if token expired
+  // @param request the request to be sent
+  // @param callback the function to be called when the request has finished
+  // @throw std::exception on error
+  void AsyncSendRequest(
+      std::shared_ptr<I2PControlRequest> request,
+      std::function<void(std::unique_ptr<I2PControlResponse>)> callback);
+
+  // @brief Sets the host of the i2p router
+  // @param host ip or hostname to connect to
+  // @throw std::bad_alloc when not enough memory
+  void SetHost(const std::string& host);
+
+  // @brief Sets the port of the i2p router
+  // @param port port to connect to
+  // @throw std::bad_alloc when not enough memory
+  void SetPort(std::uint16_t port);
+
+  // @brief Sets the password of the i2p router
+  // @param password password to use
+  // @throw std::bad_alloc when not enough memory
+  void SetPassword(const std::string& password);
+
+ private:
+  // For convenience
+  typedef I2PControlResponse Response;
+  typedef I2PControlRequest Request;
+  typedef Response::ErrorCode ErrorCode;
+  typedef Request::Method Method;
+
+  // @brief Effectively sends request without any modification
+  // @param request Original request
+  // @param callback Callback to call
+  // @throw std::exception on error
+  void ProcessAsyncSendRequest(
+      std::shared_ptr<Request> request,
+      std::function<void(std::unique_ptr<Response>)> callback);
+
+  // @brief Concatenate chunks as received and call callback when finished receiving
+  // @param it iterator over chunk of data received
+  // @param error Error as returned by underlying lib
+  // @param request Original request
+  // @param stream concatenation of chunks received so far
+  // @param callback Callback to call when response is complete
+  // @throw boost::system::error on error
+  void HandleHTTPResponse(
+      boost::iterator_range<char const*> const& it,
+      boost::system::error_code const& error,
+      std::shared_ptr<Request> request,
+      std::shared_ptr<std::stringstream> stream,
+      std::function<void(std::unique_ptr<Response>)> callback);
+
+  std::string m_Host{"127.0.0.1"};
+  std::uint16_t m_Port{7650};
+  std::string m_Password{"itoopie"};
+  std::string m_Token{};
+  std::shared_ptr<boost::asio::io_service> m_Service;
+  std::unique_ptr<boost::network::http::client> m_Client;
+};
+
+}  // namespace client
+}  // namespace kovri
+
+#endif  // SRC_UTIL_I2PCONTROL_CLIENT_H_

--- a/src/util/main.cc
+++ b/src/util/main.cc
@@ -37,6 +37,7 @@
 #ifdef WITH_FUZZ_TESTS
 #include "util/fuzz.h"
 #endif  // WITH_FUZZ_TESTS
+#include "util/i2pcontrol.h"
 #include "util/routerinfo.h"
 #include "util/su3file.h"
 
@@ -63,11 +64,13 @@ int main(int argc, const char* argv[])
   SU3FileCommand su3file_cmd;
   RouterInfoCommand routerinfo_cmd;
   Benchmark benchmark_cmd;
+  I2PControlCommand i2pcontrol_cmd;
   list_cmd[base32_cmd.GetName()] = &base32_cmd;
   list_cmd[base64_cmd.GetName()] = &base64_cmd;
   list_cmd[su3file_cmd.GetName()] = &su3file_cmd;
   list_cmd[routerinfo_cmd.GetName()] = &routerinfo_cmd;
   list_cmd[benchmark_cmd.GetName()] = &benchmark_cmd;
+  list_cmd[i2pcontrol_cmd.GetName()] = &i2pcontrol_cmd;
 
 #ifdef WITH_FUZZ_TESTS
   FuzzCommand fuzz_cmd;

--- a/tests/fuzz_tests/i2pcontrol.cc
+++ b/tests/fuzz_tests/i2pcontrol.cc
@@ -1,0 +1,66 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ *                                                                                            //
+ */
+
+#include "tests/fuzz_tests/i2pcontrol.h"
+
+#include "client/api/i2p_control/data.h"
+#include "core/util/exception.h"
+
+namespace kovri
+{
+namespace fuzz
+{
+int I2PControl::Initialize(int*, char***)
+{
+  // nothing to do
+  return 0;
+}
+
+int I2PControl::Impl(const uint8_t* data, size_t size)
+{
+  try
+    {
+      std::stringstream stream;
+      stream.write(reinterpret_cast<const char*>(data), size);
+      client::I2PControlRequest request;
+      request.Parse(stream);
+    }
+  catch (...)
+    {
+      core::Exception ex;
+      ex.Dispatch(__func__);
+      return 0;
+    }
+  return 0;
+}
+
+}  // namespace fuzz
+}  // namespace kovri

--- a/tests/fuzz_tests/i2pcontrol.h
+++ b/tests/fuzz_tests/i2pcontrol.h
@@ -1,0 +1,55 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ */
+
+#ifndef TESTS_FUZZ_TESTS_I2PCONTROL_H_
+#define TESTS_FUZZ_TESTS_I2PCONTROL_H_
+
+#include "tests/fuzz_tests/target.h"
+
+namespace kovri
+{
+namespace fuzz
+{
+/**
+ * @class I2PControl
+ * @brief Specialization of FuzzTarget for I2PControl
+ */
+
+class I2PControl : public FuzzTarget
+{
+ public:
+  virtual int Initialize(int* argc, char*** argv);
+  virtual int Impl(const uint8_t* data, size_t size);
+};
+
+}  // namespace fuzz
+}  // namespace kovri
+
+#endif  // TESTS_FUZZ_TESTS_I2PCONTROL_H_

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(TESTS_CLIENT
   "client/address_book/impl.cc"
+  "client/api/i2p_control/data.cc"
+  "client/api/i2p_control/parser.cc"
   "client/reseed.cc"
   "client/proxy/http.cc"
   "client/util/http.cc"

--- a/tests/unit_tests/client/api/i2p_control/data.cc
+++ b/tests/unit_tests/client/api/i2p_control/data.cc
@@ -1,0 +1,124 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ *                                                                                            //
+ */
+
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+#include <limits>
+#include <type_traits>
+
+#include "client/api/i2p_control/data.h"
+#include "core/util/log.h"
+
+namespace client = kovri::client;
+namespace core = kovri::core;
+typedef client::I2PControlResponse Response;
+typedef client::I2PControlRequest Request;
+typedef Response::ErrorCode ErrorCode;
+typedef Response::Method Method;
+
+struct I2PControlPacketFixture
+{
+  const std::string m_Version{"2.0"};
+  std::uint8_t m_Key{0};
+};
+
+BOOST_FIXTURE_TEST_SUITE(I2PControlPacketTest, I2PControlPacketFixture)
+
+BOOST_AUTO_TEST_CASE(Errors)
+{
+  Response response;
+  // No error
+  response.SetError(ErrorCode::None);
+  BOOST_CHECK_EQUAL(
+      response.GetErrorMsg(), response.GetTrait(response.ErrorFromInt(0)));
+  // Standard JSON-RPC2 error codes
+  response.SetError(ErrorCode::InvalidRequest);
+  BOOST_CHECK_EQUAL(
+      response.GetErrorMsg(), response.GetTrait(response.ErrorFromInt(-32600)));
+  response.SetError(ErrorCode::MethodNotFound);
+  BOOST_CHECK_EQUAL(
+      response.GetErrorMsg(), response.GetTrait(response.ErrorFromInt(-32601)));
+  response.SetError(ErrorCode::InvalidParameters);
+  BOOST_CHECK_EQUAL(
+      response.GetErrorMsg(), response.GetTrait(response.ErrorFromInt(-32602)));
+  response.SetError(ErrorCode::InternalError);
+  BOOST_CHECK_EQUAL(
+      response.GetErrorMsg(), response.GetTrait(response.ErrorFromInt(-32603)));
+  response.SetError(ErrorCode::ParseError);
+  BOOST_CHECK_EQUAL(
+      response.GetErrorMsg(), response.GetTrait(response.ErrorFromInt(-32700)));
+  // I2PControl specific error codes
+  response.SetError(ErrorCode::InvalidPassword);
+  BOOST_CHECK_EQUAL(
+      response.GetErrorMsg(), response.GetTrait(response.ErrorFromInt(-32001)));
+  response.SetError(ErrorCode::NoToken);
+  BOOST_CHECK_EQUAL(
+      response.GetErrorMsg(), response.GetTrait(response.ErrorFromInt(-32002)));
+  response.SetError(ErrorCode::NonexistentToken);
+  BOOST_CHECK_EQUAL(
+      response.GetErrorMsg(), response.GetTrait(response.ErrorFromInt(-32003)));
+  response.SetError(ErrorCode::ExpiredToken);
+  BOOST_CHECK_EQUAL(
+      response.GetErrorMsg(), response.GetTrait(response.ErrorFromInt(-32004)));
+  response.SetError(ErrorCode::UnspecifiedVersion);
+  BOOST_CHECK_EQUAL(
+      response.GetErrorMsg(), response.GetTrait(response.ErrorFromInt(-32005)));
+  response.SetError(ErrorCode::UnsupportedVersion);
+  BOOST_CHECK_EQUAL(
+      response.GetErrorMsg(), response.GetTrait(response.ErrorFromInt(-32006)));
+}
+
+BOOST_AUTO_TEST_CASE(DefaultRequestProperties)
+{
+  Request request;
+  // Check default version
+  BOOST_CHECK_EQUAL(request.GetVersion(), m_Version);
+  // Check no default method
+  BOOST_CHECK(request.GetMethod() == Method::Unknown);
+  // Check no default params
+  BOOST_CHECK_THROW(request.GetParams(), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(DefaultResponseProperties)
+{
+  Response response;
+  // Check default version
+  BOOST_CHECK_EQUAL(response.GetVersion(), m_Version);
+  // Check default with no error
+  BOOST_CHECK(response.GetError() == Response::ErrorCode::None);
+  // Check no default params
+  BOOST_CHECK_THROW(response.GetParams(), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/unit_tests/client/api/i2p_control/parser.cc
+++ b/tests/unit_tests/client/api/i2p_control/parser.cc
@@ -1,0 +1,858 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ *                                                                                            //
+ */
+
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+#include <limits>
+
+#include "client/api/i2p_control/data.h"
+#include "client/util/json.h"
+
+namespace client = kovri::client;
+namespace core = kovri::core;
+
+struct I2PControlSessionFixture
+{
+  // For convenience
+  typedef client::I2PControlResponse Response;
+  typedef client::I2PControlRequest Request;
+  typedef Response::Method Method;
+  typedef Response::MethodAuthenticate Auth;
+  typedef Response::MethodEcho Echo;
+  typedef Response::MethodI2PControl I2PControl;
+  typedef Response::MethodRouterInfo RouterInfo;
+  typedef Response::MethodRouterManager RouterManager;
+  typedef Response::MethodNetworkSetting NetworkSetting;
+  typedef Response::NetStatus NetStatus;
+
+  // Values used in multiple fixtures
+  const std::size_t m_ID{123};
+  const std::size_t m_API{456};
+  const std::string m_Password{"some_pass"};
+  const std::string m_Token{"some_token"};
+  const std::string m_Version{"2.0"};
+  const std::string m_Address{"172.18.0.10"};
+  const std::string m_Port{"15150"};
+
+  // Response with error
+  std::string m_ResponseWithError{
+      "{\"id\":123,\"result\":{\"API\":456},\"jsonrpc\":\"2.0\","
+      "\"error\":{\"code\":-32700,\"message\":\"Json parse error.\"}}"};
+};
+
+struct I2PControlAuthFixture : public I2PControlSessionFixture
+{
+  // Authenticate Request
+  std::string m_AuthenticateRequest{
+      "{\"id\":123,\"method\":\"Authenticate\",\"params\":{"
+      "\"API\":456,"
+      "\"Password\":\"some_pass\""
+      "},\"jsonrpc\":\"2.0\"}"};
+
+  // Authenticate Response
+  std::string m_AuthenticateResponse{
+      "{\"id\":123,\"result\":{"
+      "\"API\":456,"
+      "\"Token\":\"some_token\""
+      "},\"jsonrpc\":\"2.0\"}"};
+};
+
+struct I2PControlEchoFixture : public I2PControlSessionFixture
+{
+  const std::string m_EchoMessage{"echo message"};
+
+  // Echo Request
+  std::string m_EchoRequest{
+      "{\"id\":123,\"method\":\"Echo\",\"params\":{"
+      "\"Token\":\"some_token\","
+      "\"Echo\":\"echo message\""
+      "},\"jsonrpc\":\"2.0\"}"};
+
+  // Echo Response
+  std::string m_EchoResponse{
+      "{\"id\":123,\"result\":{"
+      "\"Result\":\"echo message\""
+      "},\"jsonrpc\":\"2.0\"}"};
+};
+
+struct I2PControlGetRateFixture : public I2PControlSessionFixture
+{
+  // GetRate Request
+  std::string m_GetRateRequest{
+      "{\"id\":123,\"method\":\"GetRate\",\"params\":{"
+      "\"Token\":\"some_token\","
+      "\"Stat\":\"stat_key\","
+      "\"Period\":15,"
+      "},\"jsonrpc\":\"2.0\"}"};
+
+  // GetRate Response
+  std::string m_I2PGetRateResponse{
+      "{\"id\":123,\"result\":{"
+      "\"Result\":1.15"
+      "},\"jsonrpc\":\"2.0\"}"};
+};
+struct I2PControlControlFixture : public I2PControlSessionFixture
+{
+  // I2PControl Request
+  std::string m_I2PControlRequest{
+      "{\"id\":123,\"method\":\"I2PControl\",\"params\":{"
+      "\"Token\":\"some_token\","
+      "\"i2pcontrol.address\":\"172.18.0.10\","
+      "\"i2pcontrol.password\":\"some_pass\","
+      "\"i2pcontrol.port\":\"15150\""
+      "},\"jsonrpc\":\"2.0\"}"};
+
+  // I2PControl Response
+  std::string m_I2PControlResponse{
+      "{\"id\":123,\"result\":{\"i2pcontrol.address\":null,"
+      "\"i2pcontrol.password\":null,"
+      "\"i2pcontrol.port\":null,"
+      "\"SettingsSaved\":true,"
+      "\"RestartNeeded\":false"
+      "},\"jsonrpc\":\"2.0\"}"};
+};
+
+struct I2PControlRouterInfoFixture : public I2PControlSessionFixture
+{
+  I2PControlRouterInfoFixture()
+  {
+    // Initialize json
+    m_Json["3886212441"]["bytes"] = client::JsonObject(0);
+    m_Json["3886212441"]["layout"] =
+        client::JsonObject("me-->3886212441:nrkY-->");
+  }
+
+  const std::string m_Status{"some status"};
+  const std::size_t m_Uptime{123456};
+  const std::string m_KovriVersion{"some version"};
+  const double m_BWIn1S{1.1};
+  const double m_BWIn15S{15.15};
+  const double m_BWOut1S{2.2};
+  const double m_BWOut15S{25.25};
+  Response::NetStatus m_NetStatus{NetStatus::Firewalled};
+  const std::size_t m_Participants{5};
+  const std::size_t m_ActivePeers{10};
+  const std::size_t m_FastPeers{7};
+  const std::size_t m_HighCapPeers{3};
+  const std::size_t m_KnownPeers{50};
+  const std::string m_DataPath{"/path/to/data/dir"};
+  const std::size_t m_Floodfills{20};
+  const std::size_t m_LeaseSets{30};
+  const double m_TunnelsCreationSuccessRate{0.83};
+  client::JsonObject m_Json;
+
+  // RouterInfo Request
+  std::string m_RouterInfoRequest{
+      "{\"id\":123,\"method\":\"RouterInfo\",\"params\":{"
+      "\"Token\":\"some_token\","
+      "\"i2p.router.status\":null,"
+      "\"i2p.router.uptime\":null,"
+      "\"i2p.router.version\":null,"
+      "\"i2p.router.net.bw.inbound.1s\":null,"
+      "\"i2p.router.net.bw.inbound.15s\":null,"
+      "\"i2p.router.net.bw.outbound.1s\":null,"
+      "\"i2p.router.net.bw.outbound.15s\":null,"
+      "\"i2p.router.net.status\":null,"
+      "\"i2p.router.net.tunnels.participating\":null,"
+      "\"i2p.router.netdb.activepeers\":null,"
+      "\"i2p.router.netdb.fastpeers\":null,"
+      "\"i2p.router.netdb.highcapacitypeers\":null,"
+      "\"i2p.router.netdb.isreseeding\":null,"
+      "\"i2p.router.netdb.knownpeers\":null,"
+      "\"i2p.router.datapath\":null,"
+      "\"i2p.router.netdb.floodfills\":null,"
+      "\"i2p.router.netdb.leasesets\":null,"
+      "\"i2p.router.net.tunnels.creationsuccessrate\":null,"
+      "\"i2p.router.net.tunnels.inbound.list\":null,"
+      "\"i2p.router.net.tunnels.outbound.list\":null"
+      "},\"jsonrpc\":\"2.0\"}"};
+
+  // RouterInfo Response
+  std::string m_RouterInfoResponse{
+      "{\"id\":123,\"result\":{"
+      "\"i2p.router.status\":\"some status\","
+      "\"i2p.router.uptime\":123456,"
+      "\"i2p.router.version\":\"some version\","
+      "\"i2p.router.net.bw.inbound.1s\":1.10,"
+      "\"i2p.router.net.bw.inbound.15s\":15.15,"
+      "\"i2p.router.net.bw.outbound.1s\":2.20,"
+      "\"i2p.router.net.bw.outbound.15s\":25.25,"
+      "\"i2p.router.net.status\":2,"
+      "\"i2p.router.net.tunnels.participating\":5,"
+      "\"i2p.router.netdb.activepeers\":10,"
+      "\"i2p.router.netdb.fastpeers\":7,"
+      "\"i2p.router.netdb.highcapacitypeers\":3,"
+      "\"i2p.router.netdb.isreseeding\":false,"
+      "\"i2p.router.netdb.knownpeers\":50,"
+      "\"i2p.router.datapath\":\"/path/to/data/dir\","
+      "\"i2p.router.netdb.floodfills\":20,"
+      "\"i2p.router.netdb.leasesets\":30,"
+      "\"i2p.router.net.tunnels.creationsuccessrate\":0.83,"
+      "\"i2p.router.net.tunnels.inbound.list\":null,"
+      "\"i2p.router.net.tunnels.outbound.list\":"
+      "{\"3886212441\":{"
+      "\"bytes\":\"0\","
+      "\"layout\":\"me-->3886212441:nrkY-->\"}}"
+      "},\"jsonrpc\":\"2.0\"}"};
+};
+
+struct I2PControlRouterManagerFixture : public I2PControlSessionFixture
+{
+  const std::string m_StatusUpdate{"update status"};
+  // RouterManager Request
+  std::string m_RouterManagerRequest{
+      "{\"id\":123,\"method\":\"RouterManager\",\"params\":{"
+      "\"Token\":\"some_token\","
+      "\"FindUpdates\":null,"
+      "\"Reseed\":null,"
+      "\"Restart\":null,"
+      "\"RestartGraceful\":null,"
+      "\"Shutdown\":null,"
+      "\"ShutdownGraceful\":null,"
+      "\"Update\":null"
+      "},\"jsonrpc\":\"2.0\"}"};
+
+  // RouterManager Response
+  std::string m_RouterManagerResponse{
+      "{\"id\":123,\"result\":{"
+      "\"FindUpdates\":false,"
+      "\"Reseed\":null,"
+      "\"Restart\":null,"
+      "\"RestartGraceful\":null,"
+      "\"Shutdown\":null,"
+      "\"ShutdownGraceful\":null,"
+      "\"Update\":\"update status\""
+      "},\"jsonrpc\":\"2.0\"}"};
+};
+
+struct I2PControlNetworkSettingFixture : public I2PControlSessionFixture
+{
+  const std::string m_NTCPPort{"25250"};
+  const std::string m_NTCPHostName{"ntcp hostname"};
+  const std::string m_NTCPAutoIP{"ntcp auto ip"};
+  const std::string m_SSUPort{"25251"};
+  const std::string m_SSUHostName{"ssu hostname"};
+  const std::string m_SSUAutoIP{"ssu auto ip"};
+  const std::string m_UPnP{"upnp"};
+  const std::string m_BWShare{"BW share"};
+  const std::string m_BWIn{"10.10"};
+  const std::string m_BWOut{"20.20"};
+  const std::string m_LaptopMode{"laptop mode"};
+
+  // NetworkSetting Request
+  std::string m_NetworkSettingRequest{
+      "{\"id\":123,\"method\":\"NetworkSetting\",\"params\":{"
+      "\"Token\":\"some_token\","
+      "\"i2p.router.net.ntcp.port\":\"25250\","
+      "\"i2p.router.net.ntcp.hostname\":\"ntcp hostname\","
+      "\"i2p.router.net.ntcp.autoip\":\"ntcp auto ip\","
+      "\"i2p.router.net.ssu.port\":\"25251\","
+      "\"i2p.router.net.ssu.hostname\":\"ssu hostname\","
+      "\"i2p.router.net.ssu.autoip\":\"ssu auto ip\","
+      "\"i2p.router.net.ssu.detectedip\":null,"
+      "\"i2p.router.net.upnp\":\"upnp\","
+      "\"i2p.router.net.bw.share\":\"BW share\","
+      "\"i2p.router.net.bw.in\":\"10.10\","
+      "\"i2p.router.net.bw.out\":\"20.20\","
+      "\"i2p.router.net.laptopmode\":\"laptop mode\""
+      "},\"jsonrpc\":\"2.0\"}"};
+
+  // NetworkSetting Response
+  std::string m_NetworkSettingResponse{
+      "{\"id\":123,\"result\":{"
+      "\"i2p.router.net.ntcp.port\":\"25250\","
+      "\"i2p.router.net.ntcp.hostname\":\"ntcp hostname\","
+      "\"i2p.router.net.ntcp.autoip\":\"ntcp auto ip\","
+      "\"i2p.router.net.ssu.port\":\"25251\","
+      "\"i2p.router.net.ssu.hostname\":\"ssu hostname\","
+      "\"i2p.router.net.ssu.autoip\":\"ssu auto ip\","
+      "\"i2p.router.net.ssu.detectedip\":\"172.18.0.10\","
+      "\"i2p.router.net.upnp\":\"upnp\","
+      "\"i2p.router.net.bw.share\":\"BW share\","
+      "\"i2p.router.net.bw.in\":\"10.10\","
+      "\"i2p.router.net.bw.out\":\"20.20\","
+      "\"i2p.router.net.laptopmode\":\"laptop mode\","
+      "\"SettingsSaved\":true,"
+      "\"RestartNeeded\":false"
+      "},\"jsonrpc\":\"2.0\"}"};
+};
+
+// Response with error
+BOOST_FIXTURE_TEST_CASE(ReadResponseWithError, I2PControlSessionFixture)
+{
+  std::stringstream stream(m_ResponseWithError);
+  Response response;
+  // Parse
+  BOOST_CHECK_NO_THROW(response.Parse(Method::Authenticate, stream));
+  // Check params
+  BOOST_CHECK(response.GetError() == Response::ErrorCode::ParseError);
+}
+
+BOOST_FIXTURE_TEST_SUITE(I2PControlAuthTest, I2PControlAuthFixture)
+// Authenticate Request
+BOOST_AUTO_TEST_CASE(WriteAuthenticateRequest)
+{
+  Request request;
+  // Set common params
+  request.SetID(m_ID);
+  request.SetMethod(Method::Authenticate);
+  // Set specific params
+  request.SetParam(Auth::API, m_API);
+  request.SetParam(Auth::Password, m_Password);
+  // Check output
+  BOOST_CHECK_EQUAL(request.ToJsonString(), m_AuthenticateRequest);
+}
+
+BOOST_AUTO_TEST_CASE(ReadAuthenticateRequest)
+{
+  Request request;
+  std::stringstream stream(m_AuthenticateRequest);
+  // Parse
+  BOOST_CHECK_NO_THROW(request.Parse(stream));
+  // Check params
+  BOOST_CHECK_EQUAL(request.GetVersion(), m_Version);
+  BOOST_CHECK_EQUAL(boost::get<decltype(m_ID)>(request.GetID()), m_ID);
+  BOOST_CHECK_EQUAL(request.GetParam<std::size_t>(Auth::API), m_API);
+  BOOST_CHECK_EQUAL(request.GetParam<std::string>(Auth::Password), m_Password);
+}
+
+// Authenticate Response
+BOOST_AUTO_TEST_CASE(WriteAuthenticateResponse)
+{
+  client::I2PControlResponse response;
+  response.SetMethod(Method::Authenticate);
+  // Set common params
+  response.SetID(m_ID);
+  response.SetParam(Auth::API, m_API);
+  response.SetParam(Auth::Token, m_Token);
+  // Check output
+  BOOST_CHECK_EQUAL(response.ToJsonString(), m_AuthenticateResponse);
+}
+
+BOOST_AUTO_TEST_CASE(ReadAuthenticateResponse)
+{
+  Response response;
+  std::stringstream stream(m_AuthenticateResponse);
+  // Parse
+  BOOST_CHECK_NO_THROW(response.Parse(Method::Authenticate, stream));
+  // Check params
+  BOOST_CHECK_EQUAL(response.GetVersion(), m_Version);
+  BOOST_CHECK_EQUAL(boost::get<decltype(m_ID)>(response.GetID()), m_ID);
+  BOOST_CHECK_EQUAL(response.GetParam<std::size_t>(Auth::API), m_API);
+  BOOST_CHECK_EQUAL(response.GetParam<std::string>(Auth::Token), m_Token);
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(I2PControlEchoTest, I2PControlEchoFixture)
+// Echo Request
+BOOST_AUTO_TEST_CASE(WriteEchoRequest)
+{
+  Request request;
+  // Set common params
+  request.SetID(m_ID);
+  request.SetMethod(Method::Echo);
+  request.SetToken(m_Token);
+  // Set specific params
+  request.SetParam(Echo::Echo, m_EchoMessage);
+  // Check output
+  BOOST_CHECK_EQUAL(request.ToJsonString(), m_EchoRequest);
+}
+
+BOOST_AUTO_TEST_CASE(ReadEchoRequest)
+{
+  Request request;
+  std::stringstream stream(m_EchoRequest);
+  // Parse
+  BOOST_CHECK_NO_THROW(request.Parse(stream));
+  // Check params
+  BOOST_CHECK_EQUAL(request.GetVersion(), m_Version);
+  BOOST_CHECK_EQUAL(boost::get<decltype(m_ID)>(request.GetID()), m_ID);
+  BOOST_CHECK_EQUAL(request.GetToken(), m_Token);
+  BOOST_CHECK_EQUAL(request.GetParam<std::string>(Echo::Echo), m_EchoMessage);
+}
+
+// Echo Response
+BOOST_AUTO_TEST_CASE(WriteEchoResponse)
+{
+  client::I2PControlResponse response;
+  response.SetMethod(Method::Echo);
+  // Set common params
+  response.SetID(m_ID);
+  // Set specific params
+  response.SetParam(Echo::Result, m_EchoMessage);
+  // Check output
+  BOOST_CHECK_EQUAL(response.ToJsonString(), m_EchoResponse);
+}
+
+BOOST_AUTO_TEST_CASE(ReadEchoResponse)
+{
+  Response response;
+  std::stringstream stream(m_EchoResponse);
+  // Parse
+  BOOST_CHECK_NO_THROW(response.Parse(Method::Echo, stream));
+  // Check params
+  BOOST_CHECK_EQUAL(response.GetVersion(), m_Version);
+  BOOST_CHECK_EQUAL(boost::get<decltype(m_ID)>(response.GetID()), m_ID);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(Echo::Result), m_EchoMessage);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(I2PControlControlTest, I2PControlControlFixture)
+
+// I2PControl Request
+BOOST_AUTO_TEST_CASE(WriteI2PControlRequest)
+{
+  Request request;
+  // Set common params
+  request.SetID(m_ID);
+  request.SetMethod(Method::I2PControl);
+  request.SetToken(m_Token);
+  // Set specific params
+  request.SetParam(I2PControl::Address, m_Address);
+  request.SetParam(I2PControl::Password, m_Password);
+  request.SetParam(I2PControl::Port, m_Port);
+  // Check output
+  BOOST_CHECK_EQUAL(request.ToJsonString(), m_I2PControlRequest);
+}
+
+BOOST_AUTO_TEST_CASE(ReadI2PControlRequest)
+{
+  Request request;
+  std::stringstream stream(m_I2PControlRequest);
+  // Parse
+  BOOST_CHECK_NO_THROW(request.Parse(stream));
+  // Check params
+  BOOST_CHECK_EQUAL(request.GetVersion(), m_Version);
+  BOOST_CHECK_EQUAL(boost::get<decltype(m_ID)>(request.GetID()), m_ID);
+  BOOST_CHECK_EQUAL(request.GetToken(), m_Token);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(I2PControl::Address), m_Address);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(I2PControl::Password), m_Password);
+  BOOST_CHECK_EQUAL(request.GetParam<std::string>(I2PControl::Port), m_Port);
+}
+
+// I2PControl Response
+BOOST_AUTO_TEST_CASE(WriteI2PControlResponse)
+{
+  client::I2PControlResponse response;
+  response.SetID(m_ID);
+  std::string empty;
+  response.SetMethod(Method::I2PControl);
+  // Set specific params
+  response.SetParam(I2PControl::Address, empty);
+  response.SetParam(I2PControl::Password, empty);
+  response.SetParam(I2PControl::Port, empty);
+  response.SetParam(I2PControl::SettingsSaved, true);
+  response.SetParam(I2PControl::RestartNeeded, false);
+  // Check Output
+  BOOST_CHECK_EQUAL(response.ToJsonString(), m_I2PControlResponse);
+}
+
+BOOST_AUTO_TEST_CASE(ReadI2PControlResponse)
+{
+  Response response;
+  std::stringstream stream(m_I2PControlResponse);
+  // Parse
+  BOOST_CHECK_NO_THROW(response.Parse(Method::I2PControl, stream));
+  // Check params
+  std::string empty;
+  BOOST_CHECK_EQUAL(response.GetVersion(), m_Version);
+  BOOST_CHECK_EQUAL(boost::get<decltype(m_ID)>(response.GetID()), m_ID);
+  BOOST_CHECK_EQUAL(response.GetParam<std::string>(I2PControl::Address), empty);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(I2PControl::Password), empty);
+  BOOST_CHECK_EQUAL(response.GetParam<std::string>(I2PControl::Port), empty);
+  BOOST_CHECK_EQUAL(response.GetParam<bool>(I2PControl::SettingsSaved), true);
+  BOOST_CHECK_EQUAL(response.GetParam<bool>(I2PControl::RestartNeeded), false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(I2PControlRouterInfoTest, I2PControlRouterInfoFixture)
+
+// RouterInfo Request
+BOOST_AUTO_TEST_CASE(WriteRouterInfoRequest)
+{
+  Request request;
+  // Set common params
+  request.SetID(m_ID);
+  request.SetMethod(Method::RouterInfo);
+  request.SetToken(m_Token);
+  // Set all specific params to null
+  std::string empty;
+  for (auto i(core::GetType(RouterInfo::Status));
+       i <= core::GetType(RouterInfo::TunnelsOutList);
+       i++)
+    request.SetParam(i, empty);
+  // Check output
+  BOOST_CHECK_EQUAL(request.ToJsonString(), m_RouterInfoRequest);
+}
+
+BOOST_AUTO_TEST_CASE(ReadRouterInfoRequest)
+{
+  Request request;
+  std::stringstream stream(m_RouterInfoRequest);
+  // Parse
+  BOOST_CHECK_NO_THROW(request.Parse(stream));
+  // Check params
+  BOOST_CHECK_EQUAL(request.GetVersion(), m_Version);
+  BOOST_CHECK_EQUAL(boost::get<decltype(m_ID)>(request.GetID()), m_ID);
+  BOOST_CHECK_EQUAL(request.GetToken(), m_Token);
+  std::string empty;
+  for (auto i(core::GetType(RouterInfo::Status));
+       i <= core::GetType(RouterInfo::TunnelsOutList);
+       i++)
+    BOOST_CHECK_EQUAL(request.GetParam<std::string>(i), empty);
+}
+
+// RouterInfo Response
+BOOST_AUTO_TEST_CASE(WriteRouterInfoResponse)
+{
+  client::I2PControlResponse response;
+  response.SetID(m_ID);
+  response.SetMethod(Method::RouterInfo);
+  // Set specific params
+  std::string empty;
+  response.SetParam(RouterInfo::Status, m_Status);
+  response.SetParam(RouterInfo::Uptime, m_Uptime);
+  response.SetParam(RouterInfo::Version, m_KovriVersion);
+  response.SetParam(RouterInfo::BWIn1S, m_BWIn1S);
+  response.SetParam(RouterInfo::BWIn15S, m_BWIn15S);
+  response.SetParam(RouterInfo::BWOut1S, m_BWOut1S);
+  response.SetParam(RouterInfo::BWOut15S, m_BWOut15S);
+  response.SetParam(RouterInfo::NetStatus, std::size_t(m_NetStatus));
+  response.SetParam(RouterInfo::TunnelsParticipating, m_Participants);
+  response.SetParam(RouterInfo::ActivePeers, m_ActivePeers);
+  response.SetParam(RouterInfo::FastPeers, m_FastPeers);
+  response.SetParam(RouterInfo::HighCapacityPeers, m_HighCapPeers);
+  response.SetParam(RouterInfo::IsReseeding, false);
+  response.SetParam(RouterInfo::KnownPeers, m_KnownPeers);
+  response.SetParam(RouterInfo::DataPath, m_DataPath);
+  response.SetParam(RouterInfo::Floodfills, m_Floodfills);
+  response.SetParam(RouterInfo::LeaseSets, m_LeaseSets);
+  response.SetParam(
+      RouterInfo::TunnelsCreationSuccessRate, m_TunnelsCreationSuccessRate);
+  response.SetParam(RouterInfo::TunnelsInList, client::JsonObject());
+  response.SetParam(RouterInfo::TunnelsOutList, m_Json);
+  // Check output
+  BOOST_CHECK_EQUAL(response.ToJsonString(), m_RouterInfoResponse);
+}
+
+BOOST_AUTO_TEST_CASE(ReadRouterInfoResponse)
+{
+  Response response;
+  std::stringstream stream(m_RouterInfoResponse);
+  // Parse
+  BOOST_CHECK_NO_THROW(response.Parse(Method::RouterInfo, stream));
+  // Check common params
+  std::string empty;
+  BOOST_CHECK_EQUAL(response.GetVersion(), m_Version);
+  BOOST_CHECK_EQUAL(boost::get<decltype(m_ID)>(response.GetID()), m_ID);
+  // Check specific params
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(RouterInfo::Status), m_Status);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::size_t>(RouterInfo::Uptime), m_Uptime);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(RouterInfo::Version), m_KovriVersion);
+  BOOST_CHECK_EQUAL(response.GetParam<double>(RouterInfo::BWIn1S), m_BWIn1S);
+  BOOST_CHECK_EQUAL(response.GetParam<double>(RouterInfo::BWIn15S), m_BWIn15S);
+  BOOST_CHECK_EQUAL(response.GetParam<double>(RouterInfo::BWOut1S), m_BWOut1S);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<double>(RouterInfo::BWOut15S), m_BWOut15S);
+  BOOST_CHECK(
+      response.NetStatusFromLong(
+          response.GetParam<std::size_t>(RouterInfo::NetStatus))
+      == m_NetStatus);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::size_t>(RouterInfo::TunnelsParticipating),
+      m_Participants);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::size_t>(RouterInfo::ActivePeers), m_ActivePeers);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::size_t>(RouterInfo::FastPeers), m_FastPeers);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::size_t>(RouterInfo::HighCapacityPeers),
+      m_HighCapPeers);
+  BOOST_CHECK_EQUAL(response.GetParam<bool>(RouterInfo::IsReseeding), false);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::size_t>(RouterInfo::KnownPeers), m_KnownPeers);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(RouterInfo::DataPath), m_DataPath);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::size_t>(RouterInfo::Floodfills), m_Floodfills);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::size_t>(RouterInfo::LeaseSets), m_LeaseSets);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<double>(RouterInfo::TunnelsCreationSuccessRate),
+      m_TunnelsCreationSuccessRate);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<client::JsonObject>(RouterInfo::TunnelsInList),
+      client::JsonObject());
+  BOOST_CHECK_EQUAL(
+      response.GetParam<client::JsonObject>(RouterInfo::TunnelsOutList),
+      m_Json);
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(
+    I2PControlRouterManagerTest,
+    I2PControlRouterManagerFixture)
+
+// RouterManager Request
+BOOST_AUTO_TEST_CASE(WriteRouterManagerRequest)
+{
+  Request request;
+  // Set common params
+  request.SetID(m_ID);
+  request.SetMethod(Method::RouterManager);
+  request.SetToken(m_Token);
+  // Set specific params
+  std::string empty;
+  request.SetParam(RouterManager::FindUpdates, empty);
+  request.SetParam(RouterManager::Reseed, empty);
+  request.SetParam(RouterManager::Restart, empty);
+  request.SetParam(RouterManager::RestartGraceful, empty);
+  request.SetParam(RouterManager::Shutdown, empty);
+  request.SetParam(RouterManager::ShutdownGraceful, empty);
+  request.SetParam(RouterManager::Update, empty);
+  // Check output
+  BOOST_CHECK_EQUAL(request.ToJsonString(), m_RouterManagerRequest);
+}
+
+BOOST_AUTO_TEST_CASE(ReadRouterManagerRequest)
+{
+  Request request;
+  std::stringstream stream(m_RouterManagerRequest);
+  // Parse
+  BOOST_CHECK_NO_THROW(request.Parse(stream));
+  // Check params
+  std::string empty;
+  BOOST_CHECK_EQUAL(request.GetVersion(), m_Version);
+  BOOST_CHECK_EQUAL(request.GetToken(), m_Token);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(RouterManager::Shutdown), empty);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(RouterManager::ShutdownGraceful), empty);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(RouterManager::Reseed), empty);
+}
+
+// RouterManager Response
+BOOST_AUTO_TEST_CASE(WriteRouterManagerResponse)
+{
+  client::I2PControlResponse response;
+  response.SetID(m_ID);
+  std::string empty;
+  response.SetMethod(Method::RouterManager);
+  // Set specific params
+  response.SetParam(RouterManager::FindUpdates, false);
+  response.SetParam(RouterManager::Reseed, empty);
+  response.SetParam(RouterManager::Restart, empty);
+  response.SetParam(RouterManager::RestartGraceful, empty);
+  response.SetParam(RouterManager::Shutdown, empty);
+  response.SetParam(RouterManager::ShutdownGraceful, empty);
+  response.SetParam(RouterManager::Update, m_StatusUpdate);
+  // Check output
+  BOOST_CHECK_EQUAL(response.ToJsonString(), m_RouterManagerResponse);
+}
+
+BOOST_AUTO_TEST_CASE(ReadRouterManagerResponse)
+{
+  Response response;
+  std::stringstream stream(m_RouterManagerResponse);
+  // Parse
+  BOOST_CHECK_NO_THROW(response.Parse(Method::RouterManager, stream));
+  // Check params
+  std::string empty;
+  BOOST_CHECK_EQUAL(response.GetVersion(), m_Version);
+  BOOST_CHECK_EQUAL(boost::get<decltype(m_ID)>(response.GetID()), m_ID);
+  BOOST_CHECK_EQUAL(response.GetParam<bool>(RouterManager::FindUpdates), false);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(RouterManager::Reseed), empty);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(RouterManager::Restart), empty);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(RouterManager::RestartGraceful), empty);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(RouterManager::Shutdown), empty);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(RouterManager::ShutdownGraceful), empty);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(RouterManager::Update), m_StatusUpdate);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(
+    I2PControlNetworkSettingTest,
+    I2PControlNetworkSettingFixture)
+
+// NetworkSetting Request
+BOOST_AUTO_TEST_CASE(WriteNetworkSettingRequest)
+{
+  Request request;
+  // Set common params
+  request.SetID(m_ID);
+  request.SetMethod(Method::NetworkSetting);
+  request.SetToken(m_Token);
+  // Set specific params
+  request.SetParam(NetworkSetting::NTCPPort, m_NTCPPort);
+  request.SetParam(NetworkSetting::NTCPHostName, m_NTCPHostName);
+  request.SetParam(NetworkSetting::NTCPAutoIP, m_NTCPAutoIP);
+  request.SetParam(NetworkSetting::SSUPort, m_SSUPort);
+  request.SetParam(NetworkSetting::SSUHostName, m_SSUHostName);
+  request.SetParam(NetworkSetting::SSUAutoIP, m_SSUAutoIP);
+  request.SetParam(NetworkSetting::SSUDetectedIP, std::string());
+  request.SetParam(NetworkSetting::UPnP, m_UPnP);
+  request.SetParam(NetworkSetting::BWShare, m_BWShare);
+  request.SetParam(NetworkSetting::BWIn, m_BWIn);
+  request.SetParam(NetworkSetting::BWOut, m_BWOut);
+  request.SetParam(NetworkSetting::LaptopMode, m_LaptopMode);
+  // Check output
+  BOOST_CHECK_EQUAL(request.ToJsonString(), m_NetworkSettingRequest);
+}
+
+BOOST_AUTO_TEST_CASE(ReadNetworkSettingRequest)
+{
+  Request request;
+  std::stringstream stream(m_NetworkSettingRequest);
+  // Parse
+  BOOST_CHECK_NO_THROW(request.Parse(stream));
+  // Check common params
+  std::string empty;
+  BOOST_CHECK_EQUAL(request.GetVersion(), m_Version);
+  BOOST_CHECK_EQUAL(boost::get<decltype(m_ID)>(request.GetID()), m_ID);
+  BOOST_CHECK_EQUAL(request.GetToken(), m_Token);
+  // Check Specific params
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(NetworkSetting::NTCPPort), m_NTCPPort);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(NetworkSetting::NTCPHostName),
+      m_NTCPHostName);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(NetworkSetting::NTCPAutoIP), m_NTCPAutoIP);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(NetworkSetting::SSUPort), m_SSUPort);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(NetworkSetting::SSUHostName),
+      m_SSUHostName);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(NetworkSetting::SSUAutoIP), m_SSUAutoIP);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(NetworkSetting::SSUDetectedIP),
+      std::string());
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(NetworkSetting::UPnP), m_UPnP);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(NetworkSetting::BWShare), m_BWShare);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(NetworkSetting::BWIn), m_BWIn);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(NetworkSetting::BWOut), m_BWOut);
+  BOOST_CHECK_EQUAL(
+      request.GetParam<std::string>(NetworkSetting::LaptopMode), m_LaptopMode);
+}
+
+// NetworkSetting Response
+BOOST_AUTO_TEST_CASE(WriteNetworkSettingResponse)
+{
+  client::I2PControlResponse response;
+  response.SetID(m_ID);
+  response.SetMethod(Method::NetworkSetting);
+  // Set specific params
+  response.SetParam(NetworkSetting::NTCPPort, m_NTCPPort);
+  response.SetParam(NetworkSetting::NTCPHostName, m_NTCPHostName);
+  response.SetParam(NetworkSetting::NTCPAutoIP, m_NTCPAutoIP);
+  response.SetParam(NetworkSetting::SSUPort, m_SSUPort);
+  response.SetParam(NetworkSetting::SSUHostName, m_SSUHostName);
+  response.SetParam(NetworkSetting::SSUAutoIP, m_SSUAutoIP);
+  response.SetParam(NetworkSetting::SSUDetectedIP, m_Address);
+  response.SetParam(NetworkSetting::UPnP, m_UPnP);
+  response.SetParam(NetworkSetting::BWShare, m_BWShare);
+  response.SetParam(NetworkSetting::BWIn, m_BWIn);
+  response.SetParam(NetworkSetting::BWOut, m_BWOut);
+  response.SetParam(NetworkSetting::LaptopMode, m_LaptopMode);
+  response.SetParam(NetworkSetting::SettingsSaved, true);
+  response.SetParam(NetworkSetting::RestartNeeded, false);
+  // Check output
+  BOOST_CHECK_EQUAL(response.ToJsonString(), m_NetworkSettingResponse);
+}
+
+BOOST_AUTO_TEST_CASE(ReadNetworkSettingResponse)
+{
+  Response response;
+  std::stringstream stream(m_NetworkSettingResponse);
+  // Parse
+  BOOST_CHECK_NO_THROW(response.Parse(Method::NetworkSetting, stream));
+  // Check common params
+  BOOST_CHECK_EQUAL(response.GetVersion(), m_Version);
+  BOOST_CHECK_EQUAL(boost::get<decltype(m_ID)>(response.GetID()), m_ID);
+  // Check specific params
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(NetworkSetting::NTCPPort), m_NTCPPort);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(NetworkSetting::NTCPHostName),
+      m_NTCPHostName);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(NetworkSetting::NTCPAutoIP), m_NTCPAutoIP);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(NetworkSetting::SSUPort), m_SSUPort);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(NetworkSetting::SSUHostName),
+      m_SSUHostName);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(NetworkSetting::SSUAutoIP), m_SSUAutoIP);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(NetworkSetting::SSUDetectedIP), m_Address);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(NetworkSetting::UPnP), m_UPnP);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(NetworkSetting::BWShare), m_BWShare);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(NetworkSetting::BWIn), m_BWIn);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(NetworkSetting::BWOut), m_BWOut);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<std::string>(NetworkSetting::LaptopMode), m_LaptopMode);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<bool>(NetworkSetting::SettingsSaved), true);
+  BOOST_CHECK_EQUAL(
+      response.GetParam<bool>(NetworkSetting::RestartNeeded), false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/anonimal/kovri-docs/blob/master/developer/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---
Ref #399 #383 

Here are some runtime examples : 

    #!/bin/bash

    # Shortcuts
    ./build/kovri-util control status $@
    ./build/kovri-util control version $@
    ./build/kovri-util control uptime $@
    ./build/kovri-util control reseed $@
    # Implemented but seems buggy
    # ./build/kovri-util control shutdown $@
    # ./build/kovri-util control force-shutdown $@

    # Echo
    ./build/kovri-util control --method Echo --key Echo --value blablaezefzefzefzefzfefzf $@

    # RouterInfo
    ./build/kovri-util control --method RouterInfo --key i2p.router.status $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.version $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.uptime $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.net.bw.inbound.1s $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.net.bw.inbound.15s $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.net.bw.outbound.1s $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.net.bw.outbound.15s $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.net.status $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.net.tunnels.participating $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.netdb.activepeers $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.netdb.fastpeers $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.netdb.highcapacitypeers $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.netdb.isreseeding $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.netdb.knownpeers $@

    # RouterInfo extra options
    ./build/kovri-util control --method RouterInfo --key i2p.router.datapath $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.netdb.floodfills $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.netdb.leasesets $@
    ./build/kovri-util control --method RouterInfo --key i2p.router.net.tunnels.creationsuccessrate $@

    # The next 2 are fully implemented but segfaults server side (probably because their use is not protected with a mutex )
    #./build/kovri-util control --method RouterInfo --key i2p.router.net.tunnels.inbound.list $@
    #./build/kovri-util control --method RouterInfo --key i2p.router.net.tunnels.outbound.list $@
