### PR TITLE
Build: use kovri branch for cpp-netlib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "deps/cpp-netlib"]
 	path = deps/cpp-netlib
 	url = https://github.com/anonimal/cpp-netlib.git
-	branch = 0.13-release
+	branch = kovri
 [submodule "deps/cryptopp"]
 	path = deps/cryptopp
 	url = https://github.com/anonimal/cryptopp.git


### PR DESCRIPTION
We're starting to diverge from upstream 0.13-release for various
kovri-specific'isms. See cpp-netlib kovri branch git-log for details.

Referencing #721 and https://github.com/anonimal/cpp-netlib/commit/97505de61e74108cfb9213aab9cbf3e0cfd80296.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

