### PR TITLE
Deterministically generate ElGamal key pairs

### DIFF
--- a/src/core/crypto/elgamal.h
+++ b/src/core/crypto/elgamal.h
@@ -67,6 +67,11 @@ void GenerateElGamalKeyPair(
     std::uint8_t* priv,
     std::uint8_t* pub);
 
+void GenerateDeterministicElGamalKeyPair(
+    std::uint8_t* priv,
+    std::uint8_t* pub,
+    std::uint8_t* seed);
+
 }  // namespace core
 }  // namespace kovri
 

--- a/src/core/crypto/impl/cryptopp/elgamal.cc
+++ b/src/core/crypto/impl/cryptopp/elgamal.cc
@@ -31,6 +31,7 @@
  */
 
 #include "core/crypto/elgamal.h"
+#include "core/crypto/hash.h"
 
 #include <cryptopp/integer.h>
 #include <cryptopp/osrng.h>
@@ -154,6 +155,26 @@ void GenerateElGamalKeyPair(
     std::uint8_t* pub) {
 #if defined(__x86_64__) || defined(__i386__) || defined(_MSC_VER)
   RandBytes(priv, 256);
+  a_exp_b_mod_c(
+      elgg,
+      CryptoPP::Integer(priv, 256),
+      elgp).Encode(pub, 256);
+#else
+    DiffieHellman().GenerateKeyPair(priv, pub);
+#endif
+}
+
+// Create deterministic keypair
+void GenerateDeterministicElGamalKeyPair(
+    std::uint8_t* priv,
+    std::uint8_t* pub,
+    std::uint8_t* seed) {
+#if defined(__x86_64__) || defined(__i386__) || defined(_MSC_VER)
+  // Calculate sha256(seed), store result in private key
+  kovri::core::SHA256().CalculateDigest(
+      priv,
+      seed,
+      256);
   a_exp_b_mod_c(
       elgg,
       CryptoPP::Integer(priv, 256),


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

From an unassigned TODO, generate deterministic key pairs for ElGamal unit tests.

