### PR TITLE
RouterInfo: Expand --host to take both ipv4 and ipv6 addresses.

### DIFF
--- a/src/core/router/context.cc
+++ b/src/core/router/context.cc
@@ -48,6 +48,7 @@
 #include "core/util/filesystem.h"
 #include "core/util/mtu.h"
 #include "core/util/timestamp.h"
+#include "core/util/config.h"
 
 namespace kovri
 {
@@ -77,7 +78,7 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
 
   // Set host/port for RI creation/updating
   // Note: host/port sanity checks done during configuration construction
-  auto host = m_Opts["host"].as<std::string>();  // TODO(anonimal): fix default host
+  auto hosts = m_Opts["host"].as<core::Configuration::ListParameter<std::string, 2>>();  // TODO(anonimal): fix default host
   auto port = m_Opts["port"].defaulted()
                   ? RandInRange32(RouterInfo::MinPort, RouterInfo::MaxPort)
                   : m_Opts["port"].as<int>();
@@ -110,10 +111,12 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
       m_Keys.ToBuffer(buf.data(), buf.size());
       keys.Write(buf.data(), buf.size());
 
-      LOG(debug) << "RouterContext: creating RI from in-memory keys";
+      // Read and fill the RI points
       std::vector<std::pair<std::string, std::uint16_t>> points;
-      points.emplace_back(host, port);
+      for (const auto& host : hosts.values)
+        points.emplace_back(host, port);
 
+      LOG(debug) << "RouterContext: creating RI from in-memory keys";
       core::RouterInfo router(
           m_Keys,
           points,
@@ -132,16 +135,35 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
       LOG(debug) << "RouterContext: updating existing RI " << info_path;
       core::RouterInfo router(info_path);
 
-      // NTCP
-      if (has_ntcp && !router.GetNTCPAddress())
-        router.AddAddress(std::make_tuple(Transport::NTCP, host, port));
+      for (const auto& host : hosts.values)
+        {
+          const auto& address = boost::asio::ip::address::from_string(host);
+
+          // NTCP
+          if (has_ntcp && !router.GetNTCPAddress(address.is_v6()))
+            {
+              LOG(debug)
+                  << "RouterContext: enable-ntcp present and no transport "
+                     "found in existing routerInfo for host "
+                  << host;
+              router.AddAddress(std::make_tuple(Transport::NTCP, host, port));
+            }
+          // SSU
+          if (has_ssu && !router.GetSSUAddress(address.is_v6()))
+            {
+              LOG(debug)
+                  << "RouterContext: enable-ssu present and no transport "
+                     "found in existing routerInfo for host "
+                  << host;
+              router.AddAddress(
+                  std::make_tuple(Transport::SSU, host, port),
+                  router.GetIdentHash());
+            }
+        }
+
       if (!has_ntcp)
         RemoveTransport(core::RouterInfo::Transport::NTCP);
 
-      // SSU
-      if (has_ssu && !router.GetSSUAddress())
-        router.AddAddress(
-            std::make_tuple(Transport::SSU, host, port), router.GetIdentHash());
       if (!has_ssu)
         {
           RemoveTransport(core::RouterInfo::Transport::SSU);
@@ -164,7 +186,7 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
         SetReachable();
     }
 
-  LOG(info) << "RouterContext: will listen on host " << host;
+  LOG(info) << "RouterContext: will listen on host " << hosts.raw_data;
   LOG(info) << "RouterContext: will listen on port " << port;
 
   // TODO(anonimal): we don't want a flurry of micro-managed setter functions

--- a/src/core/router/context.cc
+++ b/src/core/router/context.cc
@@ -37,6 +37,8 @@
 
 #include <fstream>
 #include <tuple>
+#include <vector>
+#include <utility>
 
 #include "core/router/i2np.h"
 #include "core/router/info.h"
@@ -109,9 +111,12 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
       keys.Write(buf.data(), buf.size());
 
       LOG(debug) << "RouterContext: creating RI from in-memory keys";
+      std::vector<std::pair<std::string, std::uint16_t>> points;
+      points.emplace_back(host, port);
+
       core::RouterInfo router(
           m_Keys,
-          std::make_pair(host, port),
+          points,
           std::make_pair(has_ntcp, has_ssu));  // TODO(anonimal): brittle, see TODO in header
 
       // Update context RI

--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -669,14 +669,12 @@ void RouterInfo::DisableV6()
   m_SupportedTransports &= ~SupportedTransport::SSUv6;
 
   // Remove addresses in question
-  for (std::size_t i = 0; i < m_Addresses.size(); i++)
-    {
-      if (m_Addresses[i].host.is_v6())
-        {
-          LOG(debug) << "RouterInfo: " << __func__ << ": removing address";
-          m_Addresses.erase(m_Addresses.begin() + i);
-        }
-    }
+  m_Addresses.erase(
+      std::remove_if(
+          std::begin(m_Addresses),
+          std::end(m_Addresses),
+          [](const auto& address) { return address.host.is_v6(); }),
+      std::end(m_Addresses));
 }
 
 void RouterInfo::Update(const std::uint8_t* buf, std::uint16_t len)

--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -60,7 +60,7 @@ RouterInfo::RouterInfo() : m_Exception(__func__), m_Buffer(nullptr)  // TODO(ano
 
 RouterInfo::RouterInfo(
     const core::PrivateKeys& keys,
-    const std::pair<std::string, std::uint16_t>& point,
+    const std::vector<std::pair<std::string, std::uint16_t>>& points,
     const std::pair<bool, bool>& has_transport,
     const std::uint8_t caps)
     : m_Exception(__func__), m_RouterIdentity(keys.GetPublic())
@@ -76,14 +76,19 @@ RouterInfo::RouterInfo(
   // Set default caps
   SetCaps(caps);
 
-  // Set default transports
-  if (has_transport.first)
-    AddAddress(std::make_tuple(Transport::NTCP, point.first, point.second));
+  for (const auto& point : points)
+    {
+      // Set default transports
+      if (has_transport.first)
+        AddAddress(std::make_tuple(Transport::NTCP, point.first, point.second));
+
+      if (has_transport.second)
+        AddAddress(
+            std::make_tuple(Transport::SSU, point.first, point.second), hash);
+    }
 
   if (has_transport.second)
     {
-      AddAddress(
-          std::make_tuple(Transport::SSU, point.first, point.second), hash);
       SetCaps(
           m_Caps | core::RouterInfo::Cap::SSUTesting
           | core::RouterInfo::Cap::SSUIntroducer);

--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -435,13 +435,13 @@ class RouterInfo : public RouterInfoTraits, public RoutingDestination
   ~RouterInfo();
 
   /// @brief Create RI with standard defaults
-  /// @param point Local hostname/ip address + port
-  /// @param has_transport Supports NTCP, SSU
   /// @param keys Privkeys which generate identity
+  /// @param points Local hostname/ip address + port list
+  /// @param has_transport Supports NTCP, SSU
   /// @param caps RI capabilities
   RouterInfo(
       const core::PrivateKeys& keys,
-      const std::pair<std::string, std::uint16_t>& point,
+      const std::vector<std::pair<std::string, std::uint16_t>>& points,
       const std::pair<bool, bool>& has_transport,  // TODO(anonimal): refactor as bitwise SupportedTransport?
       const std::uint8_t caps = core::RouterInfo::Cap::Reachable);
 

--- a/src/core/util/config.h
+++ b/src/core/util/config.h
@@ -39,6 +39,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/tokenizer.hpp>
+
 #include "core/util/exception.h"
 #include "core/util/filesystem.h"
 
@@ -46,9 +48,135 @@ namespace kovri
 {
 namespace core
 {
+
+/// @class ConfigInternal
+/// @brief Internal Core base configuration implementation
+class ConfigInternal {
+ protected:
+  /// @class ListParameter
+  /// @brief Class used to handle custom data out of the boost::program_options.
+  /// @details Template class which accepts string, integral and floating point types.
+  ///          This class can perform a parse of a string with ',' (comma) separated
+  ///          character and split the token sinto the internal values (std::vector<T>)
+  ///          member which can be accessed directly (public member).
+  /// @param   T: string, integral and floating point types. (future anytype ie: boost::asio::ip::address)
+  /// @param   MAX: define the max expected number of item to be inserted in the internal
+  ///          values. This size can be exceed with no issue, but the IsExpectedSize will fail
+  ///          once checked.
+  template <typename T, int MAX>
+  struct ListParameter
+  {
+   private:
+    /// @return The value converted from the string value into T.
+    /// @brief We apply a lexical_cast only for integral or floating point types.
+    template <typename U>
+    U GetValue(
+        const std::string& string_value,
+        typename std::enable_if<std::is_integral<U>::value
+                                || std::is_floating_point<U>::value>::type*
+            value = 0)
+    {
+      try
+        {
+          return boost::lexical_cast<U>(string_value);
+        }
+      catch (const boost::bad_lexical_cast& ex)
+        {
+          throw std::runtime_error(ex.what());
+        }
+    }
+
+    /// @return The original values as it was passed, no modifications are made.
+    /// @brief Overload of @GetValue to handle the string case.
+    template <typename U>
+    U GetValue(
+        const std::string& string_value,
+        typename std::enable_if<std::is_same<std::string,
+                                             typename std::decay<U>::type>::
+                                    value>::type* value = 0) noexcept
+    {
+      return string_value;
+    }
+
+   public:
+    static constexpr int limit = MAX;
+    // This is what is only allowed for now.
+    static_assert(
+        std::is_same<std::string, typename std::decay<T>::type>::value
+            || std::is_integral<T>::value
+            || std::is_floating_point<T>::value,
+        "Type not supported.");
+
+    /// @brief we should handle default values also through the default_value() function.
+    explicit ListParameter(const std::string& plain_params)
+        : raw_data(plain_params)
+    {
+      // May not make a big diff if we do not expect a large collection.
+      values.reserve(MAX);
+      // Parse the default value.
+      ParseFrom(raw_data);
+    }
+
+    // We need the default constructor as the boost::program_options::value should
+    // be default constructible.
+    ListParameter() = default;
+    // We want to enable move/copy semantic on this helper class. Previous declaration
+    // force us to define the following.
+    ListParameter(const ListParameter&) = default;
+    ListParameter& operator=(const ListParameter&) = default;
+    ListParameter(ListParameter&&) = default;
+    ListParameter& operator=(ListParameter&&) = default;
+
+    /// @return true if the internal list size is what we expect. Defined by the template param.
+    inline bool IsExpectedSize() const noexcept
+    {
+      return values.size() <= MAX;
+    }
+
+    /// @brief Parse and fill the internal values.
+    void ParseFrom(const std::string& parameter_data)
+    {
+      if (parameter_data.empty())
+        return;
+      try
+        {
+          // TODO(unassigned): Make the separator configurable.
+          boost::char_separator<char> token_separator{","};
+          boost::tokenizer<boost::char_separator<char>> tokens{parameter_data,
+                                                               token_separator};
+          for (const auto& token : tokens)
+            {
+              // We can be in the case where we need to insert a plain string which
+              // is what we get from the token in this case. This type can be inserted
+              // into the values straigh away *only* if T is a std:string, any other
+              // type must be converted to T, that's why we use the helper function
+              // config_internal::GetValue<T>() which in the case of not a std::string
+              // will perform a boost::lexical_cast<T> from the given string token.
+              // If the token is invalid or is there any issue during the cast, a
+              // std::runtime_error exception will be fired.
+              values.push_back(GetValue<T>(token));
+            }
+        }
+      catch (const std::runtime_error& re)
+        {
+          // Mind exceptions from the lexical_cast done in config_internal::GetValue<T>
+          throw boost::program_options::validation_error(
+              boost::program_options::validation_error::invalid_option_value);
+        }
+      // save the original data
+      raw_data = parameter_data;
+    }
+    // values will hold the result list after parsing.
+    std::vector<T> values;
+    // In case you need the raw data passed by bpo.
+    // TODO(unassigned): Check default constructor.
+    std::string raw_data;
+  };
+};
+
 /// @class Configuration
 /// @brief Core configuration implementation
-class Configuration
+class Configuration final: public ConfigInternal
 {
  public:
   /// @param args Taken as standard argv arguments (element = "space delimited" arg)
@@ -111,6 +239,29 @@ class Configuration
       const boost::program_options::options_description& config_options,
       boost::program_options::variables_map& var_map);
 };
+
+/// @brief stream in conversion implementation to be used by the boost program
+///        options library. This function is needed so the boost::program_options
+///        delegates the construction and parsing of the Listparameter object.
+template <typename T, int MAX>
+std::istream& operator>>(std::istream& in, ConfigInternal::ListParameter<T, MAX>& value)
+{
+  std::string parameter_data;
+  in >> parameter_data;
+  value.ParseFrom(parameter_data);
+  return in;
+}
+
+/// @brief Stream out conversion implementation to be used by the boost program
+///        options.
+///        This function is needed so the boost::program_options delegates the
+///        construction and parsing the expected object.
+template <typename T, int MAX>
+std::ostream& operator<<(std::ostream& os, const ConfigInternal::ListParameter<T, MAX>& value)
+{
+  os << value.raw_data;
+  return os;
+}
 
 }  // namespace core
 }  // namespace kovri

--- a/src/core/util/config.h
+++ b/src/core/util/config.h
@@ -52,7 +52,7 @@ namespace core
 /// @class ConfigInternal
 /// @brief Internal Core base configuration implementation
 class ConfigInternal {
- protected:
+ public:
   /// @class ListParameter
   /// @brief Class used to handle custom data out of the boost::program_options.
   /// @details Template class which accepts string, integral and floating point types.

--- a/src/util/routerinfo.cc
+++ b/src/util/routerinfo.cc
@@ -39,6 +39,7 @@
 #include "core/util/exception.h"
 #include "core/util/filesystem.h"
 #include "core/util/log.h"
+#include "core/util/config.h"
 #include "version.h"  // NOLINT(build/include)
 
 namespace bpo = boost::program_options;
@@ -53,7 +54,9 @@ RouterInfoCommand::RouterInfoCommand()
   bpo::options_description create_options("Create options");
   create_options.add_options()(
       "create,c", bpo::bool_switch()->default_value(false))(
-      "host", bpo::value<std::string>()->default_value("127.0.0.1"))(
+      "host",
+      bpo::value<core::Configuration::ListParameter<std::string, 2>>()->default_value(
+          core::Configuration::ListParameter<std::string, 2>("127.0.0.1")))(
       "port", bpo::value<int>()->default_value(0))(
       "floodfill,f",
       bpo::value<bool>()->default_value(false)->value_name("bool"))(
@@ -74,8 +77,10 @@ void RouterInfoCommand::PrintUsage(const std::string& name) const
 {
   LOG(info) << "Syntax: " << name << m_Options;
   LOG(info) << "Example: " << name << " routerInfo-(...).dat";
-  LOG(info) << "or: " << name << " --create --host 192.168.1.1 --port 10100 "
-                                 "--floodfill 1 --bandwidth P";
+  LOG(info) << "or: " << name
+            << " --create --host "
+               "192.168.1.1,2a01:e35:8b5c:b240:71a2:6750:8d4:47fa --port 10100 "
+               "--floodfill 1 --bandwidth P";
 }
 
 bool RouterInfoCommand::Impl(
@@ -116,7 +121,7 @@ bool RouterInfoCommand::Impl(
                             "for creation";
               return false;
             }
-          auto host = vm["host"].as<std::string>();
+          auto hosts = vm["host"].as<core::Configuration::ListParameter<std::string, 2>>();
           auto port = vm["port"].defaulted() ? core::RandInRange32(
                                                    core::RouterInfo::MinPort,
                                                    core::RouterInfo::MaxPort)
@@ -134,9 +139,12 @@ bool RouterInfoCommand::Impl(
           // Generate private key
           core::PrivateKeys keys = core::PrivateKeys::CreateRandomKeys(
               core::DEFAULT_ROUTER_SIGNING_KEY_TYPE);
-          // Create router info
+
+          // Read and fill the RI points
           std::vector<std::pair<std::string, std::uint16_t>> points;
-          points.emplace_back(host, port);
+          for (const auto& host : hosts.values)
+            points.emplace_back(host, port);
+          // Create router info
           core::RouterInfo routerInfo(
               keys, points, std::make_pair(has_ntcp, has_ssu), caps);
           // Set capabilities after creation to allow for disabling

--- a/src/util/routerinfo.cc
+++ b/src/util/routerinfo.cc
@@ -122,6 +122,7 @@ bool RouterInfoCommand::Impl(
                                                    core::RouterInfo::MaxPort)
                                              : vm["port"].as<int>();
 
+
           // Set transports
           bool const has_ntcp = vm["enable-ntcp"].as<bool>();
           bool const has_ssu = vm["enable-ssu"].as<bool>();
@@ -135,11 +136,10 @@ bool RouterInfoCommand::Impl(
           core::PrivateKeys keys = core::PrivateKeys::CreateRandomKeys(
               core::DEFAULT_ROUTER_SIGNING_KEY_TYPE);
           // Create router info
+          std::vector<std::pair<std::string, std::uint16_t>> points;
+          points.emplace_back(host, port);
           core::RouterInfo routerInfo(
-              keys,
-              std::make_pair(host, port),
-              std::make_pair(has_ntcp, has_ssu),
-              caps);
+              keys, points, std::make_pair(has_ntcp, has_ssu), caps);
           // Set capabilities after creation to allow for disabling
           if (vm["ssuintroducer"].as<bool>())
             caps |= core::RouterInfo::Cap::SSUIntroducer;

--- a/src/util/routerinfo.cc
+++ b/src/util/routerinfo.cc
@@ -122,7 +122,6 @@ bool RouterInfoCommand::Impl(
                                                    core::RouterInfo::MaxPort)
                                              : vm["port"].as<int>();
 
-
           // Set transports
           bool const has_ntcp = vm["enable-ntcp"].as<bool>();
           bool const has_ssu = vm["enable-ssu"].as<bool>();


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Add to the existing --host parameter the capabilities to handle both ipv4 and ipv6 address
using a "," separator.

See #777

