### PR TITLE
Router: Initialize a variable.

### DIFF
--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -953,7 +953,7 @@ const RouterInfo::Address* RouterInfo::GetAddress(
     return transports & supported;
   };
 
-  Transport transport;
+  Transport transport(Transport::Unknown);
   bool has_v6(false);
 
   // Ensure address has appropriate transport
@@ -962,6 +962,8 @@ const RouterInfo::Address* RouterInfo::GetAddress(
 
   if (has_transport(SupportedTransport::SSUv4 | SupportedTransport::SSUv6))
     transport = Transport::SSU;
+
+  assert(transport != Transport::Unknown);
 
   if (has_transport(SupportedTransport::NTCPv6 | SupportedTransport::SSUv6))
     has_v6 = true;


### PR DESCRIPTION
Scalar variable transport was declared without an initializer, and later
used in a comparison.

Fixes Coverity #175247.

Signed-off-by: Tadeas Moravec <moravec.tadeas@gmail.com>


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

