### PR TITLE
README: Fix Ubuntu dep openssl -> libssl-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Alpha release coming soon
 | CMake               | 3.5.1                        |          | cmake       | cmake            | cmake            | cmake         | cmake       |
 | gmake (BSD)         | 4.2.1                        |          |             |                  |                  | gmake         | gmake       |
 | Boost               | 1.58                         |          | boost       | libboost-all-dev | boost            | boost-libs    | boost       |
-| OpenSSL             | Always latest stable version |          | openssl     | openssl          | openssl          | openssl       | openssl     |
+| OpenSSL             | Always latest stable version |          | openssl     | libssl-dev       | openssl          | openssl       | openssl     |
 | Doxygen             | 1.8.6                        |    X     | doxygen     | doxygen          | doxygen          | doxygen       | doxygen     |
 | Graphviz            | 2.36                         |    X     | graphviz    | graphviz         | graphviz         | graphviz      | graphviz    |
 | Docker              | Always latest stable version |    X     | See website | See website      | See website      | See website   | See website |


### PR DESCRIPTION
openssl is a cli tool.
libssl-dev is a development lib.
Not sure how in other distros (arch?).


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the contributor guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

