### PR TITLE
SSUSession: get intro key from IPv6 capable routers

### DIFF
--- a/src/core/router/transports/ssu/session.cc
+++ b/src/core/router/transports/ssu/session.cc
@@ -1705,14 +1705,16 @@ const std::uint8_t* SSUSession::GetIntroKey() const
   if (m_RemoteRouter)
     {
       LOG(debug) << "SSUSession: " << __func__ << ": using remote's key";
-      auto* address = m_RemoteRouter->GetSSUAddress();
+      auto* const address =
+          m_RemoteRouter->GetSSUAddress(m_RemoteRouter->HasV6());
       assert(address);  // TODO(anonimal): SSU should be guaranteed
       return address->key;
     }
 
   // Use our key if we are server
   LOG(debug) << "SSUSession: " << __func__ << ": using our key";
-  auto* address = context.GetRouterInfo().GetSSUAddress();
+  auto* const address =
+      context.GetRouterInfo().GetSSUAddress(context.GetRouterInfo().HasV6());
   assert(address);  // TODO(anonimal): SSU should be guaranteed
   return address->key;
 }


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Fixes #827, for now.