### PR TITLE
Router: Fix lock in managing tunnels.

### DIFF
--- a/src/core/router/tunnel/impl.cc
+++ b/src/core/router/tunnel/impl.cc
@@ -667,14 +667,14 @@ void Tunnels::ManageInboundTunnels() {
 }
 
 void Tunnels::ManageTransitTunnels() {
-  std::uint64_t ts = kovri::core::GetSecondsSinceEpoch();
+  std::unique_lock<std::mutex> l(m_TransitTunnelsMutex);
+
+  const std::uint64_t ts = kovri::core::GetSecondsSinceEpoch();
   for (auto it = m_TransitTunnels.begin(); it != m_TransitTunnels.end();) {
     if (ts > it->second->GetCreationTime() + TUNNEL_EXPIRATION_TIMEOUT) {
       auto tmp = it->second;
-      LOG(debug) << "Tunnels: transit tunnel " << tmp->GetTunnelID() << " expired"; {
-        std::unique_lock<std::mutex> l(m_TransitTunnelsMutex);
-        it = m_TransitTunnels.erase(it);
-      }
+      LOG(debug) << "Tunnels: transit tunnel " << tmp->GetTunnelID() << " expired";
+      it = m_TransitTunnels.erase(it);
       delete tmp;
     } else {
       it++;

--- a/src/core/router/tunnel/impl.cc
+++ b/src/core/router/tunnel/impl.cc
@@ -672,10 +672,8 @@ void Tunnels::ManageTransitTunnels() {
   const std::uint64_t ts = kovri::core::GetSecondsSinceEpoch();
   for (auto it = m_TransitTunnels.begin(); it != m_TransitTunnels.end();) {
     if (ts > it->second->GetCreationTime() + TUNNEL_EXPIRATION_TIMEOUT) {
-      auto tmp = it->second;
-      LOG(debug) << "Tunnels: transit tunnel " << tmp->GetTunnelID() << " expired";
+      LOG(debug) << "Tunnels: transit tunnel " << it->second->GetTunnelID() << " expired";
       it = m_TransitTunnels.erase(it);
-      delete tmp;
     } else {
       it++;
     }


### PR DESCRIPTION
There are two problems with the position of m_TransitTunnelsMutex:

1. Value of `it` might change between the condition
   `it->second->GetCreationTime() + TUNNEL_EXPIRATION_TIMEOUT` and
   erasing `it` from m_TransitTunnels

   Hence we need a lock around the whole condition.

2. But the content of m_TransitTunnels might change during the cycle.
   If ManageTransitTunnels runs twice in parallel, a tunnel can get
   deleted in one loop, but be accessed in the other one.

   Hence we need a lock around the whole cycle.

Coverity #151155

Signed-off-by: Tadeas Moravec <moravec.tadeas@gmail.com>


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

