### PR TITLE
kovri-install.sh: refactor + fix

### DIFF
--- a/pkg/installers/kovri-install.sh
+++ b/pkg/installers/kovri-install.sh
@@ -57,10 +57,6 @@ catch()
   echo " ${green}[OK]${normal}"
 }
 
-# Path for binaries
-bin_path=$HOME/bin
-bins=(kovri kovri-util)
-
 # Get platform
 case $OSTYPE in
   linux*)
@@ -115,15 +111,30 @@ while getopts ":r:f:cpu" _opt; do
 done
 shift "$(($OPTIND -1))"
 
+# Path for binaries/scripts
+bin_path=$HOME/bin
+bin_path_files=(kovri-bash.sh kovri kovri-util)
+
 # Set default resources if needed
 if [[ -z $resources ]]; then
-  resources="pkg/client pkg/config contrib/utils/kovri-bash.sh build/${bins[0]} build/${bins[1]}"
+  # TODO: brittle, relies on appropriately placed index
+  resources=("pkg/client" "pkg/config" \
+             "contrib/utils/${bin_path_files[0]}" \
+             "build/${bin_path_files[1]}" \
+             "build/${bin_path_files[2]}")
 fi
 
 # Test if resources are available
 for _resource in ${resources[@]}; do
   if [[ ! -e $_resource ]]; then
-    false
+    # If kovri-util is unavailable, don't fail
+    if [[ "$_resource" == "${resources[-1]}" ]]; then
+      # Remove unavailable resource to avoid later attempt at install
+      unset 'resources[${#resources[@]}-1]'
+      true
+    else
+      false
+    fi
     catch "$_resource is unavailable, did you build Kovri?"
   fi
 done
@@ -163,8 +174,8 @@ Uninstall()
     fi
   done
 
-  # Remove binaries
-  for _bin in ${bins[@]}; do
+  # Remove binaries/scripts
+  for _bin in ${bin_path_files[@]}; do
     local _binary=${bin_path}/${_bin}
     if [[ -e $_binary ]]; then
       echo -n "Removing $_binary"

--- a/pkg/installers/kovri-install.sh
+++ b/pkg/installers/kovri-install.sh
@@ -47,6 +47,16 @@ PrintUsage()
   echo -e "Create package with accompanying checksum file:\n\n$0 [-r \"client config kovri kovri-util\"] -p -c [-f /tmp/kovri-package.tar.bz2]\n\n"
 }
 
+# Error handler
+catch()
+{
+  if [[ $? -ne 0 ]]; then
+    echo " ${red}[ERROR] Failed to install: '$1' ${normal}" >&2
+    exit 1
+  fi
+  echo " ${green}[OK]${normal}"
+}
+
 # Path for binaries
 bin_path=$HOME/bin
 bins=(kovri kovri-util)
@@ -331,16 +341,6 @@ if [[ $(tput colors) ]]; then
   yellow="$(tput setaf 3)"
   normal="$(tput sgr0)"
 fi
-
-# Error handler
-catch()
-{
-  if [[ $? -ne 0 ]]; then
-    echo " ${red}[ERROR] Failed to install: '$1' ${normal}" >&2
-    exit 1
-  fi
-  echo " ${green}[OK]${normal}"
-}
 
 echo "${yellow}The Kovri I2P Router Project (c) 2015-2017${normal}"
 


### PR DESCRIPTION
Fixes handling of 2 files during install/uninstall
- kovri-util: install when present, always try to uninstall
- kovri-bash.sh: was never uninstalled from ~/bin

Tested 'make install' and 'make uninstall' for targets
'make release' and plain 'make' (dynamic)


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

