### PR TITLE
Kovri: clarify HTTPS nomenclature + log warning when not using HTTPS

### DIFF
--- a/contrib/testnet/testnet.sh
+++ b/contrib/testnet/testnet.sh
@@ -281,7 +281,7 @@ set_args()
 
   # Set daemon binary arguments
   if [[ -z $KOVRI_BIN_ARGS ]]; then
-    KOVRI_BIN_ARGS="--floodfill 1 --enable-su3-verification 0 --log-auto-flush 1 --enable-ssl 0"
+    KOVRI_BIN_ARGS="--floodfill 1 --enable-su3-verification 0 --log-auto-flush 1 --enable-https 0"
     read_input "Change kovri binary arguments? [KOVRI_BIN_ARGS=\"${KOVRI_BIN_ARGS}\"]" KOVRI_BIN_ARGS
   fi
 

--- a/pkg/config/kovri.conf
+++ b/pkg/config/kovri.conf
@@ -237,7 +237,7 @@ enable-ntcp = 1
 #  ./kovri --reseed-from https://my.server.tld/i2pseeds.su3
 #
 #  Note: if the server in your URL is not one of the hard-coded reseed servers,
-#  either use --enable-ssl 0 or or put your server's certificate into
+#  either use --enable-https 0 or or put your server's certificate into
 #  the certificates directory located in KOVRI_DATA_DIR
 #
 
@@ -262,9 +262,8 @@ enable-ntcp = 1
 
 enable-su3-verification = 1
 
-#
-#  Enable SSL
-#  ===========
+#  Enable HTTPS
+#  ============
 #
 #  WARNING: DO NOT DISABLE UNLESS YOU KNOW WHAT YOU'RE DOING!
 #
@@ -272,14 +271,14 @@ enable-su3-verification = 1
 #
 #  Examples:
 #
-#  ./kovri --enable-ssl 0 --reseed-from https://my.server.tld/i2pseeds.su3
+#  ./kovri --enable-https 0 --reseed-from https://my.server.tld/i2pseeds.su3
 #
 #  1 = enabled, 0 = disabled
 #
 #  Default: 1
 #
 
-enable-ssl = 1
+enable-https = 1
 
 #######################
 ###                 ###

--- a/src/client/util/http.cc
+++ b/src/client/util/http.cc
@@ -116,10 +116,10 @@ bool HTTP::DownloadViaClearnet() {
   options.timeout(static_cast<std::uint8_t>(Timeout::Request));
   LOG(debug) << "HTTP: Download Clearnet with timeout : "
              << kovri::core::GetType(Timeout::Request);
-  // Ensure that we only download from explicit SSL-enabled hosts
-  if (core::context.GetOpts()["enable-ssl"].as<bool>()) {
+  // Ensure that we only download from explicit TLS-enabled hosts
+  if (core::context.GetOpts()["enable-https"].as<bool>()) {
     const std::string cert = uri.host() + ".crt";
-    const boost::filesystem::path cert_path = kovri::core::GetSSLCertsPath() / cert;
+    const boost::filesystem::path cert_path = kovri::core::GetTLSCertsPath() / cert;
     if (!boost::filesystem::exists(cert_path)) {
       LOG(error) << "HTTP: certificate unavailable: " << cert_path;
       return false;

--- a/src/client/util/http.cc
+++ b/src/client/util/http.cc
@@ -143,7 +143,7 @@ bool HTTP::DownloadViaClearnet() {
   }
   else
     {
-      LOG(debug) << "HTTP: Skipped Reseed SSL checking ";
+      LOG(warning) << "HTTP: not using HTTPS";
     }
 
   // Create client with options

--- a/src/core/util/config.cc
+++ b/src/core/util/config.cc
@@ -127,7 +127,7 @@ void Configuration::ParseConfig()
       "enable-ntcp",
       bpo::value<bool>()->default_value(true)->value_name("bool"))(
       "reseed-from,r", bpo::value<std::string>()->default_value(""))(
-      "enable-ssl",
+      "enable-https",
       bpo::value<bool>()->default_value(true)->value_name("bool"))(
       "enable-su3-verification",
       bpo::value<bool>()->default_value(true)->value_name("bool"));

--- a/src/core/util/filesystem.cc
+++ b/src/core/util/filesystem.cc
@@ -158,7 +158,7 @@ const boost::filesystem::path GetSU3CertsPath() {
   return GetClientPath() / "certificates" / "su3";
 }
 
-const boost::filesystem::path GetSSLCertsPath() {
+const boost::filesystem::path GetTLSCertsPath() {
   return GetClientPath() / "certificates" / "ssl";
 }
 

--- a/src/core/util/filesystem.h
+++ b/src/core/util/filesystem.h
@@ -324,8 +324,8 @@ const boost::filesystem::path EnsurePath(
 /// @return Path to certificates for SU3 verification
 const boost::filesystem::path GetSU3CertsPath();
 
-/// @return Path to SSL certificates for TLS/SSL negotiation
-const boost::filesystem::path GetSSLCertsPath();
+/// @return Path to X.509 certificates for TLS negotiation
+const boost::filesystem::path GetTLSCertsPath();
 
 /// @return Address book related path
 const boost::filesystem::path GetAddressBookPath();


### PR DESCRIPTION
Since we don't actually use SSL (force of habit to lump TLS/HTTPS/OpenSSL into "SSL") and since we don't use TLS anywhere else outside of HTTP.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

