### PR TITLE
AddressBook: create multiple subscription map

### DIFF
--- a/src/client/address_book/impl.h
+++ b/src/client/address_book/impl.h
@@ -146,10 +146,13 @@ class AddressBook : public AddressBookDefaults {
   /// @brief Insert address into in-memory storage
   /// @param host Human-readable hostname to insert
   /// @param address Hash of address to insert
-  /// @notes Throws if host or address are duplicates
+  /// @param source Subscription type for where to store the entry
+  /// @throw std::runtime_error if host already loaded into memory
+  /// @throw std::runtime_error if address already loaded into memory
   void InsertAddress(
       const std::string& host,
-      const kovri::core::IdentHash& address);
+      const kovri::core::IdentHash& address,
+      SubscriptionType source);
 
   /// @brief Inserts address into address book from HTTP Proxy jump service
   /// @param address Const reference to human-readable address
@@ -259,8 +262,8 @@ class AddressBook : public AddressBookDefaults {
   std::mutex m_AddressBookMutex;
 
   /// @var m_Addresses
-  /// @brief Map of human readable addresses to identity hashes
-  std::map<std::string, kovri::core::IdentHash> m_Addresses;
+  /// @brief Map of human readable addresses to identity hashes and subscription source
+  AddressMap m_Addresses;
 
   /// @var m_Storage
   /// @brief Unique pointer to address book storage implementation

--- a/src/client/address_book/storage.h
+++ b/src/client/address_book/storage.h
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -54,6 +54,23 @@ namespace client {
 /// @class AddressBookDefaults
 /// @brief Default string constants used throughout address book
 struct AddressBookDefaults {
+  /// @enum Subscription
+  /// @brief Subscription type for where to load/save subscription addresses
+  /// @notes Scoped to prevent namespace pollution (otherwise, purely stylistic)
+  enum struct SubscriptionType
+  {
+    Default,
+    User,
+    Private,
+  };
+
+  /// @alias AddressMap
+  /// @brief Maps human-readable hostname to an identity hash and subscription type
+  /// @details Intended for user-convenience, readability, mapping to/from database entries, and potential subscription feed support
+  /// @notes For subscription feed details, see I2P proposal 112
+  using AddressMap =
+      std::map<std::string, std::pair<core::IdentHash, SubscriptionType> >;
+
   /// @enum AddressBookSize
   enum AddressBookSize : std::uint16_t {
     /// @brief Line in subscription file
@@ -138,14 +155,12 @@ class AddressBookStorage : public AddressBookDefaults {
   /// @brief Loads subscriptions from file into memory
   /// @return Number of subscriptions loaded
   /// @param addresses Reference to map of human-readable addresses to hashes
-  std::size_t Load(
-      std::map<std::string, kovri::core::IdentHash>& addresses);
+  std::size_t Load(AddressMap& addresses);
 
   /// @brief Saves subscriptions to file in CSV format to verify addresses loaded
   /// @return Number of addresses saved
   /// @param addresses Const reference to map of human-readable address to b32 hashes of address
-  std::size_t Save(
-      const std::map<std::string, kovri::core::IdentHash>& addresses);
+  std::size_t Save(const AddressMap& addresses);
 
  private:
   /// @return Address book path with appended addresses location

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -3,6 +3,7 @@ project(kovri-tests CXX)
 
 add_executable(kovri-tests 
   client/address_book/impl.cc
+  client/address_book/storage.cc
   client/api/i2p_control/data.cc
   client/api/i2p_control/parser.cc
   client/reseed.cc

--- a/tests/unit_tests/client/address_book/impl.cc
+++ b/tests/unit_tests/client/address_book/impl.cc
@@ -223,14 +223,24 @@ BOOST_AUTO_TEST_CASE(RejectDuplicateEntry)
   kovri::client::BookEntry entry(subscription.front());
 
   // Ensure valid entry is inserted
-  BOOST_CHECK_NO_THROW(book.InsertAddress(entry.get_host(), entry.get_address()));
+  BOOST_CHECK_NO_THROW(
+      book.InsertAddress(
+          entry.get_host(),
+          entry.get_address(),
+          kovri::client::AddressBook::SubscriptionType::Default));
   // Ensure address book throws for duplicate host
   BOOST_CHECK_THROW(
-      book.InsertAddress(entry.get_host(), entry.get_address()),
+      book.InsertAddress(
+          entry.get_host(),
+          entry.get_address(),
+          kovri::client::AddressBook::SubscriptionType::Default),
       std::runtime_error);
   // Ensure address book throws for duplicate address
   BOOST_CHECK_THROW(
-      book.InsertAddress("unique." + entry.get_host(), entry.get_address()),
+      book.InsertAddress(
+          "unique." + entry.get_host(),
+          entry.get_address(),
+          kovri::client::AddressBook::SubscriptionType::Default),
       std::runtime_error);
 }
 

--- a/tests/unit_tests/client/address_book/storage.cc
+++ b/tests/unit_tests/client/address_book/storage.cc
@@ -1,0 +1,188 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2018, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ */
+
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include <iostream>
+
+#include "client/address_book/impl.h"
+#include "client/address_book/storage.h"
+
+#include "core/router/context.h"
+
+namespace client = kovri::client;
+namespace core = kovri::core;
+
+struct AddressBookStorageFixture
+{
+  /// @alias Subscription
+  /// @brief Subscription alias for readability and convenience
+  /// @details Intended for user-convenience and readability
+  using SubscriptionType = client::AddressBook::SubscriptionType;
+
+  AddressBookStorageFixture() : m_Storage(nullptr)
+  {
+    // Setup temporary data directory
+    core::context.SetCustomDataDir(temp_path.string());
+
+    // Ensure Client and AddressBook paths exist
+    core::EnsurePath(core::GetPath(core::Path::Client));
+
+    core::EnsurePath(core::GetPath(core::Path::AddressBook));
+
+    // Setup storage
+    m_Storage = GetStorageInstance();
+  }
+
+  ~AddressBookStorageFixture()
+  {
+    BOOST_CHECK_NO_THROW(RemoveFiles());
+  }
+
+  /// @brief Remove files created by AddressBookStorage
+  void RemoveFiles()
+  {
+    try
+      {
+        boost::filesystem::directory_iterator end_itr;
+        for (boost::filesystem::directory_iterator dir_itr(
+                 core::GetPath(core::Path::AddressBook));
+             dir_itr != end_itr;
+             ++dir_itr)
+          {
+            boost::filesystem::remove(dir_itr->path().filename());
+          }
+      }
+    catch (...)
+      {
+        core::Exception ex(__func__);
+        ex.Dispatch();
+        throw;
+      }
+  }
+
+  /// @brief Insert test hosts into an address map
+  void ToAddressMap(SubscriptionType source)
+  {
+    for (const auto& host : m_Hosts)
+      {
+        client::BookEntry entry(host);
+        m_Addresses[entry.get_host()] = std::make_pair(entry.get_address(), source);
+      }
+  }
+
+  /// @brief Create new storage instance
+  /// @notes Called after creating custom data directory
+  std::unique_ptr<client::AddressBookStorage> GetStorageInstance()
+  {
+    return std::make_unique<client::AddressBookStorage>();
+  }
+
+
+  std::size_t saved_addresses{};
+  client::AddressBook::AddressMap m_Addresses;
+  std::unique_ptr<client::AddressBookStorage> m_Storage;
+  boost::filesystem::path temp_path = boost::filesystem::temp_directory_path();
+  std::array<std::string, 2> const m_Hosts{{
+      "kovri.i2p=0UVPqAA4xUSfPYPBca24h8fdokhwcJZ4zWvELv-5OsBYTHKtnLzvK7byXtXT~fOV2pExi8vrkgarGTNDfJbB2KCsdVS3V7qwtTvoCGYyklcDBlJsWMj7H763hEz5rt9SzLkcpwhO3t0Zwe6jXL1UB-QW8KxM30t-ZOfPc6OiJ1QpnE6Bo5OUm6jPurQGXdWCAPio5Z-YnRL46n0IHWOQPYYSStJMYPlPS-S75rMIKbZbEMDraRvSzYAphUaHfvtWr2rCSPkKh3EbrOiBYiAP2oWvAQCsjouPgVF2qwQRnBbiAezHedM2gXzkgIyCV2kGOOcHhiihd~7fWwJOloH-gO78QkmCuY-3kp3633v3MBw7pmABr-XNKWnATZOuf2syWVBZbTnOXsWf41tu6a33HOuNsMxAOUrwbu7QRmT4X8X-EITwNlKN6r1t3uoQ~yZm4RKsJUsBGfVtKl8PBMak3flQAg95oV0OBDGuizIQ9vREOWvPGlQCAXZzEg~cUNbfBQAEAAcAAA==",
+      "monero.i2p=3VzGaQQXwzN1iAwaPI17RK~gUqKqMH6fI2dkkGBwdayAPAdiZMyk1KGoTq~q1~HBraPZnz9mZJlzf6WVGCkUmUV3SBjBEbrdL9ud0fArq3P1~Ui9ViR9B7m5EG8smAnFvKZdqS-cnmHploUfIOefoQe0ecM7YYHErZsn3kL-WtvlfoDiSth-edIBpWxeHfmXSKoHSGSJ2snl5p9hxh30KmKj9AB0d4En-jcD83Ep3jsSvtPoQl7tSsh575~q0JJLsqGqm2sR9w4nZr7O58cg-21A2tlZeldM287uoTMb9eHWnYuozUGzzWOXvqg0UxPQSTfwh7YEhx0aRTXT2OFpr84XPoH2M6xIXfEMkFtJEJ-XlM-ILUZkg3kuBEFN7n4mBK~8L0Ht1QCq8L3~y7YnN61sxC0E9ZdyEOoC~nFJxndri9s9NzgZPo5eo6DsZXweOrTAIVQgKFUozL7WXKMlgqBZ5Nl3ijD6MGCIy0fWYHGLJ4jDBY7wrcfynVXFGm4EBQAEAAcAAA==",
+  }};
+};
+
+BOOST_FIXTURE_TEST_SUITE(AddressBookStorageTests, AddressBookStorageFixture)
+
+BOOST_AUTO_TEST_CASE(ValidSaveSubscription)
+{
+  // Check we have a storage instance
+  BOOST_CHECK(m_Storage);
+
+  // Ensure successful address insertion
+  BOOST_CHECK_NO_THROW(ToAddressMap(SubscriptionType::Default));
+
+  // Ensure addresses written to storage
+  BOOST_CHECK_NO_THROW(saved_addresses = m_Storage->Save(m_Addresses));
+
+  // Ensure addresses are saved
+  BOOST_CHECK(saved_addresses && saved_addresses == m_Hosts.size());
+}
+
+BOOST_AUTO_TEST_CASE(InvalidSaveSubscription)
+{
+  // Check we have a storage instance
+  BOOST_CHECK(m_Storage);
+
+  // Save an empty subscription
+  BOOST_CHECK_NO_THROW(saved_addresses = m_Storage->Save(m_Addresses));
+
+  // Ensure no addresses are saved
+  BOOST_CHECK(!saved_addresses && m_Addresses.empty());
+}
+
+BOOST_AUTO_TEST_CASE(ValidLoadSubscription)
+{
+  // Check we have a storage instance
+  BOOST_CHECK(m_Storage);
+
+  // Ensure successful address insertion
+  BOOST_CHECK_NO_THROW(ToAddressMap(SubscriptionType::Default));
+
+  // Ensure addresses written to storage
+  BOOST_CHECK_NO_THROW(saved_addresses = m_Storage->Save(m_Addresses));
+  BOOST_CHECK(saved_addresses == m_Hosts.size());
+
+  // Reset the address map
+  m_Addresses.clear();
+
+  // Ensure addresses loaded from storage
+  BOOST_CHECK_NO_THROW(m_Storage->Load(m_Addresses));
+  BOOST_CHECK(m_Addresses.size() == m_Hosts.size());
+}
+
+BOOST_AUTO_TEST_CASE(InvalidLoadSubscription)
+{
+  // Check we have a storage instance
+  BOOST_CHECK(m_Storage);
+
+  // Save empty address map to storage
+  BOOST_CHECK_NO_THROW(saved_addresses = m_Storage->Save(m_Addresses));
+
+  // Ensure no addresses are saved
+  BOOST_CHECK(!saved_addresses && m_Addresses.empty());
+
+  // Load from empty address catalog
+  BOOST_CHECK_NO_THROW(m_Storage->Load(m_Addresses));
+
+  // Ensure no addresses are loaded
+  BOOST_CHECK(m_Addresses.empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

First steps toward implementing #337. 

Default, user, and private subscription types will be used for their respective subscription files (`hosts.txt`, `user_hosts.txt`, and `private_hosts.txt`).

All publisher subscription files will save their unique addresses into the `user` subscription type, and the publisher's file/stream will be discarded.