### PR TITLE
HTTP: don't catch / rethrow std::exception_ptr

### DIFF
--- a/src/client/util/http.cc
+++ b/src/client/util/http.cc
@@ -148,9 +148,6 @@ bool HTTP::DownloadViaClearnet() {
 
   // Create client with options
   Client client(options);
-  // TODO(unassigned): this top try block is specifically for Windows and ARMv8
-  // but is harmless for all platforms (see #453 and cpp-netlib/cpp-netlib#696)
-  try {
     try {
       // Create request
       Request request(uri.string());  // A fully-qualified, completed URI
@@ -209,17 +206,13 @@ bool HTTP::DownloadViaClearnet() {
           LOG(warning) << "HTTP: response code: " << response.status();
           return false;
       }
+    } catch (const boost::system::system_error& ex) {
+      LOG(error) << "HTTP: " << boost::diagnostic_information(ex);
+      return false;
     } catch (const std::exception& ex) {
       LOG(error) << "HTTP: unable to complete download: " << ex.what();
       return false;
-    } catch (const std::exception_ptr& ex) {
-      LOG(error) << "HTTP: caught exception_ptr, rethrowing exception";
-      std::rethrow_exception(ex);
     }
-  } catch (const boost::system::system_error& ex) {
-    LOG(error) << "HTTP: " << boost::diagnostic_information(ex);
-    return false;
-  }
   return true;
 }
 

--- a/src/client/util/http.h
+++ b/src/client/util/http.h
@@ -217,6 +217,8 @@ class HTTP : public HTTPStorage {
   // TODO(anonimal): consider removing typedefs after refactor
   // TODO(anonimal): remove the following notes after refactor
 
+  // Add to protected visibility for unit-tests
+ protected:
   /// @brief HTTP client object
   /// @notes Currently only applies to clearnet download
   typedef boost::network::http::client Client;


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

[cpp-netlib/819](https://github.com/cpp-netlib/cpp-netlib/pull/819) fixes underlying issue that required the workaround in #491.

__notes__: a style issue remains (extra indentation level), but changing the indentation obscures the real changes for this PR. If desired, I can create a separate PR for the style changes.