### PR TITLE
Windows installer: Switch from 'comparetimestamp' to 'ignoreversion'

### DIFF
--- a/pkg/installers/windows/Common.iss
+++ b/pkg/installers/windows/Common.iss
@@ -31,14 +31,24 @@ Name: "en"; MessagesFile: "compiler:Default.isl"
 
 
 [Files]
-Source: "{#RootDir}\build\kovri.exe";      DestDir: "{app}"; Flags: comparetimestamp
-Source: "{#RootDir}\build\kovri-util.exe"; DestDir: "{app}"; Flags: comparetimestamp
-Source: "Kovri.ico";                          DestDir: "{app}"; Flags: comparetimestamp
-Source: "ReadMe.htm";                         DestDir: "{app}"; Flags: comparetimestamp
+; The use of the flag "ignoreversion" for the following entries leads to the following behaviour:
+; When updating / upgrading an existing installation ALL existing files are replaced with the files in this
+; installer, regardless of file dates, version info within the files, or type of file (textual file or
+; .exe/.dll file possibly with version info).
+;
+; This is far more robust than relying on version info or on file dates (flag "comparetimestamp").
+;
+; Note that it would be very dangerous to use "ignoreversion" on files that may be shared with other
+; applications somehow. Luckily this is no issue here because ALL files are "private" to Kovri.
 
-; Install new "client" files: Any new versions of "hosts.txt" and "publishers" in "\client\address_book"
+Source: "{#RootDir}\build\kovri.exe";      DestDir: "{app}"; Flags: ignoreversion
+Source: "{#RootDir}\build\kovri-util.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "Kovri.ico";                          DestDir: "{app}"; Flags: ignoreversion
+Source: "ReadMe.htm";                         DestDir: "{app}"; Flags: ignoreversion
+
+; Install/overwrite "client" files: "hosts.txt" and "publishers" in "\client\address_book"
 ; plus certificates in "\client\certificates"
-Source: "{#RootDir}\pkg\client\*"; DestDir: "{userappdata}\Kovri\client"; Flags: recursesubdirs comparetimestamp
+Source: "{#RootDir}\pkg\client\*"; DestDir: "{userappdata}\Kovri\client"; Flags: recursesubdirs ignoreversion
 
 ; Backup any existing user config files, as we will overwrite "kovri.conf" and "tunnels.conf" unconditionally
 ; Note that Inno Setup goes through the "[Files]" entries strictly in the order given here,


### PR DESCRIPTION
With the help of the flag `ignoreversion` for `[Files]` section entries in the InnoSetup installer script the Windows installer now always replaces existing files with the corresponding files in the installer, regardless of file dates, version info in .exe headers, or file content, when updating / upgrading an existing installation.

This "hard replace" of every file is much more robust than the previous behaviour using flag `comparetimestamp,` and the only small downside seems to be somewhat longer installer execution times when upgrading.

This follows an identical switch for the Windows installer for Monero. This is also what the Windows .BAT file for installing Kovri that this installer replaced did anyway.

Note that `ignoreversion` would be very dangerous to use with files that might be shared with other applications, but luckily this package has only files that go into its own private directories.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

