### PR TITLE
Kovri: implement requisites for 0.9.28 + bump I2P router version to 0.9.28

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ message(STATUS "${KOVRI_VERSION}-${KOVRI_GIT_REVISION} \"${KOVRI_CODENAME}\"")
 message(STATUS "")
 
 # I2NP/NetDb RI properties (used internally)
-set(I2P_VERSION "0.9.27")
+set(I2P_VERSION "0.9.28")
 set(I2P_NETWORK_ID "2")  # "1" is reserved for I2P version less than 0.6.1.10
 
 # Produce version definitions, output to build directory

--- a/src/core/crypto/impl/cryptopp/elgamal.cc
+++ b/src/core/crypto/impl/cryptopp/elgamal.cc
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -75,8 +75,10 @@ class ElGamalEncryption::ElGamalEncryptionImpl {
     }
     std::array<std::uint8_t, 255> memory;
     // Don't pad with uninitialized memory
-    RandBytes(memory.data(), 255);
-    memory.at(0) = 0xFF;
+    core::RandBytes(memory.data(), memory.size());
+    // Ensure first byte is spec-defined, non-zero, random byte
+    while (!memory.at(0))
+      core::RandBytes(memory.data(), 1);
     memcpy(memory.data() + 33, data, len);
     CryptoPP::SHA256().CalculateDigest(
         memory.data() + 1,

--- a/src/core/router/transports/ssu/packet.h
+++ b/src/core/router/transports/ssu/packet.h
@@ -47,12 +47,12 @@ namespace core {
 enum SSUSize : std::uint16_t
 {
   MTUv4 = 1484,
-  MTUv6 = 1472,
+  MTUv6 = 1488,
   HeaderIPv4 = 20,
   HeaderIPv6 = 40,
   HeaderUDP = 8,
   PacketMaxIPv4 = MTUv4 - HeaderIPv4 - HeaderUDP,  // Total: 1456
-  PacketMaxIPv6 = MTUv6 - HeaderIPv6 - HeaderUDP,  // Total: 1424
+  PacketMaxIPv6 = MTUv6 - HeaderIPv6 - HeaderUDP,  // Total: 1440
   HeaderMin = 37,
   MAC = 16,
   IV = 16,

--- a/src/core/router/tunnel/impl.h
+++ b/src/core/router/tunnel/impl.h
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -61,7 +61,7 @@ const int TUNNEL_EXPIRATION_TIMEOUT = 660,    // 11 minutes
           TUNNEL_EXPIRATION_THRESHOLD = 60,   // 1 minute
           TUNNEL_RECREATION_THRESHOLD = 90,   // 1.5 minutes
           TUNNEL_CREATION_TIMEOUT = 30,       // 30 seconds
-          STANDARD_NUM_RECORDS = 5;           // in VariableTunnelBuild message
+          STANDARD_NUM_RECORDS = 4;           // in VariableTunnelBuild message
 
 enum TunnelState {
   e_TunnelStatePending,

--- a/src/core/util/mtu.h
+++ b/src/core/util/mtu.h
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -42,8 +42,8 @@
 namespace kovri {
 namespace core {
 
-// TODO(unassigned): enum class refactor
-const std::uint16_t MTU_MAX = 1472;
+// TODO(anonimal): enum refactor
+const std::uint16_t MTU_MAX = 1488;
 const std::uint16_t MTU_FALLBACK = 576;
 
 // @return the maximum transmission unit or fallback on failure


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Resolves #408. Referencing https://github.com/monero-project/kovri/issues/433#issuecomment-321105373.