### PR TITLE
 Testnet: use new path for router keys

### DIFF
--- a/contrib/testnet/testnet.sh
+++ b/contrib/testnet/testnet.sh
@@ -358,7 +358,7 @@ Create()
 
     ## Put RI + key in correct location
     cp $(ls ${router_base_name}${_seq}/routerInfo*.dat) "${_base_dir}/core/router.info"
-    cp $(ls ${router_base_name}${_seq}/routerInfo*.key) "${_base_dir}/core/router.keys"
+    cp $(ls ${router_base_name}${_seq}/routerInfo*.key) "${_base_dir}/core/router.key"
     catch "Could not copy RI and key"
 
     chown -R ${pid}:${gid} ${_base_dir}


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---
Looks like router key path changed recently
