### PR TITLE
Benchmark: BenchmarkTest with correct arguments.

### DIFF
--- a/src/util/benchmark.cc
+++ b/src/util/benchmark.cc
@@ -134,8 +134,8 @@ bool Benchmark::Impl(const std::string& cmd_name,
 template <class Verifier, class Signer>
 void Benchmark::BenchmarkTest(
     std::size_t count,
-    uint8_t * public_key,
     uint8_t * private_key,
+    uint8_t * public_key,
     uint8_t * output,
     KeyGenerator generator)
 {

--- a/src/util/benchmark.h
+++ b/src/util/benchmark.h
@@ -67,8 +67,8 @@ class Benchmark : public Command
   template <class Verifier, class Signer>
   void BenchmarkTest(
       std::size_t count,
-      uint8_t * public_key_size,
       uint8_t * private_key_size,
+      uint8_t * public_key_size,
       uint8_t * output,
       KeyGenerator generator);
 


### PR DESCRIPTION
private_key_* and public_key_* arguments were switched when calling
BenchmarkTest.

Fixes Coverity issue 175260.

Signed-off-by: Tadeas Moravec <moravec.tadeas@gmail.com>


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

