### PR TITLE
Util: fix args minimum count

### DIFF
--- a/src/util/base.cc
+++ b/src/util/base.cc
@@ -140,8 +140,7 @@ bool BaseCommand::Impl(
       return false;
     }
 
-  // TODO(anonimal): fix args size
-  if (vm.count("help") || (args.size() < 1) || (args.size() > 3))
+  if (vm.count("help") || (args.size() <= 1) || (args.size() > 3))
     {
       if (args.size() < 2)
         LOG(error) << "Not enough arguments !";


### PR DESCRIPTION
Fixes std::bad_alloc upon invalid minimum count.


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

