### PR TITLE
Unroll DecodingLookupArray for Base32 and Base64 decoders

### DIFF
--- a/src/core/crypto/impl/cryptopp/radix.cc
+++ b/src/core/crypto/impl/cryptopp/radix.cc
@@ -37,6 +37,49 @@
 #include <string>
 #include <vector>
 
+// Anonymous namespace
+namespace {
+    // Decoding table for m_Base32Alphabet
+    const int s_Base32Table[256] = {
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, 26, 27, 28, 29, 30, 31, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1,
+        -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+    };
+
+    // Decoding table for m_Base64Alphabet
+    const int s_Base64Table[256] = {
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1,
+        52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1,
+        -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1,
+        -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+        41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, 63, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+    };
+};
+
 namespace kovri
 {
 namespace core
@@ -65,20 +108,8 @@ std::vector<std::uint8_t> Base32::Decode(
     const std::uint64_t len)
 {
   // Prepare decoder
-  int lookup[256];
-  CryptoPP::Base32Decoder::InitializeDecodingLookupArray(
-      lookup,
-      reinterpret_cast<const CryptoPP::byte*>(GetAlphabet().c_str()),
-      GetAlphabet().size(),
-      true);
-
-  CryptoPP::AlgorithmParameters const params(CryptoPP::MakeParameters(
-      CryptoPP::Name::DecodingLookupArray(),
-#if defined(__FreeBSD__)  // See #788
-      reinterpret_cast<const int*>(lookup), false));
-#else
-      reinterpret_cast<const int*>(lookup)));
-#endif
+  CryptoPP::AlgorithmParameters static const params(CryptoPP::MakeParameters(
+      CryptoPP::Name::DecodingLookupArray(), s_Base32Table, false));
 
   // Decode
   return Radix::Decode<CryptoPP::Base32Decoder>(params, in, len);
@@ -109,16 +140,8 @@ std::vector<std::uint8_t> Base64::Decode(
     const std::uint64_t len)
 {
   // Prepare decoder
-  int lookup[256];
-  CryptoPP::Base64Decoder::InitializeDecodingLookupArray(
-      lookup,
-      reinterpret_cast<const CryptoPP::byte*>(m_Base64Alphabet.c_str()),
-      GetAlphabet().size(),
-      false);
-
-  CryptoPP::AlgorithmParameters const params(CryptoPP::MakeParameters(
-      CryptoPP::Name::DecodingLookupArray(),
-      reinterpret_cast<const int*>(lookup)));
+  CryptoPP::AlgorithmParameters static const params(CryptoPP::MakeParameters(
+      CryptoPP::Name::DecodingLookupArray(), s_Base64Table, false));
 
   // Decode
   return Radix::Decode<CryptoPP::Base64Decoder>(params, in, len);

--- a/src/core/crypto/impl/cryptopp/radix.cc
+++ b/src/core/crypto/impl/cryptopp/radix.cc
@@ -108,7 +108,7 @@ std::vector<std::uint8_t> Base32::Decode(
     const std::uint64_t len)
 {
   // Prepare decoder
-  CryptoPP::AlgorithmParameters static const params(CryptoPP::MakeParameters(
+  CryptoPP::AlgorithmParameters const params(CryptoPP::MakeParameters(
       CryptoPP::Name::DecodingLookupArray(), s_Base32Table, false));
 
   // Decode
@@ -140,7 +140,7 @@ std::vector<std::uint8_t> Base64::Decode(
     const std::uint64_t len)
 {
   // Prepare decoder
-  CryptoPP::AlgorithmParameters static const params(CryptoPP::MakeParameters(
+  CryptoPP::AlgorithmParameters const params(CryptoPP::MakeParameters(
       CryptoPP::Name::DecodingLookupArray(), s_Base64Table, false));
 
   // Decode

--- a/src/core/crypto/impl/cryptopp/radix.cc
+++ b/src/core/crypto/impl/cryptopp/radix.cc
@@ -108,8 +108,8 @@ std::vector<std::uint8_t> Base32::Decode(
     const std::uint64_t len)
 {
   // Prepare decoder
-  CryptoPP::AlgorithmParameters const params(CryptoPP::MakeParameters(
-      CryptoPP::Name::DecodingLookupArray(), s_Base32Table, false));
+  CryptoPP::AlgorithmParameters static const params(CryptoPP::MakeParameters(
+      CryptoPP::Name::DecodingLookupArray(), static_cast<const int*>(s_Base32Table), false));
 
   // Decode
   return Radix::Decode<CryptoPP::Base32Decoder>(params, in, len);
@@ -140,8 +140,8 @@ std::vector<std::uint8_t> Base64::Decode(
     const std::uint64_t len)
 {
   // Prepare decoder
-  CryptoPP::AlgorithmParameters const params(CryptoPP::MakeParameters(
-      CryptoPP::Name::DecodingLookupArray(), s_Base64Table, false));
+  CryptoPP::AlgorithmParameters static const params(CryptoPP::MakeParameters(
+      CryptoPP::Name::DecodingLookupArray(), static_cast<const int*>(s_Base64Table), false));
 
   // Decode
   return Radix::Decode<CryptoPP::Base64Decoder>(params, in, len);


### PR DESCRIPTION
This is a time/space tradeoff, but it also provides one-time initialization while avoiding a race.
It should also clear https://github.com/weidai11/cryptopp/issues/562, https://github.com/monero-project/kovri/pull/788 and https://github.com/monero-project/kovri/pull/802 once and for all (famous last words).

I was not sure of the project's style regarding internal linkage and hiding names so things were added to an unnamed namespace. Feel free to modify it mercilessly.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

