### PR TITLE
Radix: throw length error, not runtime, when decoding

### DIFF
--- a/src/core/crypto/radix.h
+++ b/src/core/crypto/radix.h
@@ -122,7 +122,7 @@ class Radix : public RadixBase
 
     const CryptoPP::word64 size = decoder.MaxRetrievable();
     if (!size || size > SIZE_MAX)
-      throw std::runtime_error("Radix: invalid decoded size");
+      throw std::length_error("Radix: invalid decoded size");
 
     std::vector<std::uint8_t> out(size);
     decoder.Get(reinterpret_cast<CryptoPP::byte*>(&out[0]), out.size());


### PR DESCRIPTION
Referencing #788.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

