### PR TITLE
Testnet : add optional firewalled instances

### DIFF
--- a/contrib/docker/fw_entrypoint.sh
+++ b/contrib/docker/fw_entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Copyright (c) 2015-2017, The Kovri I2P Router Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set -x
+
+# Allow i2pcontrol
+iptables -A INPUT -p tcp --dport 7650 -j ACCEPT
+# Allow response to outgoing packet
+iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+# Bloc every other inputs
+iptables -P INPUT DROP
+
+_args="$@"
+exec su kovri -s /bin/sh -c "$_args"

--- a/contrib/docker/testnet.sh
+++ b/contrib/docker/testnet.sh
@@ -38,8 +38,9 @@ gid="docker" # Assumes user is in docker group
 # TODO(unassigned): better sequencing impl
 #Note: sequence limit [2:254]
 seq_start=10  # Not 0 because of port assignments, not 1 because we can't use IP ending in .1 (assigned to gateway)
-seq_end=$((${seq_start} + 19))  # TODO(unassigned): arbitrary end amount
-sequence="seq -f "%03g" ${seq_start} ${seq_end}"
+seq_base_nb=${KOVRI_NB_BASE:-20}  # TODO(unassigned): arbitrary end amount
+seq_base_end=$((${seq_start} + ${seq_base_nb} - 1))
+sequence="seq -f "%03g" ${seq_start} ${seq_base_end}"
 
 reseed_file="reseed.zip"
 


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---
This PR introduces 2 new vars:

- KOVRI_NB_BASE: number of instances (exactly like previously setup)
- KOVRI_NB_FW: new instances that are not in the reseed file and that are firewalled (basic setup: block incoming, allow outgoing) . It's done by overwriting the `entrypoint` with the file in "contrib/docker/fw_entrypoint.sh" and some extra options to docker.

Ref #140 