### PR TITLE
Identity: refactor routing key creation

### DIFF
--- a/src/core/router/identity.h
+++ b/src/core/router/identity.h
@@ -292,8 +292,16 @@ struct XORMetric {
   }
 };
 
-IdentHash CreateRoutingKey(
-    const IdentHash& ident);
+// TODO(unassigned): should not be a free function
+/// @brief Hash identity with appended mod date according to spec
+/// @param ident Identity hash used as the basis for the routing key
+/// @throw std::invalid_argument if supplied a zero-initialized ident
+IdentHash CreateRoutingKey(const IdentHash& ident);
+
+// TODO(unassigned): should not be a free function
+/// @return Formatted UTC date used in routing key
+/// @notes Must return yyyyMMdd
+std::string GetFormattedDate();
 
 XORMetric operator^(
     const IdentHash& key1,

--- a/tests/unit_tests/core/router/identity.cc
+++ b/tests/unit_tests/core/router/identity.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2017, The Kovri I2P Router Project
+ * Copyright (c) 2015-2018, The Kovri I2P Router Project
  *
  * All rights reserved.
  *
@@ -31,9 +31,11 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <boost/test/unit_test.hpp>
+#include <boost/date_time/gregorian/gregorian_types.hpp>
 
 #include <array>
 #include <memory>
+#include <regex>
 
 #include "core/crypto/signature.h"
 #include "core/router/identity.h"
@@ -83,6 +85,26 @@ BOOST_AUTO_TEST_CASE(ParseIdentityFailure)
     BOOST_CHECK_EQUAL(
         identity.FromBuffer(m_AliceIdentity.data(), m_AliceIdentity.size() - i),
         0);
+}
+
+BOOST_AUTO_TEST_CASE(ValidRoutingKey)
+{
+  core::IdentityEx ident;
+  BOOST_CHECK(ident.FromBuffer(m_AliceIdentity.data(), m_AliceIdentity.size()));
+  BOOST_CHECK_NO_THROW(core::CreateRoutingKey(ident.GetIdentHash()));
+}
+
+BOOST_AUTO_TEST_CASE(InvalidRoutingKey)
+{
+  kovri::core::IdentHash hash;
+  BOOST_CHECK_THROW(core::CreateRoutingKey(nullptr), std::invalid_argument);
+  BOOST_CHECK_THROW(core::CreateRoutingKey(hash), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(ValidDateFormat)
+{
+  std::regex regex("(20\\d{2})(\\d{2})(\\d{2})");  // Valid for only this century
+  BOOST_CHECK(std::regex_search(core::GetFormattedDate(), regex));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Resolves TODO replacing `sprintf` with calls to standard library functions, and fixes gcc8 format truncation warning.