### PR TITLE
Kovri: implement runtime UPnP + remove transports dtor stop call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ option(WITH_STATIC_DEPS "Static build with static dependencies" OFF)
 option(WITH_SUPERCOP   "Build Ed25519 using the ref10 implementation from SUPERCOP" ON)  # Default ON unless we switch implementations
 option(WITH_TESTS      "Build unit tests" OFF)
 option(WITH_FUZZ_TESTS "Build fuzz tests" OFF)
-option(WITH_UPNP       "Include support for UPnP client" OFF)
 option(WITH_COTIRE     "Enable cotire (compile time reducer) - precompiled header and single compilation unit builds" ${MSVC})
 # Verbosity enabled by default, but can be disabled from cli by adding -DCMAKE_VERBOSE_MAKEFILE=OFF
 # https://github.com/monero-project/kovri/pull/867#discussion_r184359361
@@ -385,7 +384,6 @@ message(STATUS "  STATIC DEPS BUILD: ${WITH_STATIC_DEPS}")
 message(STATUS "  SUPERCOP         : ${WITH_SUPERCOP}")
 message(STATUS "  TESTS            : ${WITH_TESTS}")
 message(STATUS "  FUZZ TESTS       : ${WITH_FUZZ_TESTS}")
-message(STATUS "  UPnP             : ${WITH_UPNP}")
 message(STATUS "  Cotire           : ${WITH_COTIRE}")
 message(STATUS "---------------------------------------")
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,6 @@ cmake-kovri = $(cmake-debug)
 cmake-kovri-util = -D WITH_KOVRI_UTIL=ON
 
 # Current off-by-default Kovri build options
-cmake-upnp       = -D WITH_UPNP=ON
 cmake-optimize   = -D WITH_OPTIMIZE=ON
 cmake-hardening  = -D WITH_HARDENING=ON
 cmake-tests      = -D WITH_TESTS=ON
@@ -174,8 +173,6 @@ release-static-android: release-static-deps
 	$(eval cmake-kovri += $(cmake-static) $(cmake-android) $(cmake-kovri-util))
 	$(call CMAKE,$(build),$(cmake-kovri)) && $(MAKE) -C $(build) $(cmake_target)
 
-# TODO(unassigned): static UPnP once our UPnP implementation is release-ready
-
 #-----------------#
 # Optional builds #
 #-----------------#
@@ -190,17 +187,12 @@ python: shared-deps
 	$(eval cmake-kovri += $(cmake-python))
 	$(call CMAKE,$(build),$(cmake-kovri)) && $(MAKE) -C $(build) $(cmake_target)
 
-# Produce vanilla binary with UPnP support
-upnp: deps
-	$(eval cmake-kovri += $(cmake-upnp))
-	$(call CMAKE,$(build),$(cmake-kovri)) && $(MAKE) -C $(build) $(cmake_target)
-
-# Produce optimized, hardened binary *with* UPnP
+# Produce optimized, hardened binary
 all-options: deps
-	$(eval cmake-kovri += $(cmake-optimize) $(cmake-hardening) $(cmake-upnp) $(cmake-kovri-util))
+	$(eval cmake-kovri += $(cmake-optimize) $(cmake-hardening) $(cmake-kovri-util))
 	$(call CMAKE,$(build),$(cmake-kovri)) && $(MAKE) -C $(build) $(cmake_target)
 
-# Produce optimized, hardened binary *without* UPnP. Note: we need (or very much should have) optimizations with hardening
+# Produce optimized, hardened binary. Note: we need (or very much should have) optimizations with hardening
 optimized-hardened: deps
 	$(eval cmake-kovri += $(cmake-optimize) $(cmake-hardening))
 	$(call CMAKE,$(build),$(cmake-kovri)) && $(MAKE) -C $(build) $(cmake_target)
@@ -212,7 +204,7 @@ optimized-hardened-tests: deps
 
 # Produce build with coverage. Note: leaving out hardening because of need for optimizations
 coverage: deps
-	$(eval cmake-kovri += $(cmake-coverage) $(cmake-upnp) $(cmake-kovri-util))
+	$(eval cmake-kovri += $(cmake-coverage) $(cmake-kovri-util))
 	$(call CMAKE,$(build),$(cmake-kovri)) && $(MAKE) -C $(build) $(cmake_target)
 
 # Produce unit-tests with coverage

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -28,27 +28,25 @@
 #
 # Parts of this file are originally copyright (c) 2014-2018 The Monero Project
 
-if(WITH_UPNP)
-  message(STATUS "Using in-tree miniupnpc")
+message(STATUS "Using in-tree miniupnpc")
 
-  add_subdirectory(miniupnp/miniupnpc)
+add_subdirectory(miniupnp/miniupnpc)
 
-  # It is better to setup these options inside miniupnp/miniupnpc/CMakeLists.txt
-  # But the following line allow us to do it here
-  set_property(TARGET libminiupnpc-static PROPERTY FOLDER "deps")
+# It is better to setup these options inside miniupnp/miniupnpc/CMakeLists.txt
+# But the following line allow us to do it here
+set_property(TARGET libminiupnpc-static PROPERTY FOLDER "deps")
 
-  # Suppress noise warnings
-  if(MSVC)
-    set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -wd4244 -wd4267")
-  elseif(NOT MSVC)
-    set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-undef -Wno-unused-result -Wno-unused-value")
-  endif()
-
-  # https://github.com/monero-project/kovri/pull/865#discussion_r184370624
-  set_property(TARGET libminiupnpc-static APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS MINIUPNP_STATICLIB)
-
-  # Use #include <miniupnp/miniupnpc/miniupnpc.h>
-  set_property(TARGET libminiupnpc-static APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
-  # Suppress warnings from miniupnpc headers 
-  set_property(TARGET libminiupnpc-static APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
+# Suppress noise warnings
+if(MSVC)
+  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -wd4244 -wd4267")
+elseif(NOT MSVC)
+  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-undef -Wno-unused-result -Wno-unused-value")
 endif()
+
+# https://github.com/monero-project/kovri/pull/865#discussion_r184370624
+set_property(TARGET libminiupnpc-static APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS MINIUPNP_STATICLIB)
+
+# Use #include <miniupnp/miniupnpc/miniupnpc.h>
+set_property(TARGET libminiupnpc-static APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
+# Suppress warnings from miniupnpc headers
+set_property(TARGET libminiupnpc-static APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})

--- a/pkg/config/kovri.conf
+++ b/pkg/config/kovri.conf
@@ -172,6 +172,17 @@ disable-color-log = 0
 ########################
 
 #
+#  Enable UPnP port mapping
+#  ========================
+#
+#  1 = option enabled, 0 = option disabled
+#
+# Default: 0
+#
+
+enable-upnp = 0
+
+#
 #  Enable IPv6 support
 #  ===================
 #

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -198,11 +198,8 @@ if(WITH_SUPERCOP)
   target_sources(kovri-core PRIVATE ${EDDSA_SRC})
 endif()
 
-if (WITH_UPNP)
-  # Add definition for our implementation (must be here or in root recipe)
-  target_compile_definitions(kovri-core PRIVATE USE_UPNP)
-  target_link_libraries(kovri-core PRIVATE libminiupnpc-static)
-endif()
+# Add definition for our implementation (must be here or in root recipe)
+target_link_libraries(kovri-core PRIVATE libminiupnpc-static)
 
 if (COMMAND cotire)
   set_target_properties(kovri-core PROPERTIES COTIRE_PREFIX_HEADER_INCLUDE_PATH "${CMAKE_SOURCE_DIR}/deps")

--- a/src/core/router/transports/impl.cc
+++ b/src/core/router/transports/impl.cc
@@ -157,9 +157,7 @@ Transports::Transports()
       m_LastOutBandwidthUpdateBytes(0),
       m_LastBandwidthUpdateTime(0) {}
 
-Transports::~Transports() {
-  Stop();  // TODO(anonimal): remove
-}
+Transports::~Transports() {}
 
 void Transports::Start() {
   LOG(debug) << "Transports: starting";

--- a/src/core/router/transports/impl.cc
+++ b/src/core/router/transports/impl.cc
@@ -158,15 +158,15 @@ Transports::Transports()
       m_LastBandwidthUpdateTime(0) {}
 
 Transports::~Transports() {
-  Stop();
+  Stop();  // TODO(anonimal): remove
 }
 
 void Transports::Start() {
   LOG(debug) << "Transports: starting";
-#ifdef USE_UPNP
-  m_UPnP.Start();
-  LOG(debug) << "Transports: UPnP started";
-#endif
+
+  if (context.GetOpts()["enable-upnp"].as<bool>())
+    m_UPnP.Start();
+
   m_DHKeysPairSupplier.Start();
   m_IsRunning = true;
   m_Thread = std::make_unique<std::thread>(std::bind(&Transports::Run, this));
@@ -207,9 +207,7 @@ void Transports::Start() {
 }
 
 void Transports::Stop() {
-#ifdef USE_UPNP
   m_UPnP.Stop();
-#endif
   m_PeerCleanupTimer.cancel();
   m_Peers.clear();
   if (m_SSUServer) {

--- a/src/core/router/transports/impl.h
+++ b/src/core/router/transports/impl.h
@@ -55,12 +55,9 @@
 #include "core/router/transports/ntcp/session.h"
 #include "core/router/transports/session.h"
 #include "core/router/transports/ssu/server.h"
+#include "core/router/transports/upnp.h"
 
 #include "core/util/exception.h"
-
-#ifdef USE_UPNP
-#include "core/router/transports/upnp.h"
-#endif
 
 namespace kovri {
 namespace core {
@@ -279,9 +276,7 @@ class Transports {
   std::uint64_t m_LastInBandwidthUpdateBytes, m_LastOutBandwidthUpdateBytes;
   std::uint64_t m_LastBandwidthUpdateTime;
 
-#ifdef USE_UPNP
   UPnP m_UPnP;
-#endif
 
  public:
   const decltype(m_Peers)& GetPeers() const {

--- a/src/core/router/transports/upnp.cc
+++ b/src/core/router/transports/upnp.cc
@@ -30,7 +30,6 @@
  * Parts of the project are originally copyright (c) 2013-2015 The PurpleI2P Project          //
  */
 
-#ifdef USE_UPNP
 #include "core/router/transports/upnp.h"
 
 #include <boost/thread/thread.hpp>
@@ -48,14 +47,16 @@ UPnP::UPnP() : m_Devlist(nullptr, freeUPNPDevlist) {}
 
 void UPnP::Stop() {
   if (m_Thread) {
+    LOG(info) << "UPnP: stopping";
     m_Thread->join();
     m_Thread.reset(nullptr);
   }
 }
 
-void UPnP::Start() {
-  m_Thread =
-    std::make_unique<std::thread>(&UPnP::Run, this);
+void UPnP::Start()
+{
+  LOG(info) << "UPnP: starting";
+  m_Thread = std::make_unique<std::thread>(&UPnP::Run, this);
 }
 
 UPnP::~UPnP() = default;
@@ -200,5 +201,3 @@ void UPnP::Close() {
 
 }  // namespace core
 }  // namespace kovri
-
-#endif  // USE_UPNP

--- a/src/core/router/transports/upnp.h
+++ b/src/core/router/transports/upnp.h
@@ -33,8 +33,6 @@
 #ifndef SRC_CORE_ROUTER_TRANSPORTS_UPNP_H_
 #define SRC_CORE_ROUTER_TRANSPORTS_UPNP_H_
 
-#ifdef USE_UPNP
-
 #include <boost/asio.hpp>
 
 #include <miniupnp/miniupnpc/miniupnpc.h>
@@ -93,5 +91,4 @@ class UPnP {
 }  // namespace core
 }  // namespace kovri
 
-#endif  // USE_UPNP
 #endif  // SRC_CORE_ROUTER_TRANSPORTS_UPNP_H_

--- a/src/core/util/config.cc
+++ b/src/core/util/config.cc
@@ -134,6 +134,9 @@ void Configuration::ParseConfig()
 
   bpo::options_description network("\nnetwork");
   network.add_options()(
+      "enable-upnp",
+      bpo::bool_switch()->default_value(false))(
+
       "enable-ipv6",
       bpo::bool_switch()->default_value(false))(
 


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Resolves #866.

Note: there is currently a UPnP runtime issue that prevents the app from exiting. That issue is unrelated to this PR.