### PR TITLE
NTCPSession: fix max message size + Phase1/SessionRequest refactoring + trace log (Phase1/Phase2)/hex formatting cleanup

### DIFF
--- a/src/core/crypto/diffie_hellman.h
+++ b/src/core/crypto/diffie_hellman.h
@@ -31,11 +31,26 @@
 #ifndef SRC_CORE_CRYPTO_DIFFIE_HELLMAN_H_
 #define SRC_CORE_CRYPTO_DIFFIE_HELLMAN_H_
 
+#include <array>
 #include <memory>
 #include <cstdint>
 
 namespace kovri {
 namespace core {
+
+enum DHKeySize : std::uint16_t
+{
+  PubKey = 256,
+  PrivKey = 256,
+};
+
+/// @class DHKeysPair
+/// @brief Transient keys for transport sessions
+struct DHKeysPair
+{
+  std::array<std::uint8_t, DHKeySize::PubKey> public_key {{}};
+  std::array<std::uint8_t, DHKeySize::PrivKey> private_key {{}};
+};
 
 /// @class DiffieHellman
 /// @brief Diffie-Hellman

--- a/src/core/router/transports/ntcp/server.cc
+++ b/src/core/router/transports/ntcp/server.cc
@@ -213,7 +213,7 @@ void NTCPServer::HandleConnect(
   LOG(debug) << "NTCPServer: connected to " << socket.remote_endpoint();
   if (socket.local_endpoint().protocol() == boost::asio::ip::tcp::v6())
     context.UpdateNTCPV6Address(socket.local_endpoint().address());
-  conn->ClientLogin();
+  conn->StartClientSession();
   m_Service.post([conn, this]() {
       this->AddNTCPSession(conn);
   });

--- a/src/core/router/transports/ntcp/session.cc
+++ b/src/core/router/transports/ntcp/session.cc
@@ -120,7 +120,8 @@ void NTCPSession::SendPhase1()
       LOG(debug) << "NTCPSession:" << GetFormattedSessionInfo()
                  << "*** Phase1, acquiring DH keys pair";
       m_DHKeysPair = transports.GetNextDHKeysPair();
-      // TODO(anonimal): throw if null
+      if (!m_DHKeysPair)
+        throw std::runtime_error("acquired null DH keypair");
     }
 
   // X as calculated from Diffie-Hellman

--- a/src/core/router/transports/ntcp/session.h
+++ b/src/core/router/transports/ntcp/session.h
@@ -266,7 +266,7 @@ class NTCPSession
 
   /// @enum NTCPSize
   enum NTCPSize : std::uint16_t {
-    PubKey     = 256,  // DH (X, Y)
+    PubKey     = DHKeySize::PubKey,  // DH (X, Y)
     Hash        = 32,
     Padding     = 12,
     SessionKey = 32,

--- a/src/core/router/transports/ntcp/session.h
+++ b/src/core/router/transports/ntcp/session.h
@@ -87,7 +87,8 @@ class NTCPSession
     return m_IsEstablished;
   }
 
-  void ClientLogin();
+  /// @brief Starts client NTCP session (local router -> external router)
+  void StartClientSession();
 
   void ServerLogin();
 
@@ -154,6 +155,10 @@ class NTCPSession
   void CreateAESKey(
       std::uint8_t* pub_key,
       kovri::core::AESKey& key);
+
+  // TODO(anonimal): simplify phase impl/handler
+
+  void SendPhase1();
 
   // Client
   void SendPhase3();

--- a/src/core/router/transports/ntcp/session.h
+++ b/src/core/router/transports/ntcp/session.h
@@ -288,7 +288,7 @@ class NTCPSession
       Phase3AliceTS +
       Phase3Padding +
       Phase3Signature,  // Total = 448
-    MaxMessage = 16384,
+    MaxMessage = 16378,  // Spec defined as 16 KB - 6 (16378 bytes)
     Buffer = 4160,  // fits 4 tunnel messages (4 * 1028)
   };
 

--- a/src/core/router/transports/ntcp/session.h
+++ b/src/core/router/transports/ntcp/session.h
@@ -255,7 +255,7 @@ class NTCPSession
   enum struct Phase : std::uint8_t { One, Two, Three, Four };
 
   /// @brief Returns phase info
-  const std::string GetFormattedPhaseInfo(const Phase& num);
+  const std::string GetFormattedPhaseInfo(Phase num);
 
  private:
   std::string m_RemoteIdentHashAbbreviation;

--- a/src/core/router/transports/ntcp/session.h
+++ b/src/core/router/transports/ntcp/session.h
@@ -296,7 +296,10 @@ class NTCPSession
   // If so, should we not be consistent with other protocols?
   #pragma pack(1)
   struct NTCPPhase1 {
+    // @brief Diffie-Hellman X
     std::array<std::uint8_t, NTCPSize::PubKey> pub_key;
+
+    /// @brief Hash of DH-X XOR'd with Bob's Ident Hash
     std::array<std::uint8_t, NTCPSize::Hash> HXxorHI;
   };
 
@@ -316,6 +319,9 @@ class NTCPSession
   };
 
   std::unique_ptr<Establisher> m_Establisher;
+
+  /// @brief Hash of Diffie-Hellman X
+  std::array<std::uint8_t, NTCPSize::Hash> m_HX;
 
   kovri::core::AESAlignedBuffer<NTCPSize::Buffer + NTCPSize::IV> m_ReceiveBuffer;
   kovri::core::AESAlignedBuffer<NTCPSize::IV> m_TimeSyncBuffer;

--- a/src/core/router/transports/session.h
+++ b/src/core/router/transports/session.h
@@ -43,13 +43,10 @@
 #include "core/router/identity.h"
 #include "core/router/info.h"
 
+#include "core/crypto/diffie_hellman.h"
+
 namespace kovri {
 namespace core {
-
-struct DHKeysPair {  // transient keys for transport sessions
-  std::array<std::uint8_t, 256> public_key;
-  std::array<std::uint8_t, 256> private_key;
-};
 
 class SignedData {
  public:

--- a/src/core/util/byte_stream.cc
+++ b/src/core/util/byte_stream.cc
@@ -151,19 +151,29 @@ std::size_t OutputByteStream::GetSize() const {
 
 // Hex
 
-const std::string GetFormattedHex(const std::uint8_t* data, std::size_t size) {
+const std::string GetFormattedHex(const std::uint8_t* data, std::size_t size)
+{
   std::ostringstream hex;
-  std::size_t count = 0;
-  for (std::size_t i = 0; i < size; i++) {
-    hex << std::hex << std::setfill('0') << std::setw(2) << static_cast<std::uint16_t>(data[i]) << " ";
-    count++;
-    if (count == 8) {
-      hex.put('|');
-      hex.put(' ');
-      count = 0;
+  hex << "\n\t" << " |  ";
+  std::size_t count{}, sub_count{};
+  for (std::size_t i = 0; i < size; i++)
+    {
+      hex << std::hex << std::setfill('0') << std::setw(2)
+          << static_cast<std::uint16_t>(data[i]) << " ";
+      count++;
+      if (count == 32 || (i == size - 1))
+        {
+          hex << " |" << "\n\t";
+          count = 0;
+        }
+      sub_count++;
+      if (sub_count == 8 && (i != size - 1))
+        {
+          hex << " |  ";
+          sub_count = 0;
+        }
     }
-  }
-  return hex.str();
+  return hex.str() + "\n";
 }
 
 std::unique_ptr<std::vector<std::uint8_t>> AddressToByteVector(


### PR DESCRIPTION
WIP. Refs #352.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

