### PR TITLE
Util: create URI alias

### DIFF
--- a/src/client/address_book/impl.cc
+++ b/src/client/address_book/impl.cc
@@ -34,13 +34,14 @@
 
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/asio.hpp>
-#include <boost/network/uri.hpp>
 
 #include <array>
 #include <chrono>
 #include <condition_variable>
 #include <fstream>
 #include <utility>
+
+#include "client/util/uri.h"
 
 #include "core/crypto/rand.h"
 
@@ -144,7 +145,7 @@ void AddressBook::LoadPublishers() {
     // Publisher URI
     std::string publisher;
     // Validate publisher URI
-    boost::network::uri::uri uri;
+    uri::uri uri;
     // Read in publishers, line by line
     while (std::getline(file, publisher)) {
       // If found, clear whitespace before and after publisher (on the line)
@@ -159,7 +160,7 @@ void AddressBook::LoadPublishers() {
         continue;
       // Perform URI sanity test
       if (!uri.string().empty())
-        uri = boost::network::uri::uri();
+        uri = uri::uri();
       uri.append(publisher);
       if (!uri.is_valid())
         {

--- a/src/client/proxy/http.cc
+++ b/src/client/proxy/http.cc
@@ -37,7 +37,6 @@
 #include <boost/algorithm/string/regex.hpp>
 
 
-#include <boost/network/uri/decode.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
 #include <boost/tokenizer.hpp>
@@ -489,7 +488,7 @@ bool HTTPMessage::ExtractBase64Destination(std::size_t const pos)
   if (pos && base64_size < m_URL.size())
     {
       std::string const base64 = m_URL.substr(base64_size);
-      m_Base64Destination = boost::network::uri::decoded(base64);
+      m_Base64Destination = uri::decoded(base64);
       return true;
     }
 

--- a/src/client/util/http.h
+++ b/src/client/util/http.h
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -35,7 +35,6 @@
 
 // cpp-netlib
 #include <boost/network/include/http/client.hpp>
-#include <boost/network/uri.hpp>
 
 #include <cstdint>
 #include <fstream>
@@ -46,6 +45,7 @@
 #include <string>
 
 #include "client/reseed.h"
+#include "client/util/uri.h"
 #include "core/util/log.h"
 
 namespace kovri {
@@ -164,7 +164,7 @@ class HTTP : public HTTPStorage {
     LOG(debug) << "HTTP: Set URI " << uri;
     // Remove existing URI if set
     if (!m_URI.string().empty()) {
-      boost::network::uri::uri new_uri;
+      uri::uri new_uri;
       m_URI.swap(new_uri);
     }
     // Set new URI
@@ -173,7 +173,7 @@ class HTTP : public HTTPStorage {
 
   /// @brief Get initialized URI
   /// @return cpp-netlib URI object
-  boost::network::uri::uri GetURI() const
+  uri::uri GetURI() const
   {
     return m_URI;
   }
@@ -212,7 +212,7 @@ class HTTP : public HTTPStorage {
  private:
   /// @var m_URI
   /// @brief cpp-netlib URI instance
-  boost::network::uri::uri m_URI;
+  uri::uri m_URI;
 
   // TODO(anonimal): consider removing typedefs after refactor
   // TODO(anonimal): remove the following notes after refactor

--- a/src/client/util/uri.h
+++ b/src/client/util/uri.h
@@ -1,0 +1,48 @@
+/**                                                                                           //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ *                                                                                            //
+ * Parts of the project are originally copyright (c) 2013-2015 The PurpleI2P Project          //
+ */
+
+#ifndef SRC_CLIENT_UTIL_URI_H_
+#define SRC_CLIENT_UTIL_URI_H_
+
+#include <boost/network/uri.hpp>
+
+namespace kovri {
+namespace client {
+
+/// @alias uri
+/// @brief URI namespace alias for easier URI-related refactoring
+namespace uri = boost::network::uri;
+
+}  // namespace client
+}  // namespace kovri
+
+#endif  // SRC_CLIENT_UTIL_URI_H_

--- a/src/util/i2pcontrol_client.cc
+++ b/src/util/i2pcontrol_client.cc
@@ -37,6 +37,8 @@
 #include <sstream>
 #include <utility>
 
+#include "client/util/uri.h"
+
 #include "core/util/byte_stream.h"
 
 namespace asio = boost::asio;
@@ -125,7 +127,6 @@ void I2PControlClient::ProcessAsyncSendRequest(
     std::shared_ptr<Request> request,
     std::function<void(std::unique_ptr<Response>)> callback)
 {
-  namespace uri = boost::network::uri;
   uri::uri url;
   url << uri::scheme("http") << uri::host(m_Host) << uri::port(m_Port);
   http::client::request http_request(url);


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Namespace alias for cpp-netlib URI library.
Will help with more comprehensive URI-related refactors.

Referencing #721.