### PR TITLE
Kovri: boost.program_options bool option overhaul

### DIFF
--- a/contrib/python/example.py
+++ b/contrib/python/example.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2015-2017, The Kovri I2P Router Project
+# Copyright (c) 2015-2018, The Kovri I2P Router Project
 #
 # All rights reserved.
 #
@@ -29,7 +29,7 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 root = "../../"
-args = "--log-level 5 --enable-ssu 0"
+args = "--log-level 5 --disable-ssu"
 
 # Ensure kovri data dir is available
 import subprocess

--- a/contrib/testnet/monitoring/collect.sh
+++ b/contrib/testnet/monitoring/collect.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2015-2017, The Kovri I2P Router Project
+# Copyright (c) 2015-2018, The Kovri I2P Router Project
 #
 # All rights reserved.
 #
@@ -43,7 +43,7 @@ while true; do
     IFS=$'\n'
 
     # Get statistics from kovri instances
-    stats=$(/usr/bin/kovri-util control stats --host $_host --log-to-console 0)
+    stats=$(/usr/bin/kovri-util control stats --host $_host --disable-console-log)
     if [[ $? -ne 0 ]]; then
         echo "Instance $_seq is not accessible"
         continue

--- a/contrib/testnet/testnet.sh
+++ b/contrib/testnet/testnet.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2017, The Kovri I2P Router Project
+# Copyright (c) 2015-2018, The Kovri I2P Router Project
 #
 # All rights reserved.
 #
@@ -300,19 +300,19 @@ set_args()
   # TODO(unassigned): *all* arguments (including sequence count, etc.)
   # Set utility binary arguments
   if [[ -z $KOVRI_UTIL_ARGS ]]; then
-    KOVRI_UTIL_ARGS="--floodfill 1 --bandwidth P"
+    KOVRI_UTIL_ARGS="--enable-floodfill --bandwidth P"
     read_input "Change utility binary arguments? [KOVRI_UTIL_ARGS=\"${KOVRI_UTIL_ARGS}\"]" KOVRI_UTIL_ARGS
   fi
 
   # Set daemon binary arguments
   if [[ -z $KOVRI_BIN_ARGS ]]; then
-    KOVRI_BIN_ARGS="--floodfill 1 --enable-su3-verification 0 --log-auto-flush 1 --enable-https 0"
+    KOVRI_BIN_ARGS="--enable-floodfill --disable-su3-verification --disable-https --enable-auto-flush-log"
     read_input "Change kovri binary arguments? [KOVRI_BIN_ARGS=\"${KOVRI_BIN_ARGS}\"]" KOVRI_BIN_ARGS
   fi
 
   # Set firewalled daemon binary arguments
   if [[ $KOVRI_NB_FW -gt 0 && -z $KOVRI_FW_BIN_ARGS ]]; then
-    KOVRI_FW_BIN_ARGS="--floodfill 0 --enable-su3-verification 0 --log-auto-flush 1"
+    KOVRI_FW_BIN_ARGS="--enable-floodfill --disable-su3-verification --enable-auto-flush-log"
     read_input "Change firewalled kovri binary arguments? [KOVRI_FW_BIN_ARGS=\"${KOVRI_FW_BIN_ARGS}\"]" KOVRI_FW_BIN_ARGS
   fi
 }

--- a/pkg/config/kovri.conf
+++ b/pkg/config/kovri.conf
@@ -54,15 +54,15 @@
 #port =
 
 #
-#  Daemon mode
-#  ===========
+#  Enable daemon mode
+#  ==================
 #
-#  1 = enabled, 0 = disabled
+#  1 = option enabled, 0 = option disabled
 #
 #  Default: 0
 #
 
-daemon = 0
+enable-daemon = 0
 
 #
 #  Windows Service
@@ -75,26 +75,26 @@ daemon = 0
 #service =
 
 #
-#  Log to console
-#  ==============
+#  Disable logging to console
+#  ==========================
 #
-#  1 = enabled, 0 = disabled
+#  1 = option enabled, 0 = option disabled
 #
-#  Default: 1
-#
-
-log-to-console = 1
-
-#
-#  Log to file
-#  ===========
-#
-#  1 = enabled, 0 = disabled
-#
-#  Default: 1
+#  Default: 0
 #
 
-log-to-file = 1
+disable-console-log = 0
+
+#
+#  Disable logging to file
+#  =======================
+#
+#  1 = option enabled, 0 = option disabled
+#
+#  Default: 0
+#
+
+disable-file-log = 0
 
 #
 #  Log filename
@@ -132,26 +132,26 @@ log-to-file = 1
 log-level = 3
 
 #
-#  Auto flush log
-#  ==============
+#  Enable auto flush logging (write immediately to log file)
+#  =========================================================
 #
-#  1 = enabled, 0 = disabled
+#  1 = option enabled, 0 = option disabled
 #
 #  Default: 0
 #
 
-log-auto-flush = 0
+enable-auto-flush-log = 0
 
 #
-#  Enable console log color
-#  ==========================
+#  Disable console log color
+#  =========================
 #
-#  1 = color, 0 = no color
+#  1 = option enabled, 0 = option disabled
 #
-#  Default: 1
+#  Default: 0
 #
 
-log-enable-color = 1
+disable-color-log = 0
 
 #
 #  Tunnels Config
@@ -172,26 +172,26 @@ log-enable-color = 1
 ########################
 
 #
-# Enable IPv6
-# ===========
+#  Enable IPv6 support
+#  ===================
 #
-# 1 = enabled, 0 = disabled
+#  1 = option enabled, 0 = option disabled
 #
 # Default: 0
 #
 
-v6 = 0
+enable-ipv6 = 0
 
 #
-#  Enable router as floodfill
-#  ==========================
+#  Enable router as a floodfill router
+#  ===================================
 #
-#  1 = enabled, 0 = disabled
+#  1 = option enabled, 0 = option disabled
 #
 #  Default: 0
 #
 
-floodfill = 0
+enable-floodfill = 0
 
 #
 #  Bandwidth Caps
@@ -206,26 +206,26 @@ floodfill = 0
 bandwidth = L
 
 #
-#  Enable SSU Transport (UDP)
+#  Disable SSU Transport (UDP)
 #  ==========================
 #
-#  1 = enabled, 0 = disabled
+#  1 = option enabled, 0 = option disabled
 #
-#  Default: 1
-#
-
-enable-ssu = 1
-
-#
-#  Enable NTCP Transport (TCP)
-#  ==========================
-#
-#  1 = enabled, 0 = disabled
-#
-#  Default: 1
+#  Default: 0
 #
 
-enable-ntcp = 1
+disable-ssu = 0
+
+#
+#  Disable NTCP Transport (TCP)
+#  ===========================
+#
+#  1 = option enabled, 0 = option disabled
+#
+#  Default: 0
+#
+
+disable-ntcp = 0
 
 #
 #  File or URL from which to reseed
@@ -244,7 +244,7 @@ enable-ntcp = 1
 #reseed-from =
 
 #
-#  Enable SU3 Signature Verification
+#  Disable SU3 Signature Verification
 #  =================================
 #
 #  WARNING: DO NOT DISABLE UNLESS YOU KNOW WHAT YOU'RE DOING!
@@ -253,17 +253,18 @@ enable-ntcp = 1
 #
 #  Examples:
 #
-#  ./kovri --enable-su3-verification 0 --reseed-from https://my.server.tld/i2pseeds.su3
+#  ./kovri --disable-su3-verification --reseed-from https://my.server.tld/i2pseeds.su3
 #
-#  1 = enabled, 0 = disabled
+#  1 = option enabled, 0 = option disabled
 #
-#  Default: 1
+#  Default: 0
 #
 
-enable-su3-verification = 1
+disable-su3-verification = 0
 
-#  Enable HTTPS
-#  ============
+#
+#  Disable HTTPS
+#  =============
 #
 #  WARNING: DO NOT DISABLE UNLESS YOU KNOW WHAT YOU'RE DOING!
 #
@@ -271,14 +272,14 @@ enable-su3-verification = 1
 #
 #  Examples:
 #
-#  ./kovri --enable-https 0 --reseed-from https://my.server.tld/i2pseeds.su3
+#  ./kovri --disable-https --reseed-from https://my.server.tld/i2pseeds.su3
 #
-#  1 = enabled, 0 = disabled
+#  1 = option enabled, 0 = option disabled
 #
-#  Default: 1
+#  Default: 0
 #
 
-enable-https = 1
+disable-https = 0
 
 #######################
 ###                 ###

--- a/src/app/daemon.cc
+++ b/src/app/daemon.cc
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -63,7 +63,7 @@ bool DaemonSingleton::Configure(const std::vector<std::string>& args)
       core::Instance core(args);
 
       // Set daemon mode (if applicable)
-      m_IsDaemon = core.GetConfig().GetMap().at("daemon").as<bool>();
+      m_IsDaemon = core.GetConfig().GetMap().at("enable-daemon").as<bool>();
 #ifdef _WIN32
       m_Service = core.GetConfig().GetMap().at("service").as<std::string>();
 #endif

--- a/src/client/reseed.cc
+++ b/src/client/reseed.cc
@@ -91,7 +91,8 @@ bool Reseed::Start() {
   SU3 su3(
       m_Stream,
       m_SigningKeys,
-      core::context.GetOpts()["enable-su3-verification"].as<bool>());
+      core::context.GetOpts()["disable-su3-verification"].as<bool>() ? false
+                                                                     : true);
   if (!su3.SU3Impl()) {
     LOG(error) << "Reseed: SU3 implementation failed";
     return false;

--- a/src/client/util/http.cc
+++ b/src/client/util/http.cc
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -117,7 +117,7 @@ bool HTTP::DownloadViaClearnet() {
   LOG(debug) << "HTTP: Download Clearnet with timeout : "
              << kovri::core::GetType(Timeout::Request);
   // Ensure that we only download from explicit TLS-enabled hosts
-  if (core::context.GetOpts()["enable-https"].as<bool>()) {
+  if (!core::context.GetOpts()["disable-https"].as<bool>()) {
     const std::string cert = uri.host() + ".crt";
     const boost::filesystem::path cert_path = core::GetPath(core::Path::TLS) / cert;
     if (!boost::filesystem::exists(cert_path)) {

--- a/src/core/router/context.cc
+++ b/src/core/router/context.cc
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -84,8 +84,8 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
                   : m_Opts["port"].as<int>();
 
   // Set available transports
-  bool const has_ntcp = m_Opts["enable-ntcp"].as<bool>();
-  bool const has_ssu = m_Opts["enable-ssu"].as<bool>();
+  bool const has_ntcp(m_Opts["disable-ntcp"].as<bool>() ? false : true);
+  bool const has_ssu(m_Opts["disable-ssu"].as<bool>() ? false : true);
 
   if (!has_ntcp && !has_ssu)
     throw std::invalid_argument(
@@ -143,8 +143,8 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
           if (has_ntcp && !router.GetNTCPAddress(address.is_v6()))
             {
               LOG(debug)
-                  << "RouterContext: enable-ntcp present and no transport "
-                     "found in existing routerInfo for host "
+                  << "RouterContext: NTCP was expected but no transport "
+                     "was found in existing routerInfo for host "
                   << host;
               router.AddAddress(std::make_tuple(Transport::NTCP, host, port));
             }
@@ -152,8 +152,8 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
           if (has_ssu && !router.GetSSUAddress(address.is_v6()))
             {
               LOG(debug)
-                  << "RouterContext: enable-ssu present and no transport "
-                     "found in existing routerInfo for host "
+                  << "RouterContext: SSU was expected but no transport "
+                     "was found in existing routerInfo for host "
                   << host;
               router.AddAddress(
                   std::make_tuple(Transport::SSU, host, port),
@@ -195,10 +195,11 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
   LOG(debug) << "RouterContext: setting context RI traits";
 
   // IPv6
-  m_Opts["v6"].as<bool>() ? m_RouterInfo.EnableV6() : m_RouterInfo.DisableV6();
+  m_Opts["enable-ipv6"].as<bool>() ? m_RouterInfo.EnableV6()
+                                   : m_RouterInfo.DisableV6();
 
   // Floodfill
-  if (m_Opts["floodfill"].as<bool>())
+  if (m_Opts["enable-floodfill"].as<bool>())
     {
       m_RouterInfo.SetCaps(
           m_RouterInfo.GetCaps() | core::RouterInfo::Cap::Floodfill);

--- a/src/core/util/config.cc
+++ b/src/core/util/config.cc
@@ -94,14 +94,23 @@ void Configuration::ParseConfig()
       bpo::value<std::string>()
           ->default_value(core::GetPath(core::Path::DefaultData).string())
           ->value_name("path"))(
-      "daemon,d", bpo::value<bool>()->default_value(false)->value_name("bool"))(
       "service,s", bpo::value<std::string>()->default_value(""))(
-      "log-to-console",
-      bpo::value<bool>()->default_value(true)->value_name("bool"))(
-      "log-to-file",
-      bpo::value<bool>()->default_value(true)->value_name("bool"))(
-      "log-file-name",
-      bpo::value<std::string>()->default_value("")->value_name("path"))(
+
+      "enable-daemon,d",
+      bpo::bool_switch()->default_value(false))(
+
+      "disable-console-log",
+      bpo::bool_switch()->default_value(false))(
+
+      "disable-file-log",
+      bpo::bool_switch()->default_value(false))(
+
+      "disable-color-log",
+      bpo::bool_switch()->default_value(false))(
+
+      "enable-auto-flush-log",
+      bpo::bool_switch()->default_value(false))(
+
       // TODO(anonimal): use only 1 log file?
       // Log levels
       // 0 = fatal
@@ -112,31 +121,42 @@ void Configuration::ParseConfig()
       // 5 = trace debug info warn error fatal
       "log-level",
       bpo::value<std::uint16_t>()->default_value(3))(
-      "log-auto-flush",
-      bpo::value<bool>()->default_value(false)->value_name("bool"))(
-      "log-enable-color",
-      bpo::value<bool>()->default_value(true)->value_name("bool"))(
+
+      "log-file-name",
+      bpo::value<std::string>()->default_value("")->value_name("path"))(
+
       "kovriconf,c",
       bpo::value<std::string>()->default_value("")->value_name("path"))(
+
       "tunnelsconf,t",
       bpo::value<std::string>()->default_value("")->value_name("path"));
   // This is NOT our default values for port, log-file-name, kovriconf and tunnelsconf
 
   bpo::options_description network("\nnetwork");
   network.add_options()(
-      "v6,6", bpo::value<bool>()->default_value(false)->value_name("bool"))(
-      "floodfill,f",
-      bpo::value<bool>()->default_value(false)->value_name("bool"))(
-      "bandwidth,b", bpo::value<std::string>()->default_value("L"))(  // TODO(anonimal): refine + update packaged default config file
-      "enable-ssu",
-      bpo::value<bool>()->default_value(true)->value_name("bool"))(
-      "enable-ntcp",
-      bpo::value<bool>()->default_value(true)->value_name("bool"))(
+      "enable-ipv6",
+      bpo::bool_switch()->default_value(false))(
+
+      "enable-floodfill",
+      bpo::bool_switch()->default_value(false))(
+
+      // TODO(anonimal): refine bandwidth + update packaged default config file
+      "bandwidth,b",
+      bpo::value<std::string>()->default_value("L"))(
+
+      "disable-ssu",
+      bpo::bool_switch()->default_value(false))(
+
+      "disable-ntcp",
+      bpo::bool_switch()->default_value(false))(
+
       "reseed-from,r", bpo::value<std::string>()->default_value(""))(
-      "enable-https",
-      bpo::value<bool>()->default_value(true)->value_name("bool"))(
-      "enable-su3-verification",
-      bpo::value<bool>()->default_value(true)->value_name("bool"));
+
+      "disable-https",
+      bpo::bool_switch()->default_value(false))(
+
+      "disable-su3-verification",
+      bpo::bool_switch()->default_value(false));
 
   bpo::options_description client("\nclient");
   client.add_options()("httpproxyport", bpo::value<int>()->default_value(4446))(
@@ -252,7 +272,7 @@ void Configuration::ParseConfigFile(
     }
 
   // Ensure valid transport
-  if (!m_Map["enable-ntcp"].as<bool>() && !m_Map["enable-ssu"].as<bool>())
+  if (m_Map["disable-ntcp"].as<bool>() && m_Map["disable-ssu"].as<bool>())
     throw std::invalid_argument("at least one transport is required");
 }
 

--- a/src/core/util/log.cc
+++ b/src/core/util/log.cc
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -188,24 +188,22 @@ void SetupLogging(const boost::program_options::variables_map& kovri_config)
   // Auto flush for closer-to-real-time record message reporting
   // Note: our severity levels are processed in reverse
   if (severity <= logging::trivial::debug
-      || kovri_config["log-auto-flush"].as<bool>())
+      || kovri_config["enable-auto-flush-log"].as<bool>())
     file_backend->auto_flush();
   // Create file sink
   auto file_sink = boost::shared_ptr<text_file_sink>(
       std::make_unique<text_file_sink>(file_backend));
   // Set sink formatting
   text_sink->set_formatter(
-      GetFormat(kovri_config["log-enable-color"].as<bool>()));
+      GetFormat(kovri_config["disable-color-log"].as<bool>() ? false : true));
   file_sink->set_formatter(GetFormat(false));
   // Add sinks
   core->add_sink(text_sink);
   core->add_sink(file_sink);
   // Remove sinks if needed (we must first have added sinks to remove)
-  bool log_to_console = kovri_config["log-to-console"].as<bool>();
-  bool log_to_file = kovri_config["log-to-file"].as<bool>();
-  if (!log_to_console)
+  if (kovri_config["disable-console-log"].as<bool>())
     core->remove_sink(text_sink);
-  if (!log_to_file)
+  if (kovri_config["disable-file-log"].as<bool>())
     core->remove_sink(file_sink);
 }
 

--- a/src/util/kovri.cc
+++ b/src/util/kovri.cc
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2015-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -44,7 +44,7 @@
 //  Known issues when running kovri from kovri-util:
 //
 //  1. Because of(?) the Boost.Log singleton (unresolved, see TODOs),
-//  there are duplicate log records. Simply removing the log-to-console
+//  there are duplicate log records. Simply removing console logging
 //  option for either kovri-util or kovri will prevent dups.
 //
 //  2. Passing log-level to kovri from kovri-util doesn't work (it's not

--- a/src/util/main.cc
+++ b/src/util/main.cc
@@ -103,17 +103,22 @@ int main(int argc, const char* argv[])
   bpo::options_description general_desc("General options");
   // See src/app/config.cc for log options
   general_desc.add_options()("help,h", "produce this help message")(
-      "log-to-console",
-      bpo::value<bool>()->default_value(true)->value_name("bool"))(
-      "log-to-file",
-      bpo::value<bool>()->default_value(false)->value_name("bool"))(
+      "disable-console-log",
+      bpo::bool_switch()->default_value(false))(
+
+      "disable-file-log",
+      bpo::bool_switch()->default_value(false))(
+
+      "disable-color-log",
+      bpo::bool_switch()->default_value(false))(
+
+      "enable-auto-flush-log",
+      bpo::bool_switch()->default_value(false))(
+
       "log-file-name",
       bpo::value<std::string>()->default_value("")->value_name("path"))(
-      "log-level", bpo::value<std::uint16_t>()->default_value(3))(
-      "log-auto-flush",
-      bpo::value<bool>()->default_value(false)->value_name("bool"))(
-      "log-enable-color",
-      bpo::value<bool>()->default_value(true)->value_name("bool"));
+
+      "log-level", bpo::value<std::uint16_t>()->default_value(3));
 
   bpo::options_description spec("Specific options");
   spec.add_options()(

--- a/src/util/routerinfo.cc
+++ b/src/util/routerinfo.cc
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2015-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2015-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -57,18 +57,24 @@ RouterInfoCommand::RouterInfoCommand()
       "host",
       bpo::value<core::Configuration::ListParameter<std::string, 2>>()->default_value(
           core::Configuration::ListParameter<std::string, 2>("127.0.0.1")))(
-      "port", bpo::value<int>()->default_value(0))(
-      "floodfill,f",
-      bpo::value<bool>()->default_value(false)->value_name("bool"))(
+      "port,p", bpo::value<int>()->default_value(0))(
+
       "bandwidth,b", bpo::value<std::string>()->default_value("L"))(
-      "enable-ssu",
-      bpo::value<bool>()->default_value(true)->value_name("bool"))(
-      "enable-ntcp",
-      bpo::value<bool>()->default_value(true)->value_name("bool"))(
+
+      "enable-floodfill",
+      bpo::bool_switch()->default_value(false))(
+
+      "disable-ssu",
+      bpo::bool_switch()->default_value(false))(
+
+      "disable-ntcp",
+      bpo::bool_switch()->default_value(false))(
+
       "ssuintroducer,i",
-      bpo::value<bool>()->default_value(true)->value_name("bool"))(
+      bpo::bool_switch()->default_value(true))(
+
       "ssutesting,t",
-      bpo::value<bool>()->default_value(true)->value_name("bool"));
+      bpo::bool_switch()->default_value(true));
 
   m_Options.add(create_options).add(read_options);
 }
@@ -80,7 +86,7 @@ void RouterInfoCommand::PrintUsage(const std::string& name) const
   LOG(info) << "or: " << name
             << " --create --host "
                "192.168.1.1,2a01:e35:8b5c:b240:71a2:6750:8d4:47fa --port 10100 "
-               "--floodfill 1 --bandwidth P";
+               "--enable-floodfill --bandwidth P";
 }
 
 bool RouterInfoCommand::Impl(
@@ -128,8 +134,8 @@ bool RouterInfoCommand::Impl(
                                              : vm["port"].as<int>();
 
           // Set transports
-          bool const has_ntcp = vm["enable-ntcp"].as<bool>();
-          bool const has_ssu = vm["enable-ssu"].as<bool>();
+          bool const has_ntcp(vm["disable-ntcp"].as<bool>() ? false : true);
+          bool const has_ssu(vm["disable-ssu"].as<bool>() ? false : true);
 
           if (!has_ntcp && !has_ssu)
             throw std::invalid_argument(


### PR DESCRIPTION
Our boolean options were confusing and redundant. There was no
reason to `--enable 1` if the argument was true nor a reason to
`--disable 0` if the argument was also true, etc.

Removes the need to set boolean after enable/disable.

Resolves #883.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

