### PR TITLE
Proxy: Catch a potential exception in destructor.

### DIFF
--- a/src/client/proxy/http.cc
+++ b/src/client/proxy/http.cc
@@ -52,6 +52,7 @@
 #include "client/util/http.h"
 
 #include "core/router/identity.h"
+#include "core/util/exception.h"
 
 namespace kovri {
 namespace client {
@@ -547,7 +548,13 @@ void HTTPProxyHandler::Terminate() {
     m_Socket->close();
     m_Socket = nullptr;
   }
-  Done(shared_from_this());
+
+  try {
+    Done(shared_from_this());
+  } catch (...) {
+    core::Exception ex;
+    ex.Dispatch(__func__);
+  }
 }
 
 }  // namespace client

--- a/src/core/util/exception.cc
+++ b/src/core/util/exception.cc
@@ -76,6 +76,9 @@ void Exception::Dispatch(const char* message)
   } catch (const boost::program_options::error& ex) {
     LOG(error) << log << "program option exception"
                << ": '" << ex.what() << "'";
+  } catch (const std::bad_weak_ptr& ex) {
+    LOG(error) << log << "bad weak pointer" << ": '" << ex.what() << "'";
+    assert(0);
   } catch (const std::exception& ex) {
     LOG(error) << log << "standard exception" << ": '" << ex.what() << "'";
   } catch (...) {


### PR DESCRIPTION
shared_from_this() can throw std::bad_weak_ptr if called on an
object that has never been shared in a shared_ptr. Throwing an exception in
a destructor crashes the program.

Not using HTTPProxyHandler with shared pointers is a serious bug and
the program probably should crash, but in a more controlled manner and
with an error message.

But in mainly silences Coverity #175240.

Signed-off-by: Tadeas Moravec <moravec.tadeas@gmail.com>


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

