### PR TITLE
Core: Use C++11 alignas to enforce data alignment

### DIFF
--- a/src/core/crypto/aes.h
+++ b/src/core/crypto/aes.h
@@ -101,14 +101,11 @@ enum AESSize : std::uint8_t
 };
 
 template<std::size_t Size>
-class AESAlignedBuffer {  // 16 bytes alignment
+class alignas(16) AESAlignedBuffer {
  public:
-  AESAlignedBuffer() {
-    m_Buf = m_UnalignedBuffer;
-    std::uint8_t rem = ((std::size_t)m_Buf) & 0x0f;
-    if (rem)
-      m_Buf += (16 - rem);
-  }
+  AESAlignedBuffer() = default;
+  AESAlignedBuffer(const AESAlignedBuffer&) = delete;
+  AESAlignedBuffer& operator=(const AESAlignedBuffer&) = delete;
 
   operator std::uint8_t* () {
     return m_Buf;
@@ -119,8 +116,7 @@ class AESAlignedBuffer {  // 16 bytes alignment
   }
 
  private:
-  std::uint8_t m_UnalignedBuffer[Size + 15] = {};  // up to 15 bytes alignment
-  std::uint8_t* m_Buf;
+  std::uint8_t m_Buf[Size] = {};  // Aligned at 16 bytes.
 };
 
 /**


### PR DESCRIPTION
This removes union-based alignment from:

- Tag
- AES buffer


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

