### PR TITLE
Testnet: add new container for build

### DIFF
--- a/contrib/docker/Dockerfile_dev
+++ b/contrib/docker/Dockerfile_dev
@@ -1,0 +1,49 @@
+# Copyright (c) 2015-2017, The Kovri I2P Router Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FROM alpine:3.6
+
+RUN apk add --update --no-cache \
+      binutils \
+      boost \
+      boost-date_time \
+      boost-dev \
+      boost-program_options \
+      boost-system \
+      boost-unit_test_framework \
+      cmake \
+      g++ \
+      libressl-dev \
+      make \
+      iptables \
+      gdb \
+      && \ 
+      adduser -D kovri && \
+      chown -R kovri:kovri /home/kovri
+
+USER kovri

--- a/contrib/docker/testnet.sh
+++ b/contrib/docker/testnet.sh
@@ -41,17 +41,14 @@ seq_start=10  # Not 0 because of port assignments, not 1 because we can't use IP
 seq_end=$((${seq_start} + 19))  # TODO(unassigned): arbitrary end amount
 sequence="seq -f "%03g" ${seq_start} ${seq_end}"
 
-#Note: this can avoid to rebuild the docker image
-#custom_build_dir="-v /home/user/kovri/build/kovri:/usr/bin/kovri -v /home/user/kovri/build/kovri-util:/usr/bin/kovri-util"
-
 reseed_file="reseed.zip"
 
 PrintUsage()
 {
-  echo "Usage: $ $0 {create|start|stop|destroy}" >&2
+  echo "Usage: $ $0 {create|start|stop|destroy|exec}" >&2
 }
 
-if [ "$#" -ne 1 ]
+if [[ $# -lt 1 ]]
 then
   PrintUsage
   exit 1
@@ -74,6 +71,7 @@ Prepare()
   # Set environment
   set_repo
   set_image
+  set_bins
   set_workspace
   set_args
   set_network
@@ -99,6 +97,22 @@ set_repo()
   if [[ ! -d $KOVRI_REPO ]]; then
     false
     catch "Kovri not found. See building instructions."
+  fi
+}
+
+set_bins()
+{
+  read_bool_input "Use binaries from repo?" KOVRI_USE_REPO_BINS ""
+
+  if [[ $KOVRI_USE_REPO_BINS = true ]];then
+    echo "Using binaries in ${KOVRI_REPO}/build"
+    mount_repo_bins="-v ${KOVRI_REPO}/build/kovri:/usr/bin/kovri \
+      -v ${KOVRI_REPO}/build/kovri-util:/usr/bin/kovri-util"
+
+    read_bool_input "Build repo binaries?" KOVRI_BUILD_REPO_BINS "Exec make release-static"
+    if [[ $KOVRI_BUILD_REPO_BINS = false ]];then
+      echo "Please ensure that the binaries are built statically if not built within a container"
+    fi
   fi
 }
 
@@ -129,7 +143,16 @@ set_image()
     KOVRI_IMAGE=${_default_image}
   fi
 
-  read_input "Build Kovri Docker image? [$KOVRI_IMAGE]" NULL "docker build -t $KOVRI_IMAGE $KOVRI_REPO"
+  # Select Dockerfile
+  local _default_dockerfile="Dockerfile_dev"
+  if [[ -z $KOVRI_DOCKERFILE ]]; then
+    KOVRI_DOCKERFILE=${_default_dockerfile}
+    read_input "Change Dockerfile?: [KOVRI_DOCKERFILE=${KOVRI_DOCKERFILE}]" KOVRI_DOCKERFILE
+  fi
+
+  local _dockerfile_path="${KOVRI_REPO}/contrib/docker/${KOVRI_DOCKERFILE}"
+
+  read_input "Build Kovri Docker image? [$KOVRI_IMAGE]" NULL "docker build -t $KOVRI_IMAGE -f $_dockerfile_path $KOVRI_REPO"
   popd
 }
 
@@ -235,7 +258,7 @@ Create()
     local _volume="${KOVRI_WORKSPACE}/${_dir}:${_mount}"
     docker run -w $_mount -it --rm \
       -v $_volume \
-      $custom_build_dir \
+      $mount_repo_bins \
       $KOVRI_IMAGE /usr/bin/kovri-util routerinfo --create \
         --host $_host \
         --port $_port \
@@ -252,7 +275,7 @@ Create()
       --ip $_host \
       -p ${_port}:${_port} \
       -v ${KOVRI_WORKSPACE}:/home/kovri/testnet \
-      $custom_build_dir \
+      $mount_repo_bins \
       $KOVRI_IMAGE /usr/bin/kovri \
       --data-dir /home/kovri/testnet/kovri_${_seq} \
       --reseed-from /home/kovri/testnet/${reseed_file} \
@@ -342,6 +365,17 @@ Destroy()
   docker network rm $KOVRI_NETWORK && echo "Removed network: $KOVRI_NETWORK"
 }
 
+Exec()
+{
+  docker run -i -t \
+    --rm \
+    -v $KOVRI_REPO:/home/kovri/kovri \
+    -w /home/kovri/kovri \
+    $KOVRI_IMAGE \
+    $@
+  catch "Docker: run failed"
+}
+
 # Error handler
 catch()
 {
@@ -371,6 +405,30 @@ read_input()
   esac
 }
 
+# Read boolean handler
+# $1 - message
+# $2 - varname to set
+# $3 - function or string to execute if var true
+read_bool_input()
+{
+  if [[ ! ${!2} ]]; then
+    read -r -p "$1 [Y/n] " REPLY
+    case $REPLY in
+      [nN])
+        eval ${2}=false
+        ;;
+      *)
+        eval ${2}=true
+        ;;
+    esac
+  fi
+
+  if [[ ${!2} = true ]];then
+    $3
+  fi
+}
+
+_args=($@)
 case "$1" in
   create)
     Prepare && Create && echo "Kovri testnet created"
@@ -383,6 +441,9 @@ case "$1" in
     ;;
   destroy)
     Destroy && echo "Kovri testnet destroyed"
+    ;;
+  exec)
+    set_repo && set_image && Exec "${_args[@]:1}"
     ;;
   *)
     PrintUsage

--- a/contrib/docker/testnet.sh
+++ b/contrib/docker/testnet.sh
@@ -65,7 +65,7 @@ Prepare()
 
   # Cleanup for new testnet
   if [[ $KOVRI_WORKSPACE || $KOVRI_NETWORK ]]; then
-    read_input "Kovri testnet environment detected. Attempt to destroy previous testnet?" NULL cleanup_testnet
+    read_bool_input "Kovri testnet environment detected. Attempt to destroy previous testnet?" KOVRI_CLEANUP cleanup_testnet
   fi
 
   # Set environment
@@ -152,7 +152,7 @@ set_image()
 
   local _dockerfile_path="${KOVRI_REPO}/contrib/docker/${KOVRI_DOCKERFILE}"
 
-  read_input "Build Kovri Docker image? [$KOVRI_IMAGE]" NULL "docker build -t $KOVRI_IMAGE -f $_dockerfile_path $KOVRI_REPO"
+  read_bool_input "Build Kovri Docker image? [$KOVRI_IMAGE]" KOVRI_BUILD_IMAGE "docker build -t $KOVRI_IMAGE -f $_dockerfile_path $KOVRI_REPO"
   popd
 }
 

--- a/contrib/docker/testnet.sh
+++ b/contrib/docker/testnet.sh
@@ -1,3 +1,31 @@
+# Copyright (c) 2015-2017, The Kovri I2P Router Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #!/bin/bash
 
 # Set constants


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

To avoid rebuilding the docker image for each git revision, the user can now choose to "Use binaries from repo" during testnet creation.

To rebuild the binaries:

    testnet.sh exec make

Or get a shell first:

    testnet.sh exec sh

and then

     make
