### PR TITLE
Core: create buffer utility class + buffer unit-test + RI buffer refactor

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(kovri-core
   router/tunnel/impl.h
   router/tunnel/pool.h
   router/tunnel/transit.h
+  util/buffer.h
   util/byte_stream.h
   util/config.h
   util/exception.h

--- a/src/core/router/context.cc
+++ b/src/core/router/context.cc
@@ -123,7 +123,7 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
           std::make_pair(has_ntcp, has_ssu));  // TODO(anonimal): brittle, see TODO in header
 
       // Update context RI
-      m_RouterInfo.Update(router.GetBuffer(), router.GetBufferLen());
+      m_RouterInfo.Update(router.data(), router.size());
     }
   else  // Keys (and RI should also) exist
     {
@@ -178,7 +178,7 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
       router.SetDefaultOptions();
 
       // Update context RI
-      m_RouterInfo.Update(router.GetBuffer(), router.GetBufferLen());
+      m_RouterInfo.Update(router.data(), router.size());
 
       // Test for reachability of context's RI
       if (IsUnreachable())

--- a/src/core/router/i2np.cc
+++ b/src/core/router/i2np.cc
@@ -289,7 +289,7 @@ std::shared_ptr<I2NPMessage> CreateDatabaseStoreMsg(
       buf += 32;
     }
     kovri::core::Gzip compressor;
-    compressor.Put(router->GetBuffer(), router->GetBufferLen());
+    compressor.Put(router->data(), router->size());
     auto size = compressor.MaxRetrievable();
     core::OutputByteStream::Write<std::uint16_t>(buf, size);  // size
     buf += 2;

--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -49,6 +49,7 @@
 #include "core/router/identity.h"
 #include "core/router/profiling.h"
 
+#include "core/util/buffer.h"
 #include "core/util/exception.h"
 #include "core/util/tag.h"
 #include "core/util/filesystem.h"
@@ -543,21 +544,22 @@ class RouterInfo : public RouterInfoTraits, public RoutingDestination
 
  public:
   /// @return Pointer to RI buffer
-  const std::uint8_t* GetBuffer() const
+  const std::uint8_t* data() const
   {
-    return m_Buffer.get();
+    return m_Buffer.data();
   }
 
   /// @return RI buffer length
-  std::uint16_t GetBufferLen() const noexcept
+  std::uint16_t size() const noexcept
   {
-    return m_BufferLen;
+    return m_Buffer.size();
   }
 
-  /// @brief Deletes RI buffer
-  void DeleteBuffer()
+  /// @brief Clear RI buffer
+  void clear()
   {
-    m_Buffer.reset(nullptr);
+    // TODO(unassigned): we may also want to clear all options
+    m_Buffer.clear();
   }
 
   /// @return RI's router identity
@@ -802,10 +804,9 @@ class RouterInfo : public RouterInfoTraits, public RoutingDestination
 
  private:
   core::Exception m_Exception;
+  core::Buffer<Size::MinBuffer, Size::MaxBuffer> m_Buffer;
   std::string m_Path;
   IdentityEx m_RouterIdentity;
-  std::unique_ptr<std::uint8_t[]> m_Buffer;
-  std::uint16_t m_BufferLen{};
   std::uint64_t m_Timestamp{};
   std::vector<Address> m_Addresses;
   std::map<std::string, std::string> m_Options;

--- a/src/core/router/net_db/impl.cc
+++ b/src/core/router/net_db/impl.cc
@@ -339,7 +339,7 @@ bool NetDb::Load()
                         || timestamp < router->GetTimestamp()
                                     + Time::RouterExpiration))
                   {
-                    router->DeleteBuffer();
+                    router->clear();
                     router->GetOptions().clear();  // options are not used for regular routers  // TODO(anonimal): review
                     m_RouterInfos.insert(std::make_pair(router->GetIdentHash(), router));
                     if (router->HasCap(RouterInfo::Cap::Floodfill))
@@ -391,7 +391,7 @@ void NetDb::SaveUpdated() {
       it.second->SaveToFile(f);
       it.second->SetUpdated(false);
       it.second->SetUnreachable(false);
-      it.second->DeleteBuffer();
+      it.second->clear();
       count++;
     } else {
       // RouterInfo expires after N minutes if it uses an introducer
@@ -714,7 +714,7 @@ void NetDb::HandleDatabaseLookupMsg(
       if (router) {
         LOG(debug) << "NetDb: requested RouterInfo " << key << " found";
         router->LoadBuffer();
-        if (router->GetBuffer())
+        if (router->data())
           reply_msg = CreateDatabaseStoreMsg(router);
       }
     }

--- a/src/core/util/buffer.h
+++ b/src/core/util/buffer.h
@@ -1,0 +1,154 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2018, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ */
+
+#ifndef SRC_CORE_UTIL_BUFFER_H_
+#define SRC_CORE_UTIL_BUFFER_H_
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <exception>
+#include <string>
+
+namespace kovri
+{
+namespace core
+{
+// TODO(anonimal): Boost.Buffer?
+// TODO(anonimal): SecBlock buffer
+// TODO(anonimal): This class should eventually replace Tag
+
+/// @brief A simple mutable array with sliding scale of element count (similar to vector)
+template <std::size_t MinElem = 0, std::size_t MaxElem = 4096>
+class Buffer final
+{
+  static_assert(MaxElem, "Null max size");
+
+ public:
+  Buffer() : m_Length(MaxElem) {}
+
+  Buffer(const std::uint8_t* buf, const std::size_t len)
+  {
+    set_buffer(buf, len);
+  }
+
+  explicit Buffer(const std::size_t len)
+  {
+    set_length(len);
+  }
+
+  explicit Buffer(const Buffer&) = delete;
+
+  ~Buffer() = default;
+
+  bool operator==(Buffer& other)
+  {
+    return (get() == other.get() && size() == other.size());
+  }
+
+  bool operator!=(Buffer& other)
+  {
+    return (get() != other.get() || size() != other.size());
+  }
+
+  void operator()(const std::uint8_t* buf, const std::size_t len)
+  {
+    set_buffer(buf, len);
+  }
+
+  std::size_t operator()(const std::size_t len)
+  {
+    return set_length(len);
+  }
+
+ public:
+  const auto& get() const noexcept
+  {
+    return m_Buffer;
+  }
+
+  const std::uint8_t* data() const noexcept
+  {
+    return m_Buffer.data();
+  }
+
+  std::uint8_t* data() noexcept
+  {
+    return m_Buffer.data();
+  }
+
+  std::size_t capacity() const noexcept
+  {
+    return m_Buffer.size();
+  }
+
+  std::size_t size() const noexcept
+  {
+    return m_Length;
+  }
+
+  void clear()
+  {
+    m_Buffer.fill(0);
+    m_Length = 0;
+  }
+
+ private:
+  void set_buffer(
+      const std::uint8_t* data,
+      const std::size_t len)
+  {
+    assert(data || len);
+
+    if (!data)
+      throw std::invalid_argument("Buffer: null source");
+
+    std::copy(data, data + set_length(len), m_Buffer.begin());
+  }
+
+  std::size_t set_length(const std::size_t len)
+  {
+    assert(len);
+
+    if (len < MinElem || len > MaxElem)
+      throw std::length_error("Buffer: invalid length" + std::to_string(len));
+
+    m_Length = len;
+    return m_Length;
+  }
+
+ private:
+  std::array<std::uint8_t, MaxElem> m_Buffer{{}};
+  std::size_t m_Length{};  ///< Number of expected elements
+};
+}  // namespace core
+}  // namespace kovri
+
+#endif  // SRC_CORE_UTIL_BUFFER_H_

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(kovri-tests
   core/crypto/util/x509.cc
   core/router/identity.cc
   core/router/transports/ssu/packet.cc
+  core/util/buffer.cc
   core/util/byte_stream.cc
   core/util/config.cc
   main.cc

--- a/tests/unit_tests/core/util/buffer.cc
+++ b/tests/unit_tests/core/util/buffer.cc
@@ -1,0 +1,129 @@
+/**                                                                                           //
+ * Copyright (c) 2015-2018, The Kovri I2P Router Project                                      //
+ *                                                                                            //
+ * All rights reserved.                                                                       //
+ *                                                                                            //
+ * Redistribution and use in source and binary forms, with or without modification, are       //
+ * permitted provided that the following conditions are met:                                  //
+ *                                                                                            //
+ * 1. Redistributions of source code must retain the above copyright notice, this list of     //
+ *    conditions and the following disclaimer.                                                //
+ *                                                                                            //
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list     //
+ *    of conditions and the following disclaimer in the documentation and/or other            //
+ *    materials provided with the distribution.                                               //
+ *                                                                                            //
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be       //
+ *    used to endorse or promote products derived from this software without specific         //
+ *    prior written permission.                                                               //
+ *                                                                                            //
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY        //
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    //
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL     //
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       //
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,               //
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    //
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
+ */
+
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include "core/util/buffer.h"
+
+struct BufferFixture
+{
+  core::Buffer<> buf;
+  std::array<std::uint8_t, 3> arr{{1, 2, 3}};
+  enum { Max = 4096 };
+};
+
+BOOST_FIXTURE_TEST_SUITE(Buffer, BufferFixture)
+
+BOOST_AUTO_TEST_CASE(Ctor)
+{
+  BOOST_CHECK_NO_THROW(core::Buffer<> buf(arr.data(), arr.size()));
+
+  core::Buffer<> buf(arr.data(), arr.size());
+  BOOST_CHECK_EQUAL(std::memcmp(buf.data(), arr.data(), buf.size()), 0);
+}
+
+BOOST_AUTO_TEST_CASE(Comparison)
+{
+  core::Buffer<> comp;
+  BOOST_CHECK(comp == buf);
+
+  comp(arr.data(), arr.size());
+  BOOST_CHECK(comp != buf);
+  BOOST_CHECK_NE(std::memcmp(comp.data(), buf.data(), comp.size()), 0);
+
+  core::Buffer<> elem(100);
+  BOOST_CHECK(comp != elem);
+  comp.clear();
+
+  BOOST_CHECK(comp != elem);
+  // New buffer should still be zero initialized
+  BOOST_CHECK_EQUAL(std::memcmp(comp.data(), elem.data(), comp.size()), 0);
+}
+
+BOOST_AUTO_TEST_CASE(Empty)
+{
+  std::array<std::uint8_t, Max> max{{}};
+  BOOST_CHECK(buf.get() == max);
+  BOOST_CHECK_EQUAL(std::memcmp(buf.data(), max.data(), max.size()), 0);
+
+  buf.clear();
+  BOOST_CHECK_EQUAL(buf.size(), 0);
+  BOOST_CHECK_EQUAL(buf.capacity(), Max);
+}
+
+BOOST_AUTO_TEST_CASE(Data)
+{
+  core::Buffer<123, 456> buf;
+  std::array<std::uint8_t, 456> data{{}};
+
+  BOOST_CHECK_NO_THROW(buf(data.data(), data.size()));
+  BOOST_CHECK(buf.get() == data);
+
+  data.fill(1);
+
+  BOOST_CHECK_EQUAL(buf.size(), data.size());
+  BOOST_CHECK(buf.get() != data);
+
+  BOOST_CHECK_NO_THROW(buf(data.data(), data.size()));
+  BOOST_CHECK(buf.get() == data);
+}
+
+BOOST_AUTO_TEST_CASE(Size)
+{
+  BOOST_CHECK_EQUAL(buf.size(), Max);
+  BOOST_CHECK_EQUAL(buf.capacity(), Max);
+
+  BOOST_CHECK_NO_THROW(buf(100));
+  BOOST_CHECK_EQUAL(buf.size(), 100);
+  BOOST_CHECK_EQUAL(buf.capacity(), Max);
+
+  BOOST_CHECK_NO_THROW(buf(arr.data(), arr.size()));
+  BOOST_CHECK_EQUAL(buf.size(), arr.size());
+  BOOST_CHECK_EQUAL(buf.capacity(), Max);
+}
+
+BOOST_AUTO_TEST_CASE(InvalidBuffer)
+{
+  using Buf = core::Buffer<0, 1024>;
+  BOOST_CHECK_THROW(Buf buf(Max), std::exception);
+  BOOST_CHECK_THROW(Buf buf(-123), std::exception);
+  BOOST_CHECK_THROW(core::Buffer<> buf(Max + 1), std::exception);
+}
+
+BOOST_AUTO_TEST_CASE(DataOverwrite)
+{
+  core::Buffer<0, 32> bad;
+  std::array<std::uint8_t, Max> data{{}};
+  BOOST_CHECK_THROW(bad(data.data(), data.size()), std::exception);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

This was getting in the way of me finishing my `bandcaps` branch. Otherwise, I'd have left the TODO.

RouterInfo is still very messy. Pulling it apart and a writing unit-test will be beneficial. Referencing #627.