### PR TITLE
README: remove mastodon.social point of contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Alpha release coming soon
 
 ## Contact
 - Twitter: [@getkovri](https://twitter.com/getkovri)
-- Mastodon: [@kovri@mastodon.social](https://mastodon.social)
 - Email:
   - General Purpose / Media Contact
     - dev [at] getmonero.org


### PR DESCRIPTION
RFC. Do we really need this? I think not.

The service appears useless. No better than GNU social - and has tighter speech restrictions.

Also, `@getkovri` on twitter gets 45 followers in just a couple of days but `@kovri@mastadon.social` only gets 2 (one a community member and the other appears to be a bot). Not to mention, mastodon keeps spamming my bitlbee with posts from instance admins of whom I'm not following.

In all, not worth maintaining IMHO but we can keep as 'reserved' account.

Referencing https://github.com/monero-project/meta/issues/113.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

