### PR TITLE
Transports: don't reuse DH keypairs

### DIFF
--- a/src/core/router/transports/impl.cc
+++ b/src/core/router/transports/impl.cc
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -129,13 +129,6 @@ std::unique_ptr<DHKeysPair> DHKeysPairSupplier::Acquire() {
     throw;
   }
   return pair;
-}
-
-void DHKeysPairSupplier::Return(
-    std::unique_ptr<DHKeysPair> pair) {
-  LOG(debug) << "DHKeysPairSupplier: returning";
-  std::unique_lock<std::mutex> l(m_AcquiredMutex);
-  m_Queue.push(std::move(pair));
 }
 
 void Peer::Done() {
@@ -542,12 +535,6 @@ void Transports::DetectExternalIP() {
 std::unique_ptr<DHKeysPair> Transports::GetNextDHKeysPair() {
   LOG(debug) << "Transports: getting next DH keys pair";
   return m_DHKeysPairSupplier.Acquire();
-}
-
-void Transports::ReuseDHKeysPair(
-    std::unique_ptr<DHKeysPair> pair) {
-  LOG(debug) << "Transports: reusing DH keys pair";
-  m_DHKeysPairSupplier.Return(std::move(pair));
 }
 
 void Transports::PeerConnected(

--- a/src/core/router/transports/impl.h
+++ b/src/core/router/transports/impl.h
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -139,12 +139,6 @@ class Transports {
 
   /// @return a pointer to a Diffie-Hellman pair
   std::unique_ptr<kovri::core::DHKeysPair> GetNextDHKeysPair();
-
-  /// @brief Returns a keypair for reuse.
-  // TODO(unassigned): Do not reuse ephemeral keys, the whole point is that they
-  //                   are not reused.
-  void ReuseDHKeysPair(
-      std::unique_ptr<DHKeysPair> pair);
 
   /// @brief Asynchronously sends a message to a peer.
   /// @param ident the router hash of the remote peer

--- a/src/core/router/transports/ntcp/session.cc
+++ b/src/core/router/transports/ntcp/session.cc
@@ -204,7 +204,6 @@ void NTCPSession::HandlePhase2Received(
       kovri::core::netdb.SetUnreachable(
           GetRemoteIdentity().GetIdentHash(),
           true);
-      transports.ReuseDHKeysPair(std::move(m_DHKeysPair));
       m_DHKeysPair.reset(nullptr);
       Terminate();
     }
@@ -248,7 +247,6 @@ void NTCPSession::HandlePhase2Received(
       LOG(trace)
         << "NTCPSession:" << GetFormattedSessionInfo()
         << "Decrypted " << GetFormattedPhaseInfo(Phase::Two);
-      transports.ReuseDHKeysPair(std::move(m_DHKeysPair));
       m_DHKeysPair.reset(nullptr);
       Terminate();
       return;


### PR DESCRIPTION
They must be ephemeral. Resolves #368.


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

