### PR TITLE
 CMake: add Boost.Python detection for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,11 +198,11 @@ function(Uname output pattern)
   set(${output} "${${output}}" PARENT_SCOPE)
 endfunction(Uname)
 
-# TODO(unassigned): extend Boost.Python build support (confirmed) beyond Arch Linux and Ubuntu
+# TODO(unassigned): extend Boost.Python cross-platform build support 
 if (WITH_PYTHON)
   Uname(ARCH_LINUX "ARCH")
   Uname(UBUNTU "Ubuntu")
-  if (ARCH_LINUX)
+  if (APPLE OR ARCH_LINUX)
     find_package(Boost 1.58
       COMPONENTS chrono date_time filesystem log program_options python3 regex system thread REQUIRED)
   elseif (UBUNTU)


### PR DESCRIPTION
Not sure how that works if my PR is on-top of your PR.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

