### PR TITLE
Config: add automatic log flushing option

### DIFF
--- a/pkg/config/kovri.conf
+++ b/pkg/config/kovri.conf
@@ -132,6 +132,17 @@ log-to-file = 1
 log-level = 3
 
 #
+#  Auto flush log
+#  ==============
+#
+#  1 = enabled, 0 = disabled
+#
+#  Default: 0
+#
+
+log-auto-flush = 0
+
+#
 #  Tunnels Config
 #  ==============
 #

--- a/src/app/config.cc
+++ b/src/app/config.cc
@@ -96,6 +96,8 @@ void Configuration::ParseKovriConfig() {
       // 5 = trace debug info warn error fatal
       "log-level",
       bpo::value<std::uint16_t>()->default_value(3))(
+      "log-auto-flush",
+      bpo::value<bool>()->default_value(false)->value_name("bool"))(
       "kovriconf,c",
       bpo::value<std::string>()->default_value("")->value_name("path"))(
       "tunnelsconf,t",

--- a/src/core/util/log.cc
+++ b/src/core/util/log.cc
@@ -122,9 +122,10 @@ void SetupLogging(const boost::program_options::variables_map& kovri_config)
               : kovri_config["log-file-name"].as<std::string>(),
       keywords::time_based_rotation =
           sinks::file::rotation_at_time_point(0, 0, 0));  // Rotate at midnight
-  // If debug/trace, enable auto flush to (try to) catch records right before segfault
-  if (severity <= logging::trivial::
-                      debug)  // Our severity levels are processed in reverse
+  // Auto flush for closer-to-real-time record message reporting
+  // Note: our severity levels are processed in reverse
+  if (severity <= logging::trivial::debug
+      || kovri_config["log-auto-flush"].as<bool>())
     file_backend->auto_flush();
   // Create file sink
   auto file_sink = boost::shared_ptr<text_file_sink>(

--- a/src/util/main.cc
+++ b/src/util/main.cc
@@ -87,7 +87,9 @@ int main(int argc, const char* argv[])
       bpo::value<bool>()->default_value(false)->value_name("bool"))(
       "log-file-name",
       bpo::value<std::string>()->default_value("")->value_name("path"))(
-      "log-level", bpo::value<std::uint16_t>()->default_value(3));
+      "log-level", bpo::value<std::uint16_t>()->default_value(3))(
+      "log-auto-flush",
+      bpo::value<bool>()->default_value(false)->value_name("bool"));
 
   bpo::options_description spec("Specific options");
   spec.add_options()(


### PR DESCRIPTION
Will be useful when logging lower levels to a named pipe and/or if
auto-flushing is simply desired at any lower level.


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

