### PR TITLE
Build: Use cotire for all supported platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,10 @@ option(WITH_TESTS      "Build unit tests" OFF)
 option(WITH_FUZZ_TESTS "Build fuzz tests" OFF)
 option(WITH_UPNP       "Include support for UPnP client" OFF)
 option(WITH_COTIRE     "Enable cotire (compile time reducer) - precompiled header and single compilation unit builds" ${MSVC})
+# Verbosity enabled by default, but can be disabled from cli by adding -DCMAKE_VERBOSE_MAKEFILE=OFF
+# https://github.com/monero-project/kovri/pull/867#discussion_r184359361
+option(CMAKE_VERBOSE_MAKEFILE "Enable verbose build output" ON)
 
-
-set(CMAKE_VERBOSE_MAKEFILE true)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cotire/CMake)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ option(WITH_SUPERCOP   "Build Ed25519 using the ref10 implementation from SUPERC
 option(WITH_TESTS      "Build unit tests" OFF)
 option(WITH_FUZZ_TESTS "Build fuzz tests" OFF)
 option(WITH_UPNP       "Include support for UPnP client" OFF)
+option(WITH_COTIRE     "Enable cotire (compile time reducer) - precompiled header and single compilation unit builds" ${MSVC})
 
 
 set(CMAKE_VERBOSE_MAKEFILE true)
@@ -201,6 +202,20 @@ if(WITH_STATIC)
   endif()
 endif()
 
+# Speed up MSVC build
+# https://blogs.msdn.microsoft.com/vcblog/2016/10/26/recommendations-to-speed-c-builds-in-visual-studio/
+if (MSVC) 
+  set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /DEBUG:fastlink") 
+  if (NOT WITH_COTIRE AND MSVC_IDE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+  endif()
+endif()
+
+if(WITH_COTIRE)
+  set(COTIRE_PCH_MEMORY_SCALING_FACTOR "300")
+  include(cotire OPTIONAL)
+endif() 
+
 # Get uname output
 function(Uname output pattern)
   execute_process(
@@ -327,16 +342,6 @@ if (WITH_PYTHON)
   endif()
 endif()
 
-# Speed up MSVC build
-# https://blogs.msdn.microsoft.com/vcblog/2016/10/26/recommendations-to-speed-c-builds-in-visual-studio/
-if (MSVC) 
-  set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /DEBUG:fastlink") 
-  # The /MP flag is applied by cotire
-  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
-  
-  set(COTIRE_PCH_MEMORY_SCALING_FACTOR "300")
-  include(cotire)
-endif() 
 
 # Solve issue with as.exe fatal error - Object file has too many sections
 # http://stackoverflow.com/a/28372660
@@ -378,6 +383,7 @@ message(STATUS "  SUPERCOP         : ${WITH_SUPERCOP}")
 message(STATUS "  TESTS            : ${WITH_TESTS}")
 message(STATUS "  FUZZ TESTS       : ${WITH_FUZZ_TESTS}")
 message(STATUS "  UPnP             : ${WITH_UPNP}")
+message(STATUS "  Cotire           : ${WITH_COTIRE}")
 message(STATUS "---------------------------------------")
 
 # Handle paths nicely

--- a/contrib/python/CMakeLists.txt
+++ b/contrib/python/CMakeLists.txt
@@ -36,6 +36,16 @@ add_library(kovri_python SHARED
   util.cc)
 
 target_link_libraries(kovri_python PRIVATE kovri-private
-  ${PYTHON_LIBRARIES} kovri-core kovri-client)
+  ${PYTHON_LIBRARIES})
+
+# Use unity targets if they are available
+foreach(_target IN ITEMS kovri-core kovri-client)
+  get_target_property(_unityTargetName ${_target} COTIRE_UNITY_TARGET_NAME)
+  if (_unityTargetName)
+    target_link_libraries(kovri_python PRIVATE ${_unityTargetName})
+  else()
+    target_link_libraries(kovri_python PRIVATE ${_target})
+  endif()
+endforeach()
 
 set_target_properties(kovri_python PROPERTIES PREFIX "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,11 @@ function(ConfigureBinary BIN_NAME OUT_NAME)
   endif()
 endfunction()
 
+if (WITH_LIBRARY)
+  add_subdirectory(core)
+  add_subdirectory(client)
+endif()
+
 if (WITH_BINARY)
   add_subdirectory(app)
   if (WITH_KOVRI_UTIL)
@@ -34,8 +39,4 @@ if (WITH_BINARY)
   endif()
 endif()
 
-if (WITH_LIBRARY)
-  add_subdirectory(client)
-  add_subdirectory(core)
-endif()
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -15,7 +15,8 @@ else()
 endif()
 ConfigureBinary(kovri-app "kovri") 
 
-if (MSVC)
+if (COMMAND cotire)
+  set_target_properties(kovri-app PROPERTIES COTIRE_PREFIX_HEADER_INCLUDE_PATH "${CMAKE_SOURCE_DIR}/deps")
   cotire(kovri-app)
 endif()
 # vim: noai:ts=2:sw=2

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -51,7 +51,8 @@ target_link_libraries(kovri-client PRIVATE
   PUBLIC
   cppnetlib::client-connections)
 
-if (MSVC)
+if (COMMAND cotire)
+  set_target_properties(kovri-client PROPERTIES COTIRE_PREFIX_HEADER_INCLUDE_PATH "${CMAKE_SOURCE_DIR}/deps")
   cotire(kovri-client)
 endif()
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -123,7 +123,7 @@ endif()
 
 if(WITH_SUPERCOP)
   set(EDDSA_DIR "crypto/impl/supercop")
-  target_sources(kovri-core PRIVATE 
+  set(EDDSA_SRC
     ${EDDSA_DIR}/signature.cc
     ${EDDSA_DIR}/ed25519/fe_0.cc
     ${EDDSA_DIR}/ed25519/fe_1.cc
@@ -189,6 +189,13 @@ if(WITH_SUPERCOP)
     ${EDDSA_DIR}/ed25519/pow225521.h
     ${EDDSA_DIR}/ed25519/sc.h
     ${EDDSA_DIR}/ed25519/sqrtm1.h)
+
+  # Disable unity build for eddsa files
+  foreach(eddsa_file IN LISTS EDDSA_SRC)
+    set_property(SOURCE ${eddsa_file} PROPERTY COTIRE_EXCLUDED TRUE)
+  endforeach()
+  
+  target_sources(kovri-core PRIVATE ${EDDSA_SRC})
 endif()
 
 if (WITH_UPNP)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -197,7 +197,8 @@ if (WITH_UPNP)
   target_link_libraries(kovri-core PRIVATE ${CMAKE_DL_LIBS} ${UPNP_LIBRARIES})
 endif()
 
-if (MSVC)
+if (COMMAND cotire)
+  set_target_properties(kovri-core PROPERTIES COTIRE_PREFIX_HEADER_INCLUDE_PATH "${CMAKE_SOURCE_DIR}/deps")
   cotire(kovri-core)
 endif()
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -40,4 +40,9 @@ endif()
 
 ConfigureBinary(kovri-util "kovri-util")
 
+if (COMMAND cotire)
+  set_target_properties(kovri-client PROPERTIES COTIRE_PREFIX_HEADER_INCLUDE_PATH "${CMAKE_SOURCE_DIR}/deps")
+  cotire(kovri-util)
+endif()
+
 # vim: noai:ts=2:sw=2

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -28,9 +28,24 @@ find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 
 target_link_libraries(kovri-tests PRIVATE 
   Boost::unit_test_framework
-  kovri-client
-  kovri-private)
+  kovri-private
+  kovri-client)
+
+if (COMMAND cotire)
+  set_target_properties(kovri-tests PROPERTIES COTIRE_PREFIX_HEADER_INCLUDE_PATH "${CMAKE_SOURCE_DIR}/deps")
+  cotire(kovri-tests)
+
+  set(tests_target kovri-tests_unity)
+else()
+  set(tests_target kovri-tests)
+endif()
+
+add_test(NAME KovriTest COMMAND ${tests_target})
+
+if (MSVC AND NOT WITH_STATIC)
+  file(TO_NATIVE_PATH "${Boost_LIBRARY_DIRS}" BOOST_DLL_DIR)
+  file(TO_NATIVE_PATH "${OPENSSL_ROOT_DIR}/bin" OPENSSL_DLL_DIR)
+  set_property(TEST KovriTest PROPERTY ENVIRONMENT "PATH=%PATH%\;${BOOST_DLL_DIR}\;${OPENSSL_DLL_DIR}")
+endif()
 
 install(TARGETS kovri-tests RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}) 
-
-add_test(NAME KovriTest COMMAND kovri-tests)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -23,6 +23,8 @@ add_executable(kovri-tests
   main.cc
   core/router/identity.h)
 
+set_property(SOURCE main.cc PROPERTY COTIRE_EXCLUDED TRUE)
+set_property(SOURCE core/crypto/util/x509.cc PROPERTY COTIRE_EXCLUDED TRUE)
 
 find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---
https://github.com/sakra/cotire

Right now cotire is enabled only for MSVC builds. This PR enables it for other platforms.
On the local machine, it reduces the build time by 2 times.
