### PR TITLE
I2PControlDataTraits: Fix uncaught exception.

### DIFF
--- a/src/client/api/i2p_control/data.cc
+++ b/src/client/api/i2p_control/data.cc
@@ -107,7 +107,7 @@ const std::string I2PControlDataTraits::GetTrait(Method method) const
 }
 
 I2PControlDataTraits::Method I2PControlDataTraits::GetMethodFromString(
-    const std::string& value) const noexcept
+    const std::string& value) const
 {
   if (value == GetTrait(Method::Authenticate))
     return Method::Authenticate;
@@ -168,7 +168,7 @@ const std::string I2PControlDataTraits::MethodAuthenticate::GetTrait(
 }
 
 std::uint8_t I2PControlDataTraits::MethodAuthenticate::GetTrait(
-    const std::string& value) const noexcept
+    const std::string& value) const
 {
   if (value == GetTrait(API))
     return API;
@@ -212,7 +212,7 @@ const std::string I2PControlDataTraits::MethodEcho::GetTrait(
 }
 
 std::uint8_t I2PControlDataTraits::MethodEcho::GetTrait(
-    const std::string& value) const noexcept
+    const std::string& value) const
 {
   if (value == GetTrait(Echo))
     return Echo;
@@ -254,7 +254,7 @@ const std::string I2PControlDataTraits::MethodGetRate::GetTrait(
 }
 
 std::uint8_t I2PControlDataTraits::MethodGetRate::GetTrait(
-    const std::string& value) const noexcept
+    const std::string& value) const
 {
   if (value == GetTrait(Stat))
     return Stat;
@@ -304,7 +304,7 @@ const std::string I2PControlDataTraits::MethodI2PControl::GetTrait(
 }
 
 std::uint8_t I2PControlDataTraits::MethodI2PControl::GetTrait(
-    const std::string& value) const noexcept
+    const std::string& value) const
 {
   if (value == GetTrait(Address))
     return Address;
@@ -423,7 +423,7 @@ const std::string I2PControlDataTraits::MethodRouterInfo::GetTrait(
 }
 
 std::uint8_t I2PControlDataTraits::MethodRouterInfo::GetTrait(
-    const std::string& value) const noexcept
+    const std::string& value) const
 {
   if (value == GetTrait(Status))
     return Status;
@@ -586,7 +586,7 @@ const std::string I2PControlDataTraits::MethodRouterManager::GetTrait(
       "Invalid router manager command " + std::to_string(command));
 }
 std::uint8_t I2PControlDataTraits::MethodRouterManager::GetTrait(
-    const std::string& value) const noexcept
+    const std::string& value) const
 {
   if (value == GetTrait(FindUpdates))
     return FindUpdates;
@@ -699,7 +699,7 @@ const std::string I2PControlDataTraits::MethodNetworkSetting::GetTrait(
 }
 
 std::uint8_t I2PControlDataTraits::MethodNetworkSetting::GetTrait(
-    const std::string& value) const noexcept
+    const std::string& value) const
 {
   if (value == GetTrait(NTCPPort))
     return NTCPPort;

--- a/src/client/api/i2p_control/data.h
+++ b/src/client/api/i2p_control/data.h
@@ -79,7 +79,7 @@ struct I2PControlDataTraits
 
   /// @return Enumerated method trait
   /// @param value String value of potential trait given
-  Method GetMethodFromString(const std::string& value) const noexcept;
+  Method GetMethodFromString(const std::string& value) const;
 
   /// @class AbstractMethod
   /// @brief Base class for specific methods
@@ -95,7 +95,7 @@ struct I2PControlDataTraits
 
     /// @return Enumerated key trait
     /// @param value String value of potential trait given
-    virtual std::uint8_t GetTrait(const std::string& value) const noexcept = 0;
+    virtual std::uint8_t GetTrait(const std::string& value) const = 0;
 
     /// @return Enumerated Method implemented
     virtual Method Which(void) const = 0;
@@ -151,7 +151,7 @@ struct I2PControlDataTraits
       return Method::Authenticate;
     }
     const std::string GetTrait(std::uint8_t value) const;
-    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    std::uint8_t GetTrait(const std::string& value) const;
     void ParseRequest(const ptree& tree);
     void ParseResponse(const ptree& tree);
   };
@@ -169,7 +169,7 @@ struct I2PControlDataTraits
       return Method::Echo;
     }
     const std::string GetTrait(std::uint8_t value) const;
-    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    std::uint8_t GetTrait(const std::string& value) const;
     void ParseRequest(const ptree& tree);
     void ParseResponse(const ptree& tree);
   };
@@ -188,7 +188,7 @@ struct I2PControlDataTraits
       return Method::GetRate;
     }
     const std::string GetTrait(std::uint8_t value) const;
-    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    std::uint8_t GetTrait(const std::string& value) const;
     void ParseRequest(const ptree& tree);
     void ParseResponse(const ptree& tree);
   };
@@ -209,7 +209,7 @@ struct I2PControlDataTraits
       return Method::I2PControl;
     }
     const std::string GetTrait(std::uint8_t value) const;
-    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    std::uint8_t GetTrait(const std::string& value) const;
     void ParseRequest(const ptree& tree);
     void ParseResponse(const ptree& tree);
   };
@@ -247,7 +247,7 @@ struct I2PControlDataTraits
       return Method::RouterInfo;
     }
     const std::string GetTrait(std::uint8_t value) const;
-    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    std::uint8_t GetTrait(const std::string& value) const;
     void ParseRequest(const ptree& tree);
     void ParseResponse(const ptree& tree);
   };
@@ -270,7 +270,7 @@ struct I2PControlDataTraits
       return Method::RouterManager;
     }
     const std::string GetTrait(std::uint8_t value) const;
-    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    std::uint8_t GetTrait(const std::string& value) const;
     void ParseRequest(const ptree& tree);
     void ParseResponse(const ptree& tree);
   };
@@ -300,7 +300,7 @@ struct I2PControlDataTraits
       return Method::NetworkSetting;
     }
     const std::string GetTrait(std::uint8_t value) const;
-    std::uint8_t GetTrait(const std::string& value) const noexcept;
+    std::uint8_t GetTrait(const std::string& value) const;
     void ParseRequest(const ptree& tree);
     void ParseResponse(const ptree& tree);
   };


### PR DESCRIPTION
Fix for Coverity Issue 175261.

I2PControlDataTraits::GetTrait throws std::domain_error on unknown
method. It gets called from I2PControlDataTraits::GetMethodFromString
which is marked as noexcept, and instead returns Method::Unknown.

Signed-off-by: Tadeas Moravec <ted@cryptosphere-systems.com>


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

