### PR TITLE
Kovri: implement Boost.Python wrapper (PoC for prelim C++ API)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ option(WITH_DOXYGEN    "Enable support for Doxygen" OFF)
 option(WITH_HARDENING  "Use hardening compiler flags" OFF)
 option(WITH_LIBRARY    "Build library" ON)
 option(WITH_OPTIMIZE   "Optimization flags" OFF)
+option(WITH_PYTHON     "Build wrappers which require Boost.Python" OFF)
 option(WITH_STATIC     "Static build" OFF)
 option(WITH_SUPERCOP   "Build Ed25519 using the ref10 implementation from SUPERCOP" ON)  # Default ON unless we switch implementations
 option(WITH_TESTS      "Build unit tests" OFF)
@@ -187,14 +188,14 @@ if(WITH_STATIC)
   endif()
 endif()
 
-find_package(
-  Boost 1.58
-  COMPONENTS
-    chrono log
-    program_options date_time
-    thread system
-    filesystem regex
-  REQUIRED)
+# TODO(unassigned): Boost.Python build currently only tested on Arch Linux
+if (WITH_PYTHON)
+  find_package(Boost 1.58
+    COMPONENTS chrono date_time filesystem log program_options python3 regex system thread REQUIRED)
+else()
+  find_package(Boost 1.58
+    COMPONENTS chrono date_time filesystem log program_options regex system thread REQUIRED)
+endif()
 
 if(NOT Boost_FOUND)
   message(FATAL_ERROR "Boost not found or requirement not satisfied. See building instructions.")
@@ -293,6 +294,17 @@ if(WITH_DOXYGEN)
   include(UseDoxygen)
 endif()
 
+# For Boost.Python wrapping
+if (WITH_PYTHON)
+  find_package(PythonLibs REQUIRED)
+  if (NOT PythonLibs_FOUND)
+    message(FATAL_ERROR "Python not found or requirement not satisfied. See building instructions.")
+  else()
+    message(STATUS "Found Python: ${PYTHON_INCLUDE_DIR}, ${PYTHON_LIBRARIES}")
+    include_directories(${PYTHON_INCLUDE_DIRS})
+  endif()
+endif()
+
 # Load remaining includes
 include_directories(${CMAKE_SOURCE_DIR})
 
@@ -317,6 +329,7 @@ message(STATUS "  DOXYGEN          : ${WITH_DOXYGEN}")
 message(STATUS "  HARDENING        : ${WITH_HARDENING}")
 message(STATUS "  LIBRARY          : ${WITH_LIBRARY}")
 message(STATUS "  OPTIMIZATION     : ${WITH_OPTIMIZE}")
+message(STATUS "  PYTHON           : ${WITH_PYTHON}")
 message(STATUS "  STATIC BUILD     : ${WITH_STATIC}")
 message(STATUS "  SUPERCOP         : ${WITH_SUPERCOP}")
 message(STATUS "  TESTS            : ${WITH_TESTS}")
@@ -327,11 +340,17 @@ message(STATUS "---------------------------------------")
 # Handle paths nicely
 include(GNUInstallDirs)
 
+# Binaries
 set(APP_NAME "${PROJECT_NAME}-app")
-set(CLIENT_NAME "${PROJECT_NAME}-client")
-set(CORE_NAME "${PROJECT_NAME}-core")
 set(UTIL_NAME "${PROJECT_NAME}-util")
 set(TESTS_NAME "${PROJECT_NAME}-tests")
 
+# TODO(unassigned): add version numbers
+# Libraries
+set(CLIENT_NAME "${PROJECT_NAME}-client")
+set(CORE_NAME "${PROJECT_NAME}-core")
+set(PYTHON_NAME "${PROJECT_NAME}_python")
+
 add_subdirectory(src)
 add_subdirectory(tests)
+add_subdirectory(contrib)

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2015-2017, The Kovri I2P Router Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+if (WITH_PYTHON)
+  add_subdirectory(python)
+endif()

--- a/contrib/python/CMakeLists.txt
+++ b/contrib/python/CMakeLists.txt
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2015-2017, The Kovri I2P Router Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+include_directories(${CMAKE_SOURCE_DIR}/src)
+
+set(PYTHON_SRC "kovri.cc")
+
+add_library(${PYTHON_NAME} SHARED ${PYTHON_SRC})
+
+target_link_libraries(
+  ${PYTHON_NAME}
+  ${Boost_LIBRARIES} ${PYTHON_LIBRARIES}
+  ${CORE_NAME} ${CLIENT_NAME})
+
+set_target_properties(${PYTHON_NAME} PROPERTIES PREFIX "")

--- a/contrib/python/kovri.cc
+++ b/contrib/python/kovri.cc
@@ -1,0 +1,20 @@
+#include <boost/python.hpp>
+
+#include "client/instance.h"
+
+void Run()
+{
+  auto core = std::make_unique<kovri::core::Instance>();
+  auto client = std::make_unique<kovri::client::Instance>(std::move(core));
+
+  client->Initialize();
+  client->Start();
+  client->Stop();
+}
+
+// Trivial Boost.Python extending model PoC for kovri
+BOOST_PYTHON_MODULE(kovri_python)
+{
+  // TODO(anonimal): in-tandem API development
+  boost::python::def("Run", Run);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,9 @@ function(ConfigureBinary BIN_NAME BIN_SRC OUT_NAME)
     ${BIN_NAME}
     ${CLIENT_NAME} ${CORE_NAME}
     ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+  if (WITH_PYTHON)
+    target_link_libraries(${BIN_NAME} ${PYTHON_LIBRARIES})
+  endif()
   set_target_properties(${BIN_NAME} PROPERTIES OUTPUT_NAME "${OUT_NAME}")
   if(WITH_STATIC)
     if(NOT MINGW)


### PR DESCRIPTION
- Will aid in C++ API/testnet development; very much so for run-time testing
- This commit also includes necessary/related build changes

Essentially closes #86. Further API development is ongoing in #350 and #351.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

