### PR TITLE
AddressBook + HTTP Proxy: store only unique subscription addresses

### DIFF
--- a/src/client/address_book/impl.h
+++ b/src/client/address_book/impl.h
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -107,9 +107,18 @@ class AddressBook : public AddressBookDefaults {
     return m_SharedLocalDestination;
   }
 
+  /// @brief Insert address into in-memory storage
+  /// @param host Human-readable hostname to insert
+  /// @param address Hash of address to insert
+  /// @notes Throws if host or address are duplicates
+  void InsertAddress(
+      const std::string& host,
+      const kovri::core::IdentHash& address);
+
   /// @brief Inserts address into address book from HTTP Proxy jump service
   /// @param address Const reference to human-readable address
   /// @param base64 Const reference to Base64 address
+  // TODO(oneiric): remove after separating HTTP Proxy from Address Book
   void InsertAddressIntoStorage(
       const std::string& address,
       const std::string& base64);


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Fixes #814

__edit__: HTTP Proxy is changed indirectly through the Address Book singleton the proxy uses to save jump service addresses.