### PR TITLE
Kovri: implement SSU IPv6 peer testing + bump I2P router version to 0.9.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ message(STATUS "${KOVRI_VERSION}-${KOVRI_GIT_REVISION} \"${KOVRI_CODENAME}\"")
 message(STATUS "")
 
 # I2NP/NetDb RI properties (used internally)
-set(I2P_VERSION "0.9.26")
+set(I2P_VERSION "0.9.27")
 set(I2P_NETWORK_ID "2")  # "1" is reserved for I2P version less than 0.6.1.10
 
 # Produce version definitions, output to build directory

--- a/src/core/router/context.cc
+++ b/src/core/router/context.cc
@@ -42,6 +42,7 @@
 #include "core/router/info.h"
 #include "core/router/net_db/impl.h"
 
+#include "core/util/byte_stream.h"
 #include "core/util/filesystem.h"
 #include "core/util/mtu.h"
 #include "core/util/timestamp.h"
@@ -216,27 +217,7 @@ void RouterContext::UpdateAddress(
     const std::uint16_t port)
 {
   // Set new host address as IPv4 or IPv6
-  // TODO(unassigned): move to utility code
-  boost::asio::ip::address new_host;
-  switch (size)
-    {
-      case 4:
-        {
-          boost::asio::ip::address_v4::bytes_type bytes;
-          std::memcpy(bytes.data(), host, size);
-          new_host = boost::asio::ip::address_v4(bytes);
-        }
-        break;
-      case 16:
-        {
-          boost::asio::ip::address_v6::bytes_type bytes;
-          std::memcpy(bytes.data(), host, size);
-          new_host = boost::asio::ip::address_v6(bytes);
-        }
-        break;
-      default:
-        throw std::length_error("invalid address size");
-    };
+  boost::asio::ip::address new_host(BytesToAddress(host, size));
 
   // Set new host if applicable
   bool updated = false;

--- a/src/core/router/transports/ssu/packet.cc
+++ b/src/core/router/transports/ssu/packet.cc
@@ -642,12 +642,14 @@ std::uint32_t SSUPeerTestPacket::GetNonce() const {
   return m_Nonce;
 }
 
-void SSUPeerTestPacket::SetIPAddress(
-    std::uint32_t address) {
+// TODO(anonimal): use or remove
+void SSUPeerTestPacket::SetIPAddress(const boost::asio::ip::address& address)
+{
   m_IPAddress = address;
 }
 
-std::uint32_t SSUPeerTestPacket::GetIPAddress() const {
+const boost::asio::ip::address& SSUPeerTestPacket::GetIPAddress() const
+{
   return m_IPAddress;
 }
 
@@ -890,11 +892,8 @@ std::unique_ptr<SSUDataPacket> SSUPacketParser::ParseData() {
 std::unique_ptr<SSUPeerTestPacket> SSUPacketParser::ParsePeerTest() {
   auto packet = std::make_unique<SSUPeerTestPacket>();
   packet->SetNonce(Read<std::uint32_t>());
-  // TODO(anonimal): handle other address sizes
-  if (Read<std::uint8_t>() != 4)
-    throw std::length_error(
-        "SSUPacketParser: invalid peer test packet address size");
-  packet->SetIPAddress(Read<std::uint32_t>());
+  std::uint8_t const size(Read<std::uint8_t>());
+  packet->SetIPAddress(core::BytesToAddress(ReadBytes(size), size));
   packet->SetPort(Read<std::uint16_t>());
   packet->SetIntroKey(ReadBytes(SSUSize::IntroKey));
   return packet;

--- a/src/core/router/transports/ssu/packet.h
+++ b/src/core/router/transports/ssu/packet.h
@@ -686,17 +686,13 @@ class SSUPeerTestPacket : public SSUPacket {
   /// @return Nonce that was previously set when parsed
   std::uint32_t GetNonce() const;
 
-  // TODO(unassigned): implement SetIPAddress() like others (see spec)?
-  /// @brief Sets Alice's 1 byte IP address and byte size representation
-  ///   of Alice's IP address
+  /// @brief Sets IP address as set by message owner (see SSU spec)
   /// @note Assumes content is valid (based on position)
-  /// @param address Alice's IP address
-  void SetIPAddress(
-      std::uint32_t address);
+  /// @param address IP address
+  void SetIPAddress(const boost::asio::ip::address& address);
 
-  // TODO(unassigned): implement GetIPAddress() like others (see spec)?
-  /// @return Alice's IP address that was previously set when parsed
-  std::uint32_t GetIPAddress() const;
+  /// @return IP address that was previously set when parsed
+  const boost::asio::ip::address& GetIPAddress() const;
 
   /// @brief Sets Alice's 2 byte port number
   /// @note Assumes content is valid (based on position)
@@ -720,7 +716,8 @@ class SSUPeerTestPacket : public SSUPacket {
   std::size_t GetSize() const;
 
  private:
-  std::uint32_t m_Nonce, m_IPAddress;
+  std::uint32_t m_Nonce;
+  boost::asio::ip::address m_IPAddress;
   std::uint8_t* m_IntroKey;
   std::uint16_t m_Port;
 };

--- a/src/core/router/transports/ssu/session.h
+++ b/src/core/router/transports/ssu/session.h
@@ -308,7 +308,7 @@ class SSUSession
 
   void SendPeerTest(
       const std::uint32_t nonce,
-      const std::uint32_t address,
+      const boost::asio::ip::address& address,
       const std::uint16_t port,
       const std::uint8_t* intro_key,
       const bool to_address = true,

--- a/src/core/util/byte_stream.cc
+++ b/src/core/util/byte_stream.cc
@@ -30,6 +30,8 @@
 
 #include "core/util/byte_stream.h"
 
+#include <boost/asio/ip/address.hpp>
+
 #include <cassert>
 #include <cstring>
 #include <iomanip>
@@ -192,6 +194,36 @@ std::vector<std::uint8_t> AddressToByteVector(
             : address.to_v6().to_bytes().data(),
       data.size());
   return data;
+}
+
+boost::asio::ip::address BytesToAddress(
+    const std::uint8_t* host,
+    const std::uint8_t size)
+{
+  boost::asio::ip::address address;
+
+  assert(size == 4 || size == 16);
+  switch (size)
+    {
+      case 4:
+        {
+          boost::asio::ip::address_v4::bytes_type bytes;
+          std::memcpy(bytes.data(), host, size);
+          address = boost::asio::ip::address_v4(bytes);
+        }
+        break;
+      case 16:
+        {
+          boost::asio::ip::address_v6::bytes_type bytes;
+          std::memcpy(bytes.data(), host, size);
+          address = boost::asio::ip::address_v6(bytes);
+        }
+        break;
+      default:
+        throw std::length_error("invalid address size");
+    };
+
+  return address;
 }
 
 }  // namespace core

--- a/src/core/util/byte_stream.h
+++ b/src/core/util/byte_stream.h
@@ -238,6 +238,13 @@ const std::string GetFormattedHex(
 std::vector<std::uint8_t> AddressToByteVector(
     const boost::asio::ip::address& address);
 
+/// @brief Returns asio address of byte array
+/// @param host IP address in byte form
+/// @param size Size of host byte array
+boost::asio::ip::address BytesToAddress(
+    const std::uint8_t* host,
+    const std::uint8_t size);
+
 // TODO(anonimal): remove from global namespace
 namespace
 {


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

See git-log for details.

Resolves #213 (finally). Referencing https://github.com/monero-project/kovri/issues/433#issuecomment-321105373 and #140.

Requires merging of #828.
