### PR TITLE
HTTPMessage: refactor jump service parser + add test-cases

### DIFF
--- a/src/client/proxy/http.cc
+++ b/src/client/proxy/http.cc
@@ -390,41 +390,94 @@ bool HTTPMessage::ExtractIncomingRequest() {
   return true;
 }
 
-void HTTPMessage::HandleJumpService() {
-  // TODO(GUZZI) should have boolean return value; error
-  // response?; research this
+bool HTTPMessage::HandleJumpService()
+{
   // TODO(anonimal): add support for remaining services /
   // rewrite this function
-  std::size_t pos1 = m_Path.rfind(m_JumpService.at(0));
-  std::size_t pos2 = m_Path.rfind(m_JumpService.at(1));
-  std::size_t pos;
-  if (pos1 == std::string::npos) {
-    if (pos2 == std::string::npos)
-      return;  // Not a jump service
-    else
-      pos = pos2;
-  } else {
-    if (pos2 == std::string::npos)
-      pos = pos1;
-    else if (pos1 > pos2)
-      pos = pos1;
-    else
-      pos = pos2;
-  }
-  auto base64 = m_Path.substr(pos + m_JumpService.at(0).size());
-  // We must decode
-  base64 = boost::network::uri::decoded(base64);
-  // Insert into address book
-  LOG(debug)
-    << "HTTPProxyHandler: jump service for " << m_Address
-    << " found at " << base64 << ", inserting to address book";
-  // TODO(unassigned): this is very dangerous and broken.
-  // We should ask the user for confirmation before proceeding.
-  // Previous reference: http://pastethis.i2p/raw/pn5fL4YNJL7OSWj3Sc6N/
-  // We *could* redirect the user again to avoid dirtiness in the browser
-  kovri::client::context.GetAddressBook().InsertAddressIntoStorage(
-      m_Address, base64);
-  m_Path.erase(pos);
+
+  // Perform sanity check again to:
+  // - ensure valid jump service request
+  std::size_t const pos = IsJumpServiceRequest();
+  if (!pos)
+    {
+      LOG(error) << "HTTPProxyHandler: not a valid jump service request";
+      // Jump service parameter not found in URL, so just return
+      return false;
+    }
+
+  if (!ExtractBase64Destination(pos))
+    {
+      LOG(error) << "HTTPProxyHandler: unable to process base64 destination for "
+                 << m_Address;
+      m_URL.erase(pos);
+      return false;
+    }
+
+  LOG(debug) << "HTTPProxyHandler: jump service for " << m_Address
+             << " found at " << m_Base64Destination;
+  m_URL.erase(pos);
+  return true;
+}
+
+std::size_t HTTPMessage::IsJumpServiceRequest() const
+{
+  std::size_t pos = 0;
+  std::size_t const pos1 = m_URL.rfind(m_JumpService.at(0));
+  std::size_t const pos2 = m_URL.rfind(m_JumpService.at(1));
+  if (pos1 == std::string::npos)
+    {
+      if (pos2 == std::string::npos)
+        return 0;  // Not a jump service
+      else
+        pos = pos2;
+    }
+  else
+    {
+      if (pos2 == std::string::npos)
+        pos = pos1;
+      else if (pos1 > pos2)
+        pos = pos1;
+      else
+        pos = pos2;
+    }
+
+  // final sanity check
+  if (pos && pos != std::string::npos)
+    return pos;
+
+  return 0;
+}
+
+bool HTTPMessage::ExtractBase64Destination(std::size_t const pos)
+{
+  std::size_t const base64_size = pos + m_JumpService.at(0).size();
+  if (pos && base64_size < m_URL.size())
+    {
+      std::string const base64 = m_URL.substr(base64_size);
+      m_Base64Destination = boost::network::uri::decoded(base64);
+      return true;
+    }
+
+  return false;
+}
+
+bool HTTPMessage::SaveJumpServiceAddress()
+{
+  try
+    {
+      LOG(debug) << "HTTPProxyHandler: inserting " << m_Address
+                 << " into address book";
+      kovri::client::context.GetAddressBook().InsertAddressIntoStorage(
+          m_Address, m_Base64Destination);
+    }
+  catch (...)
+    {
+      core::Exception ex;
+      ex.Dispatch("HTTPProxyHandler: unable to insert address into storage");
+      return false;
+    }
+
+  return true;
 }
 
 /* All hope is lost beyond this point */

--- a/src/client/proxy/http.h
+++ b/src/client/proxy/http.h
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -195,7 +195,7 @@ class HTTPMessage : public std::enable_shared_from_this<HTTPMessage>{
     m_URL, m_Method, m_Version,  m_Path;
   std::vector<std::string> m_Headers;
   std::string m_Host, m_UserAgent;
-  std::string m_Address;
+  std::string m_Address, m_Base64Destination;
 
   boost::asio::streambuf m_Buffer;
   boost::asio::streambuf m_BodyBuffer;
@@ -226,9 +226,9 @@ class HTTPMessage : public std::enable_shared_from_this<HTTPMessage>{
   /// return bool
   bool HandleData(const std::string  &buf);
 
-  /// @brief Parses path for base64 address, inserts into address book
-  /// need to change to boolean return for testing
-  void HandleJumpService();
+  /// @brief Parses URI for base64 destination
+  /// @return true on success
+  bool HandleJumpService();
 
   /// @brief Performs regex, sets address/port/path, validates version
   ///   on request sent from user
@@ -242,6 +242,19 @@ class HTTPMessage : public std::enable_shared_from_this<HTTPMessage>{
 
   const unsigned int HEADERBODY_LEN = 2;
   const unsigned int REQUESTLINE_HEADERS_MIN = 1;
+ private:
+  /// @brief Checks if request is a valid jump service request
+  /// @return Index of jump service helper sub-string, 0 indicates failure
+  std::size_t IsJumpServiceRequest() const;
+
+  /// @brief Extracts & url-decodes base64 destination from URL
+  /// @param pos Index of jump service helper sub-string in URL
+  /// @return True on success
+  bool ExtractBase64Destination(std::size_t const pos);
+
+  /// @brief Saves found address in address book
+  /// @return True on success
+  bool SaveJumpServiceAddress();
 };
 /// @class HTTPProxyServer
 /// setup asio service

--- a/tests/unit_tests/client/proxy/http.cc
+++ b/tests/unit_tests/client/proxy/http.cc
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2016, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -33,6 +33,53 @@
 #include <boost/test/unit_test.hpp>
 #include "client/proxy/http.h"
 
+struct HTTPProxyRequestFixture
+{
+  enum struct FunctionName 
+  {
+    CreateHTTPRequest,
+    ExtractIncomingRequest,
+    HandleData,
+    HandleJumpService
+  };
+
+  std::string CreateProxyHeader(const std::string uri) const
+  {
+    std::string proxy_header("GET ");
+    proxy_header.append(uri);
+    proxy_header.append(" HTTP/1.1\r\n\r\n");
+    return proxy_header;
+  }
+
+  bool HandleProxyFunction(
+      const std::string uri,
+      FunctionName function_name) const
+  {
+    std::string const header = CreateProxyHeader(uri);
+    kovri::client::HTTPMessage proxy_request;
+    if (!proxy_request.HandleData(header))
+      return false;
+    switch (function_name)
+      {
+        case FunctionName::CreateHTTPRequest:
+          if (!proxy_request.CreateHTTPRequest())
+            return false;
+          break;
+        case FunctionName::ExtractIncomingRequest:
+          if (!proxy_request.ExtractIncomingRequest())
+            return false;
+          break;
+        case FunctionName::HandleJumpService:
+          if (!proxy_request.HandleJumpService())
+            return false;
+          break;
+        default:
+          throw std::invalid_argument("unknown proxy function");
+      }
+    return true;
+  }
+};
+
 BOOST_AUTO_TEST_SUITE(HTTPPProtocolTests)
 
 BOOST_AUTO_TEST_CASE(Short) {
@@ -55,6 +102,99 @@ BOOST_AUTO_TEST_CASE(ok) {
   std::string tmpData = "GET guzzi.i2p ";
   tmpData+="HTTP/1.1\r\nUser-Agent: dummy\r\n\r\n";
   BOOST_CHECK(tmp.HandleData(tmpData));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+/**
+ *
+ * Jump service request tests
+ *
+ */
+
+BOOST_FIXTURE_TEST_SUITE(HTTPProxyJumpServiceTests, HTTPProxyRequestFixture)
+
+BOOST_AUTO_TEST_CASE(JumpServiceI2PAddressHelper)
+{
+  // Valid jump service request
+  std::string const valid_jump_request("stats.i2p?i2paddresshelper=0UVPqAA4xUSfPYPBca24h8fdokhwcJZ-5OsBYvK7byXtXT~fOV2pExi8vrkgarGTNDfJbB2KCsdVS3V7qwtTvoCGYyklcDBlJsWMj7H763hEz5rt9SzLkcpwhOjXL1UB-QW8KxM30t-ZOfPc6OiJ1QpnE6Bo5OUm6jPurQGXdWCAPio5Z-YnRL46n0IHWOQPYYSSt-S75rMIKbZbEMDraRvSzYAphUaHfvtWr2rCSPkKh3EbrOiBYiAP2oWvAQCsjouPgVBbiAezHedM2gXzkgIyCV2kGOOcHhiihd~7fWwJOloH-gO78QkmCuY-3kp3633v3MB-XNKWnATZOuf2syWVBZbTnOXsWf41tu6a33HOuNsMxAOUrwbu7Q-EITwNlKN6~yZm4RKsJUsBGfVtKl8PBMak3flQAg95oV0OBDGuizIQ9vREOWvPGlQCAXZzEg~cUNbfBQAEAAcAAA%3D%3D");
+  BOOST_CHECK(HandleProxyFunction(valid_jump_request, FunctionName::HandleJumpService));
+}
+
+BOOST_AUTO_TEST_CASE(JumpServiceI2PAddressHelperSecondParam)
+{
+  // Jump service request with preceding non-jump-service parameter
+  std::string const valid_jump_following("stats.i2p?some=key&i2paddresshelper=0UVPqAA4xUSfPYPBca24h8fdokhwcJZ4zWvELv-5OsBYTHKtnLzvK7byXtXT~fOV2pExi8vrkgarGTNDfJbB2KCsdVS3V7qwtTvoCGYyklcDBlJsWMj7H763hEz5rpwhO3t0Zwe6jXL1UB-QW8KxM30t-ZOfPc6OiJ1QpnE6Bo5OUm6jPurQGXdW-YnRL46n0IHWOQPYYSSt-S75rMIKbZbEMDraRvSzYAphUaHfvtWr2rCSPkKh3EbrOiBYiAP2oWvAQCsjouPgVBbiAezHedM2gXzkgIyCV2kGOOcHhiihd~7fWwJOloH-gO78QkmCuY-3kp3633v3MB-XNKWnATZOuf2syWVBZbTnOXsWf41tu6a33HOuNsMxAOUrwbu7Q-EITwNlKN6~yZm4RKsJUsBGfVtKl8PBMak3flQAg95oV0OBDGuizIQ9vREOWvPGlQCAXZzEg~cUNbfBQAEAAcAAA%3D%3D");
+  BOOST_CHECK(HandleProxyFunction(valid_jump_following, FunctionName::HandleJumpService));
+}
+
+BOOST_AUTO_TEST_CASE(JumpServiceInvalidThenValidHelper)
+{
+  // Jump service helper with preceding invalid helper
+  std::string const invalid_then_valid_jump("stats.i2p?i2paddresshelper=someinvalidbase64&i2paddresshelper=0UVPqAA4xUSfPYPBca24h8fdokhwcJZ4zWvELv-5OsBYTHKtnLzvK7byXtXT~fOV2pExi8vrkgarGTNDfJbB2KCsdVS3V7qwtTvoCGYyklcDBlJsWMj7H763hEz5rpwhO3t0Zwe6jXL1UB-QW8KxM30t-ZOfPc6OiJ1QpnE6Bo5OUm6jPurQGXdW-YnRL46n0IHWOQPYYSSt-S75rMIKbZbEMDraRvSzYAphUaHfvtWr2rCSPkKh3EbrOiBYiAP2oWvAQCsjouPgVBbiAezHedM2gXzkgIyCV2kGOOcHhiihd~7fWwJOloH-gO78QkmCuY-3kp3633v3MB-XNKWnATZOuf2syWVBZbTnOXsWf41tu6a33HOuNsMxAOUrwbu7Q-EITwNlKN6~yZm4RKsJUsBGfVtKl8PBMak3flQAg95oV0OBDGuizIQ9vREOWvPGlQCAXZzEg~cUNbfBQAEAAcAAA%3D%3D");
+  BOOST_CHECK(HandleProxyFunction(invalid_then_valid_jump, FunctionName::HandleJumpService));
+}
+
+BOOST_AUTO_TEST_CASE(JumpServiceMultiHelpersOutOfOrder)
+{
+  // Jump service helper with non-jump-service parameter,
+  //   followed by an invalid jump service helper,
+  //   followed by a valid jump service helper
+  std::string const multi_invalid_then_valid_jump("stats.i2p?some=key&i2paddresshelper=someinvalidbase64?i2paddresshelper=0UVPqAA4xUSfPYPBca24h8fdokhwcJZ4zWvELv-5OsBYTHKtnLzvK7byXtXT~fOV2pExi8vrkgarGTNDfJbB2KCsdVS3V7qwtTvoCGYyklcDBlJsWMj7H763hEz5rpwhO3t0Zwe6jXL1UB-QW8KxM30t-ZOfPc6OiJ1QpnE6Bo5OUm6jPurQGXdW-YnRL46n0IHWOQPYYSSt-S75rMIKbZbEMDraRvSzYAphUaHfvtWr2rCSPkKh3EbrOiBYiAP2oWvAQCsjouPgVBbiAezHedM2gXzkgIyCV2kGOOcHhiihd~7fWwJOloH-gO78QkmCuY-3kp3633v3MB-XNKWnATZOuf2syWVBZbTnOXsWf41tu6a33HOuNsMxAOUrwbu7Q-EITwNlKN6~yZm4RKsJUsBGfVtKl8PBMak3flQAg95oV0OBDGuizIQ9vREOWvPGlQCAXZzEg~cUNbfBQAEAAcAAA%3D%3D");
+  BOOST_CHECK(HandleProxyFunction(multi_invalid_then_valid_jump, FunctionName::HandleJumpService));
+}
+
+BOOST_AUTO_TEST_CASE(JumpServiceInvalidHelperSingle)
+{
+  // Invalid single jump service helper
+  std::string const invalid_single_jump("stats.i2p?i2paBBresshelper=0UVPqAA4xUSfPYPBca24h8fdokhwcJZ4zWvELv-5OsBYTHKtnLzvK7byXtXT~fOV2pExi8vrkgarGTNDfJbB2KCsdVS3V7qwtTvoCGYyklcDBlJsWMj7H763hEz5rt9SzLkcpwhO3t0Zwe6jXL1UB-QW8KxM30t-ZOfPc6OiJ1QpnE6Bo5OUm6jPurQGXdWCAPio5Z-YnRL46n0IHWOQPYYSStJMYPlPS-S75rMIKbZbEMDraRvSzYAphUaHfvtWr2rCSPkKh3EbrOiBYiAP2oWvAQCsjouPgVF2qwQRnBbiAezHedM2gXzkgIyCV2kGOOcHhiihd~7fWwJOloH-gO78QkmCuY-3kp3633v3MBw7pmABr-XNKWnATZOuf2syWVBZbTnOXsWf41tu6a33HOuNsMxAOUrwbu7QRmT4X8X-EITwNlKN6r1t3uoQ~yZm4RKsJUsBGfVtKl8PBMak3flQAg95oV0OBDGuizIQ9vREOWvPGlQCAXZzEg~cUNbfBQAEAAcAAA%3D%3D");
+  BOOST_CHECK(!HandleProxyFunction(invalid_single_jump, FunctionName::HandleJumpService));
+}
+
+BOOST_AUTO_TEST_CASE(JumpServiceInvalidHelperMultiple)
+{
+  // Invalid jump service helper with preceding non-jump-service parameter
+  std::string const invalid_multiple_jump("stats.i2p?some=key&i2paBBresshelper=0UVPqAA4xUSfPYPBca24h8fdokhwcJZ4zWvELv-5OsBYTHKtnLzvK7byXtXT~fOV2pExi8vrkgarGTNDfJbB2KCsdVS3V7qwtTvoCGYyklcDBlJsWMj7H763hEz5rt9SzLkcpwhO3t0Zwe6jXL1UB-QW8KxM30t-ZOfPc6OiJ1QpnE6Bo5OUm6jPurQGXdWCAPio5Z-YnRL46n0IHWOQPYYSStJMYPlPS-S75rMIKbZbEMDraRvSzYAphUaHfvtWr2rCSPkKh3EbrOiBYiAP2oWvAQCsjouPgVF2qwQRnBbiAezHedM2gXzkgIyCV2kGOOcHhiihd~7fWwJOloH-gO78QkmCuY-3kp3633v3MBw7pmABr-XNKWnATZOuf2syWVBZbTnOXsWf41tu6a33HOuNsMxAOUrwbu7QRmT4X8X-EITwNlKN6r1t3uoQ~yZm4RKsJUsBGfVtKl8PBMak3flQAg95oV0OBDGuizIQ9vREOWvPGlQCAXZzEg~cUNbfBQAEAAcAAA%3D%3D");
+  BOOST_CHECK(!HandleProxyFunction(invalid_multiple_jump, FunctionName::HandleJumpService));
+}
+
+BOOST_AUTO_TEST_CASE(JumpServiceNoHelper)
+{
+  std::string const no_jump_helper("stats.i2p");
+  BOOST_CHECK(!HandleProxyFunction(no_jump_helper, FunctionName::HandleJumpService));
+}
+
+BOOST_AUTO_TEST_CASE(JumpServiceNoBase64)
+{
+  std::string const no_jump_base64("stats.i2p?i2paddresshelper=");
+  BOOST_CHECK(!HandleProxyFunction(no_jump_base64, FunctionName::HandleJumpService));
+}
+
+/**
+ *
+ * CreateHTTPRequest jump service tests
+ *
+ */
+
+BOOST_AUTO_TEST_CASE(CreateHTTPRequestJumpService)
+{
+  // Valid jump service request
+  std::string const valid_jump_request("stats.i2p?i2paddresshelper=0UVPqAA4xUSfPYPBca24h8fdokhwcJZ-5OsBYvK7byXtXT~fOV2pExi8vrkgarGTNDfJbB2KCsdVS3V7qwtTvoCGYyklcDBlJsWMj7H763hEz5rt9SzLkcpwhOjXL1UB-QW8KxM30t-ZOfPc6OiJ1QpnE6Bo5OUm6jPurQGXdWCAPio5Z-YnRL46n0IHWOQPYYSSt-S75rMIKbZbEMDraRvSzYAphUaHfvtWr2rCSPkKh3EbrOiBYiAP2oWvAQCsjouPgVBbiAezHedM2gXzkgIyCV2kGOOcHhiihd~7fWwJOloH-gO78QkmCuY-3kp3633v3MB-XNKWnATZOuf2syWVBZbTnOXsWf41tu6a33HOuNsMxAOUrwbu7Q-EITwNlKN6~yZm4RKsJUsBGfVtKl8PBMak3flQAg95oV0OBDGuizIQ9vREOWvPGlQCAXZzEg~cUNbfBQAEAAcAAA%3D%3D");
+  BOOST_CHECK(HandleProxyFunction(valid_jump_request, FunctionName::CreateHTTPRequest));
+}
+
+BOOST_AUTO_TEST_CASE(CreateHTTPRequestJumpServiceInvalid)
+{
+  // Invalid single jump service helper
+  // Should pass, this could still be a valid HTTP proxy request
+  std::string const invalid_single_jump("stats.i2p?i2paBBresshelper=0UVPqAA4xUSfPYPBca24h8fdokhwcJZ4zWvELv-5OsBYTHKtnLzvK7byXtXT~fOV2pExi8vrkgarGTNDfJbB2KCsdVS3V7qwtTvoCGYyklcDBlJsWMj7H763hEz5rt9SzLkcpwhO3t0Zwe6jXL1UB-QW8KxM30t-ZOfPc6OiJ1QpnE6Bo5OUm6jPurQGXdWCAPio5Z-YnRL46n0IHWOQPYYSStJMYPlPS-S75rMIKbZbEMDraRvSzYAphUaHfvtWr2rCSPkKh3EbrOiBYiAP2oWvAQCsjouPgVF2qwQRnBbiAezHedM2gXzkgIyCV2kGOOcHhiihd~7fWwJOloH-gO78QkmCuY-3kp3633v3MBw7pmABr-XNKWnATZOuf2syWVBZbTnOXsWf41tu6a33HOuNsMxAOUrwbu7QRmT4X8X-EITwNlKN6r1t3uoQ~yZm4RKsJUsBGfVtKl8PBMak3flQAg95oV0OBDGuizIQ9vREOWvPGlQCAXZzEg~cUNbfBQAEAAcAAA%3D%3D");
+  BOOST_CHECK(HandleProxyFunction(invalid_single_jump, FunctionName::CreateHTTPRequest));
+}
+
+BOOST_AUTO_TEST_CASE(CreateHTTPRequestJumpServiceNoBase64)
+{
+  std::string const no_jump_base64("stats.i2p?i2paddresshelper=");
+  BOOST_CHECK(!HandleProxyFunction(no_jump_base64, FunctionName::CreateHTTPRequest));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Part of #812, HTTPMessage::HandleJumpService now searches the HTTP URI for the `i2paddresshelper` parameter.

Unit test to ensure correct handling of valid jump service parameter.

Still requires unit tests for invalid parameters, and other failure cases.