### PR TITLE
RouterInfo: refactor signature creation and verification

### DIFF
--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -69,6 +69,7 @@ struct RouterInfoTraits
   {
     MinBuffer = core::DSA_SIGNATURE_LENGTH,  // TODO(unassigned): see #498
     MaxBuffer = 2048,  // TODO(anonimal): review if arbitrary
+    MinUnsignedBuffer = 399,  // Minimum RouterInfo length w/o signature, see spec
     // TODO(unassigned): algorithm to dynamically determine cost
     NTCPCost = 10,  // NTCP *should* have priority over SSU
     SSUCost = 5,
@@ -522,6 +523,11 @@ class RouterInfo : public RouterInfoTraits, public RoutingDestination
   /// @param private_keys Private keys used to derive signing key
   ///   (and subsequently sign the RI with)
   void CreateBuffer(const PrivateKeys& private_keys);
+
+  /// @brief Verify RI signature
+  /// @throws std::length_error if unsigned buffer length is below minimum
+  /// @throws std::runtime_error if signature verification fails
+  void Verify();
 
   /// @brief Save RI to file
   /// @param path Full RI path of file to save to

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(kovri-tests
   core/crypto/util/x509.cc
   core/router/identity.cc
   core/router/net_db/impl.cc
+  core/router/info.cc
   core/router/transports/ssu/packet.cc
   core/util/buffer.cc
   core/util/byte_stream.cc

--- a/tests/unit_tests/core/router/info.cc
+++ b/tests/unit_tests/core/router/info.cc
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2015-2018, The Kovri I2P Router Project
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ *    conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *    of conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include "core/router/identity.h"
+
+namespace core = kovri::core;
+
+struct RouterInfoFixture
+{
+  core::PrivateKeys keys = core::PrivateKeys::CreateRandomKeys(
+      core::SIGNING_KEY_TYPE_EDDSA_SHA512_ED25519);
+};
+
+BOOST_FIXTURE_TEST_SUITE(RouterInfoTests, RouterInfoFixture)
+
+BOOST_AUTO_TEST_CASE(ValidSignature)
+{
+  // Ensure EdDSA router is created & signature verification succeeds
+  BOOST_CHECK_NO_THROW(core::RouterInfo r(keys, {{"127.0.0.1", 10701}}, {}));
+}
+
+BOOST_AUTO_TEST_CASE(InvalidSignature)
+{
+  core::RouterInfo router;
+
+  // Ensure default constructed router fails verification
+  BOOST_CHECK_THROW(router.Verify(), std::exception);
+
+  // Create router buffer without setting default options
+  BOOST_CHECK_THROW(router.CreateBuffer(keys), std::exception);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Moves `RouterInfo` signing into creation, before converting to a buffer. Adds signature verification and unit-test.