### PR TITLE
Radix: remove FreeBSD-specific build block

### DIFF
--- a/src/core/crypto/impl/cryptopp/radix.cc
+++ b/src/core/crypto/impl/cryptopp/radix.cc
@@ -74,11 +74,7 @@ std::vector<std::uint8_t> Base32::Decode(
 
   CryptoPP::AlgorithmParameters const params(CryptoPP::MakeParameters(
       CryptoPP::Name::DecodingLookupArray(),
-#if defined(__FreeBSD__)  // See #788
-      reinterpret_cast<const int*>(lookup), false));
-#else
       reinterpret_cast<const int*>(lookup)));
-#endif
 
   // Decode
   return Radix::Decode<CryptoPP::Base32Decoder>(params, in, len);


### PR DESCRIPTION
Crypto++ 6.0 release has resolved this decoding issue (#794).

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

