### PR TITLE
Get rid of VLA usage

### DIFF
--- a/src/core/util/filesystem.cc
+++ b/src/core/util/filesystem.cc
@@ -96,7 +96,7 @@ StringStream::ReadKeyPair()
 
   // TODO(anonimal): debug logging; include delimiter/terminator
 
-  return std::make_tuple(key, value, read_size);
+  return std::make_tuple(std::move(key), std::move(value), read_size);
 }
 
 std::string StringStream::ReadStringFromByte()

--- a/src/core/util/filesystem.cc
+++ b/src/core/util/filesystem.cc
@@ -71,7 +71,7 @@ StringStream::StringStream(
   m_Terminator = terminator;
 }
 
-const std::tuple<std::string, std::string, std::size_t>
+std::tuple<std::string, std::string, std::size_t>
 StringStream::ReadKeyPair()
 {
   std::uint16_t read_size(0);  // TODO(anonimal): member for stream read size
@@ -99,7 +99,7 @@ StringStream::ReadKeyPair()
   return std::make_tuple(key, value, read_size);
 }
 
-const std::string StringStream::ReadStringFromByte()
+std::string StringStream::ReadStringFromByte()
 {
   // Get stated length amount
   std::uint8_t len;

--- a/src/core/util/filesystem.cc
+++ b/src/core/util/filesystem.cc
@@ -105,12 +105,11 @@ std::string StringStream::ReadStringFromByte()
   std::uint8_t len;
   m_Stream.read(reinterpret_cast<char*>(&len), 1);
 
-  // Read given amount
-  char buf[len];
-  m_Stream.read(reinterpret_cast<char*>(buf), len);
+  std::string string(len, '\0');
 
-  // Return as string
-  const std::string string(buf, len);
+  // Read given amount
+  m_Stream.read(const_cast<char*>(string.data()), string.size());
+
   return string;
 }
 

--- a/src/core/util/filesystem.h
+++ b/src/core/util/filesystem.h
@@ -110,10 +110,10 @@ class StringStream {
  public:
   /// @return Tuple of key pair (key/value) + size read of stream
   // TODO(anonimal): std::pair refactor, use member for read stream size
-  const std::tuple<std::string, std::string, std::size_t> ReadKeyPair();
+  std::tuple<std::string, std::string, std::size_t> ReadKeyPair();
 
   /// @return String value of stream amount as described in byte
-  const std::string ReadStringFromByte();
+  std::string ReadStringFromByte();
 
   /// @brief Write key value pair (with delimiter and terminator) to stream
   /// @warning Writes size of key then key, size of value and then value


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

We don't really need VLA usage. Moreover, we can use copy elision optimization by fixing methods signature.