### PR TITLE
CMake: add NDEBUG flag for release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,11 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -DNDEBUG")
+
 # Default build is Debug
-# TODO(anonimal): currently, there are no release-specific flags (fix this when we're out of alpha)
+# TODO(anonimal): currently, there are no other release-specific flags (fix this when we release)
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
 endif()


### PR DESCRIPTION
NDEBUG especially needed to prevent potentially sensitive information
leakage in core dumps or by OS dump reporters when aborts are made by
posix assertions.


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

