### PR TITLE
Repo: update guide name in GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 ---
 **By submitting this issue, I confirm the following:**
 
-- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
+- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
 - I have checked that the issue I am reporting can be replicated or that the feature I am suggesting is not present.
 - I have checked opened or recently closed [pull requests](https://github.com/monero-project/kovri/pulls) for existing solutions/implementations to my issue/suggestion.
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 ---
 **By submitting this pull-request, I confirm the following:**
 
-- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
+- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
 - I have checked that another pull-request for this purpose does not exist.
 - I have considered and confirmed that this submission will be valuable to others.
 - I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.


### PR DESCRIPTION
The contributor guide no longer exists.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---
