### PR TITLE
Crypto/NTCP: annotate/refactor AES-256 expanded keysize + Phase2 Bob's IV offset

### DIFF
--- a/src/core/crypto/aes.h
+++ b/src/core/crypto/aes.h
@@ -39,6 +39,9 @@
 
 #include "core/router/identity.h"
 
+// FIPS 197 (AES)
+// http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.197.pdf
+
 namespace kovri {
 namespace core {
 
@@ -76,6 +79,26 @@ struct CipherBlock {
 };
 
 typedef kovri::core::Tag<32> AESKey;
+
+/// @enum AESSize
+/// @brief Sizes for, specifically, AES-256
+enum AESSize : std::uint8_t
+{
+  /// @brief 32-bit word
+  W = 32,
+
+  /// @brief Number of columns in state
+  Nb = 4,
+
+  /// @brief Number of columns in cipher key
+  Nk = 8,
+
+  /// @brief Number of rounds
+  Nr = 14,
+
+  /// @brief W*Nb*(Nr+1)/Nk (i.e., 60-word schedule / Nk = 7.5 rounds of expansion)
+  ExpandedKey = W * Nb * (Nr + 1) / Nk,  // 240 bytes
+};
 
 template<std::size_t Size>
 class AESAlignedBuffer {  // 16 bytes alignment

--- a/src/core/crypto/impl/cryptopp/aes.cc
+++ b/src/core/crypto/impl/cryptopp/aes.cc
@@ -126,7 +126,7 @@ class ECBCryptoAESNI {
 #endif
 
  private:
-  AESAlignedBuffer<240> m_KeySchedule;  // 14 rounds for AES-256, 240 bytes
+  AESAlignedBuffer<AESSize::ExpandedKey> m_KeySchedule;
 };
 
 /**

--- a/src/core/router/transports/ntcp/session.cc
+++ b/src/core/router/transports/ntcp/session.cc
@@ -222,8 +222,7 @@ void NTCPSession::HandlePhase2Received(
     kovri::core::AESKey aes_key;
     CreateAESKey(m_Establisher->phase2.pub_key.data(), aes_key);
     m_Decryption.SetKey(aes_key);
-    // TODO(unassigned): document 240
-    m_Decryption.SetIV(m_Establisher->phase2.pub_key.data() + 240);
+    m_Decryption.SetIV(m_Establisher->phase2.pub_key.data() + NTCPSize::Phase2BobIVOffset);
     m_Encryption.SetKey(aes_key);
     m_Encryption.SetIV(m_Establisher->phase1.HXxorHI.data() + NTCPSize::IV);
     m_Decryption.Decrypt(
@@ -590,7 +589,7 @@ void NTCPSession::SendPhase2() {
     kovri::core::AESKey aes_key;
     CreateAESKey(m_Establisher->phase1.pub_key.data(), aes_key);
     m_Encryption.SetKey(aes_key);
-    m_Encryption.SetIV(y + 240);
+    m_Encryption.SetIV(y + NTCPSize::Phase2BobIVOffset);
     m_Decryption.SetKey(aes_key);
     m_Decryption.SetIV(m_Establisher->phase1.HXxorHI.data() + NTCPSize::IV);
     m_Encryption.Encrypt(

--- a/src/core/router/transports/ntcp/session.h
+++ b/src/core/router/transports/ntcp/session.h
@@ -277,6 +277,7 @@ class NTCPSession
     SessionKey = 32,
     IV          = 16,
     Adler32     = 4,
+    Phase2BobIVOffset = AESSize::ExpandedKey,
     // TODO(unassigned):
     // Through release of java 0.9.15, the router identity was always 387 bytes,
     // the signature was always a 40 byte DSA signature, and the padding was always 15 bytes.


### PR DESCRIPTION
WIP. Refs #352.

**Edit**: also referencing #285.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

