### PR TITLE
InputByteStream: checks for null source buffer when reading

### DIFF
--- a/src/core/util/byte_stream.h
+++ b/src/core/util/byte_stream.h
@@ -141,6 +141,9 @@ class InputByteStream : public ByteStream
     static_assert(
         std::is_integral<UInt>::value || std::is_signed<UInt>(),
         "InputByteStream: invalid type (unsigned integral only)");
+    assert(buf);
+    if (!buf)
+      throw std::invalid_argument("InputByteStream: null buffer");
 
     UInt size;
     std::memcpy(&size, buf, sizeof(size));

--- a/tests/unit_tests/core/util/byte_stream.cc
+++ b/tests/unit_tests/core/util/byte_stream.cc
@@ -71,6 +71,12 @@ BOOST_AUTO_TEST_CASE(NullStreams)
 
   BOOST_CHECK_THROW(
       core::InputByteStream input(buf.data(), 0), std::length_error);
+
+#ifndef _NDEBUG
+  BOOST_CHECK_THROW(
+      core::InputByteStream::Read<std::uint8_t>(nullptr),
+      std::invalid_argument);
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(InputByteStream)


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

~~~Partial fix for #823.~~~

Checks that buffers passed to `kovri::core::InputByteStream::Read` are non-null.