### PR TITLE
Kovri: don't dispatch error_with_option_name

### DIFF
--- a/src/app/daemon.cc
+++ b/src/app/daemon.cc
@@ -70,6 +70,12 @@ bool DaemonSingleton::Configure(const std::vector<std::string>& args)
       // Create/configure client instance
       m_Client = std::make_unique<client::Instance>(core);
     }
+  // Catch harmless program_option exceptions without dispatching (and producing excessive logging)
+  catch (const boost::program_options::error_with_option_name& ex)
+    {
+      LOG(info) << ex.what() << "\nSee configuration file for details";
+      return false;
+    }
   catch (...)
     {
       m_Exception.Dispatch(__func__);

--- a/src/core/instance.cc
+++ b/src/core/instance.cc
@@ -75,6 +75,10 @@ Instance::Instance(const std::vector<std::string>& args) try : m_Config(args)
     // Continue with configuration/setup
     m_Config.SetupAESNI();
   }
+catch (const boost::program_options::error_with_option_name& ex)
+  {
+    // Avoids dispatcher logging without an intrusive change to the dispatcher
+  }
 catch (...)
   {
     m_Exception.Dispatch();

--- a/src/core/util/config.cc
+++ b/src/core/util/config.cc
@@ -48,6 +48,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <sstream>
 
 #include "core/router/context.h"
 #include "core/router/info.h"
@@ -70,6 +71,10 @@ Configuration::Configuration(const std::vector<std::string>& args) try
     : m_Args(args)
   {
     ParseConfig();
+  }
+catch (const boost::program_options::error_with_option_name& ex)
+  {
+    // Avoids dispatcher logging without an intrusive change to the dispatcher
   }
 catch (...)
   {
@@ -187,9 +192,9 @@ void Configuration::ParseConfig()
   // Help options
   if (m_Map.count("help"))
     {
-      LOG(info) << config_options;
-      throw std::runtime_error(
-          "for more details, see user-guide or config file");
+      std::ostringstream message;
+      message << config_options;
+      throw boost::program_options::error_with_option_name(message.str());
     }
   // Parse config file after mapping command-line
   // TODO(anonimal): we want to be able to reload config file without original


### PR DESCRIPTION
Cleans up log output when calling arg help or invalid arg option.

Resolves #899.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

