### PR TITLE
Testnet: implement webserver for subscription publishing

### DIFF
--- a/contrib/docker/Dockerfile.dev.apache
+++ b/contrib/docker/Dockerfile.dev.apache
@@ -1,0 +1,35 @@
+# Copyright (c) 2015-2017, The Kovri I2P Router Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FROM httpd:2.4
+
+# Note: we don't COPY because:
+#  - ServerName needs to be set at run-time
+#  - We want run-time generated testnet subscription file
+
+# TODO(unassigned): more?

--- a/contrib/docker/apache.entrypoint.sh
+++ b/contrib/docker/apache.entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2015-2017, The Kovri I2P Router Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set -e
+
+exec /bin/sh -c "$@"

--- a/pkg/config/kovri.conf
+++ b/pkg/config/kovri.conf
@@ -226,28 +226,30 @@ enable-ntcp = 1
 #  ./kovri --reseed-from https://my.server.tld/i2pseeds.su3
 #
 #  Note: if the server in your URL is not one of the hard-coded reseed servers,
-#  either use --reseed-skip-ssl-checkor or put your server's certificate into
+#  either use --enable-ssl 0 or or put your server's certificate into
 #  the certificates directory located in KOVRI_DATA_DIR
 #
 
 #reseed-from =
 
 #
-#  Skip SSL check for reseed host
-#  ==============================
+#  Enable SSL
+#  ===========
 #
-#  Useful for custom reseed servers
+#  WARNING: DO NOT DISABLE UNLESS YOU KNOW WHAT YOU'RE DOING!
+#
+#  Useful for custom reseed servers and/or custom subscription publishers
 #
 #  Examples:
 #
-#  ./kovri --reseed-skip-ssl-check --reseed-from https://my.server.tld/i2pseeds.su3
+#  ./kovri --enable-ssl 0 --reseed-from https://my.server.tld/i2pseeds.su3
 #
 #  1 = enabled, 0 = disabled
 #
 #  Default: 0
 #
 
-#reseed-skip-ssl-check = 0
+#enable-ssl = 1
 
 #######################
 ###                 ###

--- a/src/app/config.cc
+++ b/src/app/config.cc
@@ -115,8 +115,8 @@ void Configuration::ParseKovriConfig() {
       "enable-ntcp",
       bpo::value<bool>()->default_value(true)->value_name("bool"))(
       "reseed-from,r", bpo::value<std::string>()->default_value(""))(
-      "reseed-skip-ssl-check",
-      bpo::value<bool>()->default_value(false)->value_name("bool"))(
+      "enable-ssl",
+      bpo::value<bool>()->default_value(true)->value_name("bool"))(
       "disable-su3-verification",
       bpo::value<bool>()->default_value(false)->value_name("bool"));
 

--- a/src/app/instance.cc
+++ b/src/app/instance.cc
@@ -116,12 +116,13 @@ void Instance::InitRouterContext() {
   }
   // Set reseed options
   context.SetOptionReseedFrom(map["reseed-from"].as<std::string>());
-  context.SetOptionReseedSkipSSLCheck(map["reseed-skip-ssl-check"].as<bool>());
   context.SetOptionDisableSU3Verification(
       map["disable-su3-verification"].as<bool>());
   // Set transport options
   context.SetSupportsNTCP(map["enable-ntcp"].as<bool>());
   context.SetSupportsSSU(map["enable-ssu"].as<bool>());
+  // Set SSL option
+  context.SetOptionEnableSSL(map["enable-ssl"].as<bool>());
 }
 
 // TODO(unassigned): see TODO's for router/client context and singleton

--- a/src/client/util/http.cc
+++ b/src/client/util/http.cc
@@ -116,8 +116,8 @@ bool HTTP::DownloadViaClearnet() {
   options.timeout(static_cast<std::uint8_t>(Timeout::Request));
   LOG(debug) << "HTTP: Download Clearnet with timeout : "
              << kovri::core::GetType(Timeout::Request);
-  // Ensure that we only download from certified reseed servers
-  if (!kovri::context.GetOptionReseedSkipSSLCheck()) {
+  // Ensure that we only download from explicit SSL-enabled hosts
+  if (kovri::context.GetOptionEnableSSL()) {
     const std::string cert = uri.host() + ".crt";
     const boost::filesystem::path cert_path = kovri::core::GetSSLCertsPath() / cert;
     if (!boost::filesystem::exists(cert_path)) {

--- a/src/core/router/context.cc
+++ b/src/core/router/context.cc
@@ -59,7 +59,7 @@ RouterContext::RouterContext()
       m_StartupTime(0),
       m_Status(eRouterStatusOK),
       m_Port(0),
-      m_ReseedSkipSSLCheck(false),
+      m_EnableSSL(true),
       m_DisableSU3Verification(false),
       m_SupportsNTCP(true),
       m_SupportsSSU(true) {}

--- a/src/core/router/context.h
+++ b/src/core/router/context.h
@@ -275,14 +275,14 @@ class RouterContext : public kovri::core::GarlicDestination {
   }
 
   /// @brief Sets user-supplied reseed SSL option
-  void SetOptionReseedSkipSSLCheck(
+  void SetOptionEnableSSL(
       bool option) {
-    m_ReseedSkipSSLCheck = option;
+    m_EnableSSL = option;
   }
 
   /// @return User-supplied option to skip SSL
-  bool GetOptionReseedSkipSSLCheck() const {
-    return m_ReseedSkipSSLCheck;
+  bool GetOptionEnableSSL() const {
+    return m_EnableSSL;
   }
 
   /// @brief Sets user-supplied disable SU3 verification option
@@ -328,7 +328,7 @@ class RouterContext : public kovri::core::GarlicDestination {
   std::string m_Host;
   std::uint16_t m_Port;
   std::string m_ReseedFrom;
-  bool m_ReseedSkipSSLCheck;
+  bool m_EnableSSL;
   bool m_DisableSU3Verification;
   bool m_SupportsNTCP, m_SupportsSSU;
   std::string m_CustomDataDir;


### PR DESCRIPTION
Also implements kovri `--enable-ssl` option.

Resolves #718.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

