### PR TITLE
Testnet: add monitoring

### DIFF
--- a/contrib/testnet/monitoring/dashboards/details-containers.json
+++ b/contrib/testnet/monitoring/dashboards/details-containers.json
@@ -1,0 +1,722 @@
+{
+    "dashboard": {
+        "annotations": {
+            "list": [
+                {
+                    "builtIn": 1,
+                    "datasource": "-- Grafana --",
+                    "enable": true,
+                    "hide": true,
+                    "iconColor": "rgba(0, 211, 255, 1)",
+                    "name": "Annotations & Alerts",
+                    "type": "dashboard"
+                }
+            ]
+        },
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "hideControls": false,
+        "id": null,
+        "links": [],
+        "refresh": "10s",
+        "rows": [
+            {
+                "collapse": false,
+                "height": 308,
+                "panels": [
+                    {
+                        "aliasColors": {
+                            "cpu_usage_system.mean {container_name: /}": "#7EB26D"
+                        },
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 2,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "rightSide": true,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "minSpan": 3,
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "cpu_usage_system.mean {container_name: /}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "cpu_usage_system.mean {container_name: /docker}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "cpu_usage_system.mean {container_name: /user/0.user}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "cpu_usage_system.mean {container_name: /user/0.user}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "cpu_usage_system.mean {container_name: /user/0.user}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "cpu_usage_system.mean {container_name: /user/0.user/1.session}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "cpu_usage_system.mean {container_name: /user/0.user/2.session}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "cpu_usage_system.mean {container_name: /user}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "cpu_usage_system.mean {container_name: 5fe5b1b0-d62c-4991-a0b6-07dcd7aab760}",
+                                "legend": false
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "span": 12,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "container_name"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "hide": false,
+                                "measurement": "cpu_usage_system",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT derivative(mean(\"value\"), 1s)/1000000000 FROM \"cpu_usage_total\" WHERE  $timeFilter and container_name =~ /$container_name_filter/ GROUP BY time($interval), \"container_name\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": [
+                                    {
+                                        "key": "container_name",
+                                        "operator": "!=",
+                                        "value": "/"
+                                    }
+                                ]
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "CPU Usage",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": false,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "percentunit",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "hertz",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": 250,
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 3,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "rightSide": true,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "png",
+                        "seriesOverrides": [
+                            {
+                                "alias": "memory_usage.mean {container_name: /}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "memory_usage.mean {container_name: /docker}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "memory_usage.mean {container_name: /user}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "memory_usage.mean {container_name: /user/0.user}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "memory_usage.mean {container_name: /user/0.user}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "memory_usage.mean {container_name: /user/0.user/1.session}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "memory_usage.mean {container_name: /user/0.user/2.session}",
+                                "legend": false
+                            },
+                            {
+                                "alias": "memory_usage.mean {container_name: 5fe5b1b0-d62c-4991-a0b6-07dcd7aab760}",
+                                "legend": false
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "span": 12,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "container_name"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "measurement": "memory_usage",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"memory_usage\" WHERE $timeFilter and container_name =~ /$container_name_filter/ GROUP BY time($interval), \"container_name\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memory Usage",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "bytes",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Dashboard Row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": 250,
+                "panels": [
+                    {
+                        "aliasColors": {
+                            "rx_bytes.mean": "#E5AC0E",
+                            "tx_bytes.mean": "#1F78C1"
+                        },
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 5,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "rightSide": true,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "png",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 12,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "measurement": "rx_bytes",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT derivative(mean(\"value\"), 1s) FROM \"rx_bytes\" WHERE $timeFilter and container_name =~ /$container_name_filter/ GROUP BY time($interval) , \"container_name\"  fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Network Receive",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "transparent": false,
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Dashboard Row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": 250,
+                "panels": [
+                    {
+                        "aliasColors": {
+                            "rx_bytes.mean": "#E5AC0E",
+                            "tx_bytes.mean": "#1F78C1"
+                        },
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 4,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "rightSide": true,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "png",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 12,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "hide": false,
+                                "measurement": "tx_bytes",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT derivative(mean(\"value\"), 1s) FROM \"tx_bytes\" WHERE $timeFilter and container_name =~ /$container_name_filter/ GROUP BY time($interval) , \"container_name\"  fill(null)",
+                                "rawQuery": true,
+                                "refId": "B",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Network Transmit",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "transparent": false,
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "Bps",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Dashboard Row",
+                "titleSize": "h6"
+            }
+        ],
+        "schemaVersion": 14,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+            "list": [
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "kovri_testnet_01[0-4]",
+                        "value": "kovri_testnet_01[0-4]"
+                    },
+                    "datasource": "InfluxDB",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "Container name filter",
+                    "multi": false,
+                    "name": "container_name_filter",
+                    "options": [
+                        {
+                            "selected": true,
+                            "text": "kovri_testnet_01[0-4]",
+                            "value": "kovri_testnet_01[0-4]"
+                        },
+                        {
+                            "selected": false,
+                            "text": "kovri_testnet_02[5-9]",
+                            "value": "kovri_testnet_02[5-9]"
+                        },
+                        {
+                            "selected": false,
+                            "text": "kovri_testnet_01.*",
+                            "value": "kovri_testnet_01.*"
+                        },
+                        {
+                            "selected": false,
+                            "text": "kovri_testnet_02.*",
+                            "value": "kovri_testnet_02.*"
+                        },
+                        {
+                            "selected": false,
+                            "text": "kovri_testnet.*",
+                            "value": "kovri_testnet.*"
+                        },
+                        {
+                            "selected": false,
+                            "text": "kovri.*",
+                            "value": "kovri.*"
+                        }
+                    ],
+                    "query": "SHOW TAG VALUES WITH KEY = \"container_name\"",
+                    "refresh": 0,
+                    "regex": "",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                }
+            ]
+        },
+        "time": {
+            "from": "now-1h",
+            "to": "now"
+        },
+        "timepicker": {
+            "now": true,
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "browser",
+        "title": "Details Containers",
+        "version": 1
+    },
+    "meta": {
+        "canEdit": true,
+        "canSave": true,
+        "canStar": true,
+        "created": "2017-12-25T04:22:25Z",
+        "createdBy": "Anonymous",
+        "expires": "0001-01-01T00:00:00Z",
+        "slug": "details-containers",
+        "type": "db",
+        "updated": "2017-12-25T04:22:25Z",
+        "updatedBy": "Anonymous",
+        "version": 1
+    }
+}

--- a/contrib/testnet/monitoring/dashboards/details-netdb.json
+++ b/contrib/testnet/monitoring/dashboards/details-netdb.json
@@ -1,0 +1,635 @@
+{
+    "dashboard": {
+        "annotations": {
+            "list": [
+                {
+                    "builtIn": 1,
+                    "datasource": "-- Grafana --",
+                    "enable": true,
+                    "hide": true,
+                    "iconColor": "rgba(0, 211, 255, 1)",
+                    "name": "Annotations & Alerts",
+                    "type": "dashboard"
+                }
+            ]
+        },
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "hideControls": false,
+        "id": null,
+        "links": [],
+        "refresh": "10s",
+        "rows": [
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 1,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": true,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 12,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "instance"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "measurement": "i2p.router.netdb.activepeers",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"i2p.router.netdb.activepeers\" WHERE $timeFilter and instance =~ /$instance_filter/  GROUP BY time($__interval), \"instance\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Active Peers",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Dashboard Row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": 250,
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 2,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": true,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 12,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "instance"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "measurement": "i2p.router.netdb.leasesets",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"i2p.router.netdb.leasesets\" WHERE $timeFilter and instance =~ /$instance_filter/  GROUP BY time($__interval), \"instance\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "LeaseSets",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Dashboard Row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": 250,
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 3,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": true,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 12,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "instance"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "measurement": "i2p.router.netdb.knownpeers",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"i2p.router.netdb.knownpeers\" WHERE $timeFilter and instance =~ /$instance_filter/  GROUP BY time($__interval), \"instance\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Known Peers",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Dashboard Row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": 250,
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 4,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": true,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 12,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "instance"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "measurement": "i2p.router.netdb.floodfills",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"i2p.router.netdb.floodfills\" WHERE $timeFilter and instance =~ /$instance_filter/  GROUP BY time($__interval), \"instance\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Floodfills",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Dashboard Row",
+                "titleSize": "h6"
+            }
+        ],
+        "schemaVersion": 14,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+            "list": [
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "kovri_testnet_02.*",
+                        "value": "kovri_testnet_02.*"
+                    },
+                    "datasource": "InfluxDB",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "Instance Filter (regex)",
+                    "multi": false,
+                    "name": "instance_filter",
+                    "options": [
+                        {
+                            "selected": true,
+                            "text": "kovri_testnet_01[0-4]",
+                            "value": "kovri_testnet_01[0-4]"
+                        },
+                        {
+                            "selected": false,
+                            "text": "kovri_testnet_02[5-9]",
+                            "value": "kovri_testnet_02[5-9]"
+                        },
+                        {
+                            "selected": false,
+                            "text": "kovri_testnet_01.*",
+                            "value": "kovri_testnet_01.*"
+                        },
+                        {
+                            "selected": false,
+                            "text": "kovri_testnet_02.*",
+                            "value": "kovri_testnet_02.*"
+                        },
+                        {
+                            "selected": false,
+                            "text": "kovri_testnet.*",
+                            "value": "kovri_testnet.*"
+                        }
+                    ],
+                    "query": "SHOW TAG VALUES WITH KEY = \"instance\" ",
+                    "refresh": 0,
+                    "regex": "",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                }
+            ]
+        },
+        "time": {
+            "from": "now-1h",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "",
+        "title": "Details NetDB",
+        "version": 1
+    },
+    "meta": {
+        "canEdit": true,
+        "canSave": true,
+        "canStar": true,
+        "created": "2017-12-25T04:22:25Z",
+        "createdBy": "Anonymous",
+        "expires": "0001-01-01T00:00:00Z",
+        "slug": "details-netdb",
+        "type": "db",
+        "updated": "2017-12-25T04:22:25Z",
+        "updatedBy": "Anonymous",
+        "version": 1
+    }
+}

--- a/contrib/testnet/monitoring/dashboards/instance-overview.json
+++ b/contrib/testnet/monitoring/dashboards/instance-overview.json
@@ -1,0 +1,1507 @@
+{
+    "dashboard": {
+        "annotations": {
+            "list": [
+                {
+                    "builtIn": 1,
+                    "datasource": "-- Grafana --",
+                    "enable": true,
+                    "hide": true,
+                    "iconColor": "rgba(0, 211, 255, 1)",
+                    "name": "Annotations & Alerts",
+                    "type": "dashboard"
+                }
+            ]
+        },
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "hideControls": false,
+        "id": null,
+        "links": [],
+        "refresh": "10s",
+        "rows": [
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 9,
+                        "legend": {
+                            "alignAsTable": false,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": false,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"memory_usage\" WHERE $timeFilter and container_name =~ /$instance_filter/ GROUP BY time($interval), \"container_name\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memory",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "decbytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 10,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": false,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 4,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "hide": false,
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"load_average\" WHERE  $timeFilter and container_name =~ /$instance_filter/ GROUP BY time($interval), \"container_name\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            },
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "container_name"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "hide": true,
+                                "measurement": "load_average",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "refId": "B",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Load avg",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "percentunit",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 11,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": false,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 4,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "hide": true,
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT derivative(mean(\"value\"), 1s)/1000000000 FROM \"cpu_usage_total\" WHERE  $timeFilter and container_name =~ /$instance_filter/ GROUP BY time($interval), \"container_name\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            },
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "hide": false,
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT derivative(mean(\"value\"), 1s)/1000000000 FROM \"cpu_usage_system\" WHERE  $timeFilter and container_name =~ /$instance_filter/ GROUP BY time($interval), \"container_name\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "B",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            },
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT derivative(mean(\"value\"), 1s)/1000000000 FROM \"cpu_usage_user\" WHERE  $timeFilter and container_name =~ /$instance_filter/ GROUP BY time($interval), \"container_name\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "C",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "CPU Usage",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "percentunit",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Dashboard Row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": 290,
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 8,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": false,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "instance"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "measurement": "i2p.router.netdb.activepeers",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"i2p.router.netdb.activepeers\" WHERE $timeFilter and instance =~ /$instance_filter/  GROUP BY time($__interval), \"instance\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            },
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"i2p.router.netdb.knownpeers\" WHERE $timeFilter and instance =~ /$instance_filter/  GROUP BY time($__interval), \"instance\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "B",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            },
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"i2p.router.netdb.floodfills\" WHERE $timeFilter and instance =~ /$instance_filter/  GROUP BY time($__interval), \"instance\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "C",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            },
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"i2p.router.netdb.leasesets\" WHERE $timeFilter and instance =~ /$instance_filter/  GROUP BY time($__interval), \"instance\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "D",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "NetDB",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 2,
+                        "legend": {
+                            "alignAsTable": false,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": false,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "instance"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "measurement": "i2p.router.netdb.leasesets",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"i2p.router.net.tunnels.participating\" WHERE $timeFilter and instance =~ /$instance_filter/  GROUP BY time($__interval), \"instance\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Tunnels Participating",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 5,
+                        "legend": {
+                            "alignAsTable": false,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": false,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 3,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "instance"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "measurement": "i2p.router.netdb.leasesets",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"i2p.router.net.tunnels.creationsuccessrate\" WHERE $timeFilter and instance =~ /$instance_filter/  GROUP BY time($__interval), \"instance\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Tunnels Creation Success rate",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Dashboard Row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": 250,
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 3,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": false,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "instance"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "measurement": "i2p.router.netdb.knownpeers",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"i2p.router.net.bw.inbound.1s\" WHERE $timeFilter and instance =~ /$instance_filter/  GROUP BY time($__interval), \"instance\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            },
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"i2p.router.net.bw.outbound.1s\" WHERE $timeFilter and instance =~ /$instance_filter/  GROUP BY time($__interval), \"instance\" fill(null)",
+                                "rawQuery": true,
+                                "refId": "B",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Reported Bandwidth (1s)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 7,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": false,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "instance"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "hide": false,
+                                "measurement": "i2p.router.netdb.knownpeers",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT derivative(mean(\"value\"), 1s) FROM \"rx_bytes\" WHERE $timeFilter and container_name =~ /$instance_filter/ GROUP BY time($interval) , \"container_name\"  fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            },
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "hide": false,
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT derivative(mean(\"value\"), 1s) FROM \"tx_bytes\" WHERE $timeFilter and container_name =~ /$instance_filter/ GROUP BY time($interval) , \"container_name\"  fill(null)",
+                                "rawQuery": true,
+                                "refId": "B",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Container Bandwidth (1s)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "Bps",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": null,
+                        "fill": 1,
+                        "id": 12,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": true,
+                            "rightSide": false,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "instance"
+                                        ],
+                                        "type": "tag"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "hide": false,
+                                "measurement": "i2p.router.netdb.knownpeers",
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"rx_errors\" WHERE $timeFilter and container_name =~ /$instance_filter/ GROUP BY time($interval) , \"container_name\"  fill(null)",
+                                "rawQuery": true,
+                                "refId": "A",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            },
+                            {
+                                "dsType": "influxdb",
+                                "groupBy": [
+                                    {
+                                        "params": [
+                                            "$__interval"
+                                        ],
+                                        "type": "time"
+                                    },
+                                    {
+                                        "params": [
+                                            "null"
+                                        ],
+                                        "type": "fill"
+                                    }
+                                ],
+                                "hide": false,
+                                "orderByTime": "ASC",
+                                "policy": "default",
+                                "query": "SELECT mean(\"value\") FROM \"tx_errors\" WHERE $timeFilter and container_name =~ /$instance_filter/ GROUP BY time($interval) , \"container_name\"  fill(null)",
+                                "rawQuery": true,
+                                "refId": "B",
+                                "resultFormat": "time_series",
+                                "select": [
+                                    [
+                                        {
+                                            "params": [
+                                                "value"
+                                            ],
+                                            "type": "field"
+                                        },
+                                        {
+                                            "params": [],
+                                            "type": "mean"
+                                        }
+                                    ]
+                                ],
+                                "tags": []
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Container Tx errors",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Dashboard Row",
+                "titleSize": "h6"
+            }
+        ],
+        "schemaVersion": 14,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+            "list": [
+                {
+                    "allValue": null,
+                    "current": {
+                        "tags": [],
+                        "text": "kovri_testnet_016",
+                        "value": "kovri_testnet_016"
+                    },
+                    "datasource": "InfluxDB",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "Instance Filter (regex)",
+                    "multi": false,
+                    "name": "instance_filter",
+                    "options": [],
+                    "query": "SHOW TAG VALUES WITH KEY = \"instance\" ",
+                    "refresh": 1,
+                    "regex": "",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                }
+            ]
+        },
+        "time": {
+            "from": "now-1h",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "",
+        "title": "Instance Overview",
+        "version": 1
+    },
+    "meta": {
+        "canEdit": true,
+        "canSave": true,
+        "canStar": true,
+        "created": "2017-12-25T04:22:25Z",
+        "createdBy": "Anonymous",
+        "expires": "0001-01-01T00:00:00Z",
+        "slug": "instance-overview",
+        "type": "db",
+        "updated": "2017-12-25T04:22:25Z",
+        "updatedBy": "Anonymous",
+        "version": 1
+    }
+}

--- a/contrib/testnet/testnet.sh
+++ b/contrib/testnet/testnet.sh
@@ -35,6 +35,28 @@ router_base_name="router_"
 kovri_base_name="kovri_"
 pipe_base_name="log_pipe"
 
+# Monitoring Database
+db_image="influxdb:latest"
+db_container_name="kovri-influxdb"
+db_host_octet=".3"
+db_name="kovri"
+
+# Monitoring: Container stats collector
+stats_container_image="google/cadvisor:latest"
+stats_container_name="kovri-cadvisor"
+stats_container_host_octet=".4"
+
+# Monitoring: Kovri stats collector
+stats_kovri_name="kovri-collector"
+stats_kovri_host_octet=".5"
+
+# Monitoring UI
+grafana_image="grafana/grafana"
+grafana_base_name="kovri-grafana"
+grafana_host_octet=".6"
+grafana_host_port="3030"
+grafana_password="kovri"
+
 # Docker mount
 mount="/home/kovri"
 mount_testnet="${mount}/testnet"
@@ -111,6 +133,7 @@ PrintUsage()
   echo "KOVRI_BUILD_REPO_BINS   = build repo binaries from *within* the container"
   echo "KOVRI_CLEANUP           = cleanup/destroy previous testnet"
   echo "KOVRI_USE_NAMED_PIPES   = use named pipes for logging"
+  echo "KOVRI_DISABLE_MONITORING= disable logging"
   echo ""
   echo "Log monitoring"
   echo "--------------"
@@ -366,6 +389,8 @@ Create()
     chown -R ${pid}:${gid} ${_base_dir}
     catch "Could not set ownership ${pid}:${gid}"
   done
+
+  create_monitoring
   popd
 }
 
@@ -549,13 +574,99 @@ create_webserver_instance()
   local _cmd="sed -i -e 's/#ServerName .*/ServerName ${_web_host}:80/' ${web_system_dir}/${web_conf_dir}/${web_conf} && httpd-foreground"
 
   # Start publisher instance
-  docker create -it --rm --network=${KOVRI_NETWORK} --ip=${_web_host} --name $web_name \
+  docker create -it --network=${KOVRI_NETWORK} --ip=${_web_host} --name $web_name \
     $_entrypoint \
     -v ${_dest_dir}/${web_root_dir}/:${web_system_dir}/${web_root_dir}/ \
     $KOVRI_WEB_IMAGE \
     "$_cmd"
 
   catch "Docker could not run webserver"
+}
+
+create_monitoring()
+{
+  read_bool_input "Disable monitoring?" KOVRI_DISABLE_MONITORING ""
+  if [[ $KOVRI_DISABLE_MONITORING = false ]]; then
+    # Set db IP
+    local _db_host="${network_octets}${db_host_octet}"
+    local _db_uri="${_db_host}:8086"
+
+    # Create DB container
+    docker create -it --name ${db_container_name} --network=${KOVRI_NETWORK} --ip=${_db_host} \
+      ${db_image}
+    catch "Could not create $db_container_name"
+
+    # Create database ${db_name}
+    echo -n "Starting... " && docker start ${db_container_name}
+    catch "Could not start $db_container_name"
+
+    echo "Wait 3s for db to start... " && sleep 3
+    echo "Create database kovri"
+    curl -i -XPOST http://${_db_uri}/query --data-urlencode "q=CREATE DATABASE ${db_name}"
+    catch "Could not create database ${db_name}"
+
+    echo -n "Stopping... " && docker stop ${db_container_name}
+    catch "Could not stop $db_container_name"
+
+    # Create container stats collector
+    local _stats_container_host="${network_octets}${stats_container_host_octet}"
+    docker create --name ${stats_container_name} --network=${KOVRI_NETWORK} --ip=${_stats_container_host} \
+      --volume=/:/rootfs:ro --volume=/var/run:/var/run:rw --volume=/sys:/sys:ro \
+      --volume=/var/lib/docker/:/var/lib/docker:ro \
+      --volume=/dev/disk/:/dev/disk:ro \
+      ${stats_container_image} -storage_driver=influxdb -storage_driver_host=${_db_uri} -storage_driver_db=${db_name}
+    catch "Could not create $stats_container_name"
+    echo "Created container stats collector ${stats_container_name}"
+
+    # Create kovri stats collector
+    local _collector_host="${network_octets}${stats_kovri_host_octet}"
+    docker create -it  --name ${stats_kovri_name} --network=${KOVRI_NETWORK} --ip=${_collector_host} \
+      -v ${KOVRI_REPO}/${docker_dir}/monitoring/collect.sh:/collect.sh \
+      $mount_repo_bins \
+      $KOVRI_IMAGE \
+      /collect.sh "${sequence}" "${network_octets}" "${_db_uri}" "${db_name}" "${docker_base_name}"
+    catch "Could not create $stats_kovri_name"
+    echo "Created kovri stats collector ${stats_kovri_name}"
+
+    # Create UI container
+    local _grafana_host="${network_octets}${grafana_host_octet}"
+    local _grafana_uri="http://admin:${grafana_password}@${_grafana_host}:3000"
+    docker run -d --name ${grafana_base_name} --network=${KOVRI_NETWORK} --ip=${_grafana_host} \
+      -p ${grafana_host_port}:3000 -e "GF_SECURITY_ADMIN_PASSWORD=${grafana_password}" ${grafana_image}
+    catch "Could not create ${grafana_base_name}"
+    echo "Created monitoring UI ${stats_kovri_name}"
+
+    # Grafana: add ${db_container_name} as a "data source"
+    echo "Wait 10s for container to start... " && sleep 10
+
+    curl "${_grafana_uri}/api/datasources" \
+      -X POST -H 'Content-Type: application/json;charset=UTF-8' \
+      --data-binary \
+      '{"name":"InfluxDB","type":"influxdb","url":"http://'${_db_host}':8086","access":"proxy","isDefault":true,"database":"'${db_name}'"}'
+    catch "Could not configure default datasource"
+    echo "Grafana: Created datasource ${_db_host}:8086"
+
+    # Grafana: Create API token
+    local _apiKey=$(curl -X POST -H "Content-Type: application/json" -d '{"name":"apikeycurl", "role": "Admin"}' ${_grafana_uri}/api/auth/keys | python -c "import sys, json; print json.load(sys.stdin)['key']")
+    catch "Grafana: Could not create API key"
+    echo "Grafana: Created api key $_apiKey"
+
+    # Grafana: add dashboards
+    for dashboard in ${KOVRI_REPO}/contrib/testnet/monitoring/dashboards/*.json; do
+      echo "Importing dashboard ${dashboard}... " && curl -X POST --insecure \
+        -H "Authorization: Bearer $_apiKey" \
+        -H "Content-Type: application/json" \
+        -d @${dashboard} \
+        ${_grafana_uri}/api/dashboards/db && echo ""
+      catch "Grafana: failed to add dashboard $dashboard"
+    done
+
+    # Stop grafana
+    echo -n "Stopping... " && docker stop ${grafana_base_name}
+    catch "Could not stop ${grafana_base_name}"
+
+    echo "Monitoring interface is accessibe at: http://127.0.0.1:${grafana_host_port} with credentials admin:${grafana_password}"
+  fi
 }
 
 Start()
@@ -567,6 +678,13 @@ Start()
     echo -n "Starting... " && docker start $_container_name
     catch "Could not start docker: $_seq"
   done
+
+  if [[ $KOVRI_DISABLE_MONITORING = false ]]; then
+    echo -n "Starting monitoring database... " && docker start $db_container_name
+    echo -n "Starting container stats collector... " && docker start $stats_container_name
+    echo -n "Starting kovri stats collector... " && docker start $stats_kovri_name
+    echo -n "Starting monitoring UI... " && docker start $grafana_base_name
+  fi
 }
 
 Stop()
@@ -582,6 +700,13 @@ Stop()
   local _stop="docker stop -t $KOVRI_STOP_TIMEOUT"
 
   # Stop testnet
+  if [[ $KOVRI_DISABLE_MONITORING = false ]]; then
+    echo -n "Stopping monitoring collector " && $_stop $stats_kovri_name
+    echo -n "Stopping container stats collector... " && $_stop $stats_container_name
+    echo -n "Stopping monitoring database... " && $_stop $db_container_name
+    echo -n "Stopping monitoring UI... " && $_stop $grafana_base_name
+  fi
+
   echo -n "Stopping web server... " && $_stop $web_name
   for _seq in $($sequence); do
     local _container_name="${docker_base_name}${_seq}"
@@ -607,6 +732,13 @@ Destroy()
   fi
 
   Stop
+
+  if [[ $KOVRI_DISABLE_MONITORING = false ]]; then
+    echo -n "Removing monitoring collector... " && docker rm -v $stats_kovri_name
+    echo -n "Removing container stats collector... " && docker rm -v $stats_container_name
+    echo -n "Removing monitoring database... " && docker rm -v $db_container_name
+    echo -n "Removing monitoring UI... " && docker rm -v $grafana_base_name
+  fi
 
   echo -n "Removing web server... " && docker rm -v $web_name
   for _seq in $($sequence); do

--- a/contrib/testnet/testnet.sh
+++ b/contrib/testnet/testnet.sh
@@ -110,11 +110,12 @@ PrintUsage()
   echo "KOVRI_USE_REPO_BINS     = use repo-built binaries"
   echo "KOVRI_BUILD_REPO_BINS   = build repo binaries from *within* the container"
   echo "KOVRI_CLEANUP           = cleanup/destroy previous testnet"
+  echo "KOVRI_USE_NAMED_PIPES   = use named pipes for logging"
   echo ""
   echo "Log monitoring"
   echo "--------------"
   echo ""
-  echo "Every kovri instance will provide real-time logging via named pipes."
+  echo "Every kovri instance will provide real-time logging via named pipes (unless disabled)."
   echo "These pipes are located in their respective directories."
   echo ""
   echo "  Example: /tmp/testnet/kovri_010/log_pipe"
@@ -153,6 +154,7 @@ Prepare()
   set_workspace
   set_args
   set_network
+  read_bool_input "Use named pipes for logging?" KOVRI_USE_NAMED_PIPES ""
 }
 
 cleanup_testnet()
@@ -490,8 +492,13 @@ create_instance()
   # Create named pipe for logging
   local _pipe="${KOVRI_WORKSPACE}/${kovri_base_name}${_seq}/${pipe_base_name}"
 
-  mkfifo "$_pipe"
-  catch "Could not create named pipe $_pipe"
+  if [[ $KOVRI_USE_NAMED_PIPES = false ]]; then
+    touch "$_pipe"
+    catch "Could not create file $_pipe"
+  else
+    mkfifo "$_pipe"
+    catch "Could not create named pipe $_pipe"
+  fi
 
   # Set container options
   local _container_name="${docker_base_name}${_seq}"


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---
if `KOVRI_DISABLE_MONITORING` is set to `false`, it will create 4 additional containers:
- 1 for a time series database ([influxdb](https://www.influxdata.com/))
- 1 for collecting statistics from kovri instances via kovri-util
- 1 for collecting container statistics ([cadvisor](https://github.com/google/cadvisor)) 
- 1 for visualization ([grafana](https://grafana.com/))

There is a variable at the top left to choose what it is included (standard regex).

So out of the box, it produces things like:
![containers](https://user-images.githubusercontent.com/22608168/34333960-0b483c2e-e942-11e7-9286-ba767dffc415.png)
![instance](https://user-images.githubusercontent.com/22608168/34333970-1f0b9c24-e942-11e7-8f18-4e902cac8d08.png)

Dashboards can be edited via the UI and then backuped via the script contrib/testnet/monitoring/dashboards/backup.py
