### PR TITLE
Garlic: add check for potential clove buffer over-read 

### DIFF
--- a/src/core/router/garlic.cc
+++ b/src/core/router/garlic.cc
@@ -609,6 +609,11 @@ void GarlicDestination::HandleGarlicPayload(
         std::shared_ptr<kovri::core::OutboundTunnel> tunnel;
         if (from && from->GetTunnelPool())
           tunnel = from->GetTunnelPool()->GetNextOutboundTunnel();
+        // TODO(anonimal): apply my refactored + documented patch from H1 #291489
+        if (buf + kovri::core::GetI2NPMessageLength(buf) + 4 + 8 + 3 - buf1  > static_cast<int>(len)) {
+          LOG(error) << "GarlicDestination: clove is too long";
+          break;
+        }
         if (tunnel) {  // we have send it through an outbound tunnel
           auto msg = CreateI2NPMessage(buf, kovri::core::GetI2NPMessageLength(buf), from);
           tunnel->SendTunnelDataMsg(gateway_hash, gateway_tunnel, msg);


### PR DESCRIPTION
Referencing HackerOne report `#291489` and #511.

**Edit:** the H1 report also makes related references to #64, #65, #630, and monero-project/meta#83

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

