### PR TITLE
IdentityEx: lowerbounds check on buffer creation

### DIFF
--- a/src/core/router/identity.cc
+++ b/src/core/router/identity.cc
@@ -292,10 +292,18 @@ std::size_t IdentityEx::FromBuffer(
 
 std::size_t IdentityEx::ToBuffer(
     std::uint8_t* buf,
-    std::size_t) const {
+    std::size_t buflen) const {
+  if (buflen < DEFAULT_IDENTITY_SIZE)
+    throw std::length_error("IdentityEx: supplied buffer is too small");
+
   memcpy(buf, &m_StandardIdentity, DEFAULT_IDENTITY_SIZE);
   if (m_ExtendedLen > 0 && m_ExtendedBuffer)
+  {
+    if (buflen < DEFAULT_IDENTITY_SIZE + m_ExtendedLen)
+      throw std::length_error("IdentityEx: supplied buffer is too small"); 
+
     memcpy(buf + DEFAULT_IDENTITY_SIZE, m_ExtendedBuffer.get(), m_ExtendedLen);
+  }
   return GetFullLen();
 }
 


### PR DESCRIPTION
Use the size parameter supplied to IdentityEx::ToBuffer() to ensure
the supplied buffer is large enough.


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

