### PR TITLE
Tests: fix BookEntry naming warning

### DIFF
--- a/tests/unit_tests/client/address_book/impl.cc
+++ b/tests/unit_tests/client/address_book/impl.cc
@@ -174,12 +174,12 @@ BOOST_AUTO_TEST_CASE(ValidBookEntry) {
 
   // Test constructing from an identity hash
   BOOST_CHECK_NO_THROW(
-      kovri::client::BookEntry entry("kovri.i2p", entry.get_address()));
+      kovri::client::BookEntry e("kovri.i2p", entry.get_address()));
 
   // Test constructing from a base64-encoded address
   std::string const valid_dest =
       subscription.front().substr(subscription.front().find('=') + 1);
-  BOOST_CHECK_NO_THROW(kovri::client::BookEntry entry("kovri.i2p", valid_dest));
+  BOOST_CHECK_NO_THROW(kovri::client::BookEntry e("kovri.i2p", valid_dest));
 }
 
 BOOST_AUTO_TEST_CASE(InvalidBookEntry) {


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Renames constructed entry objects for clarity, and resolves clang `-Wuninitialized` warning:

```
kovri/tests/unit_tests/client/address_book/impl.cc:177:51: warning: variable 'entry' is uninitialized when used within its own initialization [-Wuninitialized]                                                                                                      
      kovri::client::BookEntry entry("kovri.i2p", entry.get_address()));
```