### PR TITLE
Core: invert SU3 verification config logic

### DIFF
--- a/contrib/testnet/testnet.sh
+++ b/contrib/testnet/testnet.sh
@@ -281,13 +281,13 @@ set_args()
 
   # Set daemon binary arguments
   if [[ -z $KOVRI_BIN_ARGS ]]; then
-    KOVRI_BIN_ARGS="--floodfill 1 --disable-su3-verification 1 --log-auto-flush 1 --enable-ssl 0"
+    KOVRI_BIN_ARGS="--floodfill 1 --enable-su3-verification 0 --log-auto-flush 1 --enable-ssl 0"
     read_input "Change kovri binary arguments? [KOVRI_BIN_ARGS=\"${KOVRI_BIN_ARGS}\"]" KOVRI_BIN_ARGS
   fi
 
   # Set firewalled daemon binary arguments
   if [[ $KOVRI_NB_FW -gt 0 && -z $KOVRI_FW_BIN_ARGS ]]; then
-    KOVRI_FW_BIN_ARGS="--floodfill 0 --disable-su3-verification 1 --log-auto-flush 1"
+    KOVRI_FW_BIN_ARGS="--floodfill 0 --enable-su3-verification 0 --log-auto-flush 1"
     read_input "Change firewalled kovri binary arguments? [KOVRI_FW_BIN_ARGS=\"${KOVRI_FW_BIN_ARGS}\"]" KOVRI_FW_BIN_ARGS
   fi
 }

--- a/pkg/config/kovri.conf
+++ b/pkg/config/kovri.conf
@@ -244,6 +244,25 @@ enable-ntcp = 1
 #reseed-from =
 
 #
+#  Enable SU3 Signature Verification
+#  =================================
+#
+#  WARNING: DO NOT DISABLE UNLESS YOU KNOW WHAT YOU'RE DOING!
+#
+#  Useful for custom SU3 files
+#
+#  Examples:
+#
+#  ./kovri --enable-su3-verification 0 --reseed-from https://my.server.tld/i2pseeds.su3
+#
+#  1 = enabled, 0 = disabled
+#
+#  Default: 1
+#
+
+enable-su3-verification = 1
+
+#
 #  Enable SSL
 #  ===========
 #
@@ -257,10 +276,10 @@ enable-ntcp = 1
 #
 #  1 = enabled, 0 = disabled
 #
-#  Default: 0
+#  Default: 1
 #
 
-#enable-ssl = 1
+enable-ssl = 1
 
 #######################
 ###                 ###

--- a/src/client/reseed.cc
+++ b/src/client/reseed.cc
@@ -91,7 +91,7 @@ bool Reseed::Start() {
   SU3 su3(
       m_Stream,
       m_SigningKeys,
-      core::context.GetOpts()["disable-su3-verification"].as<bool>());
+      core::context.GetOpts()["enable-su3-verification"].as<bool>());
   if (!su3.SU3Impl()) {
     LOG(error) << "Reseed: SU3 implementation failed";
     return false;
@@ -242,7 +242,7 @@ bool Reseed::FetchStream(
  */
 bool SU3::SU3Impl()
 {
-  if (m_DisableVerification)
+  if (!m_Verify)
     {
       LOG(warning) << "SU3: verification disabled !";
       // TODO(unassigned): detection and implemention of other formats

--- a/src/client/reseed.h
+++ b/src/client/reseed.h
@@ -147,10 +147,10 @@ class SU3 {
  public:
   SU3(const std::string& su3,
       std::map<std::string, kovri::core::PublicKey>& keys,
-      bool disable_verification = false)
+      bool verify = true)
       : m_Stream(su3),
         m_SigningKeys(keys),
-        m_DisableVerification(disable_verification),
+        m_Verify(verify),
         m_Data(std::make_unique<Data>()) {}
 
   // Extracted RI's (map of router info files)
@@ -283,8 +283,8 @@ class SU3 {
   // X.509 signing keys for SU3 verification
   std::map<std::string, kovri::core::PublicKey> m_SigningKeys;
 
-  /// @brief Disable SU3 verification?
-  bool m_DisableVerification;
+  /// @brief Enable SU3 verification?
+  bool m_Verify;
 
   // Spec-defined data
   std::unique_ptr<Data> m_Data;

--- a/src/core/util/config.cc
+++ b/src/core/util/config.cc
@@ -129,8 +129,8 @@ void Configuration::ParseConfig()
       "reseed-from,r", bpo::value<std::string>()->default_value(""))(
       "enable-ssl",
       bpo::value<bool>()->default_value(true)->value_name("bool"))(
-      "disable-su3-verification",
-      bpo::value<bool>()->default_value(false)->value_name("bool"));
+      "enable-su3-verification",
+      bpo::value<bool>()->default_value(true)->value_name("bool"));
 
   bpo::options_description client("\nclient");
   client.add_options()("httpproxyport", bpo::value<int>()->default_value(4446))(


### PR DESCRIPTION
for consistency + add to config file + minor update to config SSL option
(note: SSL enabled by default without config file).


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

