### PR TITLE
RouterInfo: refactor creation API

### DIFF
--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -70,6 +70,14 @@ RouterInfo::RouterInfo(
       != core::SIGNING_KEY_TYPE_EDDSA_SHA512_ED25519)
     throw std::invalid_argument("RouterInfo: invalid signing key type");
 
+  // Reject empty addresses
+  if (points.empty())
+    throw std::invalid_argument("RouterInfo: no transport address(es)");
+
+  // Reject routers with NTCP & SSU disabled
+  if (!has_transport.first && !has_transport.second)
+    throw std::invalid_argument("RouterInfo: no supported transports");
+
   // Log our identity
   const IdentHash& hash = m_RouterIdentity.GetIdentHash();
   LOG(info) << "RouterInfo: our router's ident: " << m_RouterIdentity.ToBase64();

--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -750,8 +750,8 @@ void RouterInfo::CreateRouterInfo(
   LOG(debug) << "RouterInfo: " << __func__;
 
   // Write ident
-  // TODO(anonimal): review the following arbitrary size (must be >= 387)
-  std::array<std::uint8_t, 1024> ident {{}};
+  // Max size for ident with key certificate, see spec
+  std::array<std::uint8_t, 391> ident {{}};
   auto ident_len =
       private_keys.GetPublic().ToBuffer(ident.data(), ident.size());
   router_info.Write(ident.data(), ident_len);

--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -68,6 +68,11 @@ RouterInfo::RouterInfo(
   // TODO(anonimal): in core config, we guarantee validity of host and port but
   //  we don't guarantee here without said caller in place.
 
+  // Reject non-EdDSA signing keys, see #498 and spec
+  if (m_RouterIdentity.GetSigningKeyType()
+      != core::SIGNING_KEY_TYPE_EDDSA_SHA512_ED25519)
+    throw std::invalid_argument("RouterInfo: invalid signing key type");
+
   // Log our identity
   const IdentHash& hash = m_RouterIdentity.GetIdentHash();
   LOG(info) << "RouterInfo: our router's ident: " << m_RouterIdentity.ToBase64();

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(kovri-tests
   core/crypto/rand.cc
   core/crypto/util/x509.cc
   core/router/identity.cc
+  core/router/info.cc
   core/router/transports/ssu/packet.cc
   core/util/byte_stream.cc
   core/util/config.cc

--- a/tests/unit_tests/core/router/info.cc
+++ b/tests/unit_tests/core/router/info.cc
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2015-2018, The Kovri I2P Router Project
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ *    conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *    of conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include "core/router/identity.h"
+
+namespace core = kovri::core;
+
+struct RouterInfoFixture
+{
+  core::PrivateKeys keys = core::PrivateKeys::CreateRandomKeys(
+      core::SIGNING_KEY_TYPE_EDDSA_SHA512_ED25519);
+};
+
+BOOST_FIXTURE_TEST_SUITE(RouterInfoTests, RouterInfoFixture)
+
+BOOST_AUTO_TEST_CASE(CreateValidRouters)
+{
+  // Ensure EdDSA router w/ IPv4 transport is created
+  //   Other signing types not tested, see #498
+  BOOST_CHECK_NO_THROW(
+      core::RouterInfo router(keys, {{"127.0.0.1", 10701}}, {true, true}));
+
+  // Ensure EdDSA router w/ IPv6 transport is created
+  BOOST_CHECK_NO_THROW(
+      core::RouterInfo router(keys, {{"::1", 10702}}, {true, true}));
+
+  // Ensure NTCP-only router is created
+  BOOST_CHECK_NO_THROW(
+      core::RouterInfo router(keys, {{"127.0.0.1", 10701}}, {true, false}));
+
+  // Ensure SSU-only router is created
+  BOOST_CHECK_NO_THROW(
+      core::RouterInfo router(keys, {{"127.0.0.1", 10701}}, {false, true}));
+}
+
+BOOST_AUTO_TEST_CASE(CreateInvalidRouters)
+{
+  // Ensure router with no transports throws
+  BOOST_CHECK_THROW(
+      core::RouterInfo router(keys, {}, {}), std::invalid_argument);
+
+  // Ensure router with NTCP & SSU disabled throws
+  BOOST_CHECK_THROW(
+      core::RouterInfo router(keys, {{"127.0.0.1", 10701}}, {false, false}),
+      std::invalid_argument);
+
+  // Ensure invalid IPv4 throws
+  BOOST_CHECK_THROW(
+      core::RouterInfo router(keys, {{"9127.0.0.1", 10801}}, {}),
+      std::invalid_argument);
+
+  // Ensure invalid IPv6 throws
+  BOOST_CHECK_THROW(
+      core::RouterInfo router(keys, {{"/:::0", 10801}}, {}),
+      std::invalid_argument);
+
+  // Ensure invalid port throws
+  BOOST_CHECK_THROW(
+      core::RouterInfo router(keys, {{"127.0.0.1", 42}}, {}),
+      std::invalid_argument);
+
+  // Create RSA signing keys
+  keys = core::PrivateKeys::CreateRandomKeys(
+      core::SIGNING_KEY_TYPE_RSA_SHA512_4096);
+
+  // Ensure RSA_SHA512_4096 signing key throws
+  //   Other signing types not tested, see #498
+  BOOST_CHECK_THROW(
+      core::RouterInfo router_rsa(keys, {{"127.0.0.1", 10801}}, {}),
+      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Adds exceptions for invalid ctor parameters, moves signing to router creation, and adds router signature verification.

Toward #498, disallows non-EdDSA signing keys for new routers.