### PR TITLE
Kovri: bump I2P router version to 0.9.35 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ message(STATUS "${KOVRI_VERSION}-${KOVRI_GIT_REVISION} \"${KOVRI_CODENAME}\"")
 message(STATUS "")
 
 # I2NP/NetDb RI properties (used internally)
-set(I2P_VERSION "0.9.32")
+set(I2P_VERSION "0.9.35")
 set(I2P_NETWORK_ID "2")  # "1" is reserved for I2P version less than 0.6.1.10
 
 # Produce version definitions, output to build directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ message(STATUS "${KOVRI_VERSION}-${KOVRI_GIT_REVISION} \"${KOVRI_CODENAME}\"")
 message(STATUS "")
 
 # I2NP/NetDb RI properties (used internally)
-set(I2P_VERSION "0.9.28")
+set(I2P_VERSION "0.9.32")
 set(I2P_NETWORK_ID "2")  # "1" is reserved for I2P version less than 0.6.1.10
 
 # Produce version definitions, output to build directory

--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -382,10 +382,15 @@ void RouterInfo::ParseRouterInfo(const std::string& router_info)
                                 sizeof(introducer.key));
                           }
                           break;
-                        // TODO(unassigned):
-                        //   Implement introducer expiration according to proposal #133
+                        case Trait::IntroExp:
+                          // TODO(unassigned):
+                          //   Implement introducer expiration according to proposal #133
+                          LOG(debug) << "RouterInfo: expiration supplied";
+                          break;
                         default:
-                          LOG(warning) << "RouterInfo: unknown introducer trait";
+                          LOG(warning)
+                              << "RouterInfo: unknown introducer trait";
+                          is_valid_address = false;
                           break;
                       }
                   }

--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -403,9 +403,10 @@ void RouterInfo::ParseRouterInfo(const std::string& router_info)
                                 sizeof(introducer.key));
                           }
                           break;
+                        // TODO(unassigned):
+                        //   Implement introducer expiration according to proposal #133
                         default:
-                          LOG(error) << "RouterInfo: invalid introducer trait";
-                          is_valid_address = false;
+                          LOG(warning) << "RouterInfo: unknown introducer trait";
                           break;
                       }
                   }

--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -271,38 +271,17 @@ void RouterInfo::ParseRouterInfo(const std::string& router_info)
               case Trait::Host:
                 {
                   // Process host and transport
-                  // TODO(unassigned): we process transport so we can resolve host. This seems like a hack.
                   boost::system::error_code ecode;
                   address.host =
                       boost::asio::ip::address::from_string(value, ecode);
+                  // Unresolved hosts should be ignored as part of #686
                   if (ecode)
                     {
-                      // Unresolved hosts return invalid argument. See TODO below
-                      if (ecode != boost::asio::error::invalid_argument)
-                        {
-                          is_valid_address = false;
-                          LOG(error) << "RouterInfo: " << __func__ << ": '"
-                                     << ecode.message() << "'";
-                        }
-                      // Prepare for host resolution
-                      switch (address.transport)
-                        {
-		          case Transport::NTCP:
-                            // NTCP will (should be) resolved in transports
-                            // TODO(unassigned): refactor. Though we will resolve host later, assigning values upon error is simply confusing.
-                            m_SupportedTransports |= SupportedTransport::NTCPv4;
-                            address.address = value;
-                            break;
-		          case Transport::SSU:
-                            // TODO(unassigned): implement address resolver for SSU (then break from default case)
-                            LOG(warning)
-                                << "RouterInfo: unexpected SSU address "
-                                << value;
-                            // fall-through
-                          default:
-                            is_valid_address = false;
-                        }
-                      break;
+                       is_valid_address = false;
+                       LOG(error) << "RouterInfo: " << __func__
+                                  << ": address host error: '"
+                                  << ecode.message() << "'";
+                       break;
                     }
                   // Add supported transport
                   if (address.host.is_v4())

--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -475,7 +475,6 @@ class RouterInfo : public RouterInfoTraits, public RoutingDestination
   {
     Transport transport;
     boost::asio::ip::address host;
-    std::string address;
     std::uint16_t port{}, mtu{};
     std::uint64_t date{};
     std::uint8_t cost{};

--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -165,6 +165,7 @@ struct RouterInfoTraits
     IntroPort,
     IntroTag,
     IntroKey,
+    IntroExp,  ///< Introducer expiration
 
     // Demarcation
     Delimiter,
@@ -241,6 +242,9 @@ struct RouterInfoTraits
         case Trait::IntroKey:
           return "ikey";
 
+        case Trait::IntroExp:
+          return "iexp";
+
         // Demarcation
         case Trait::Delimiter:
           return "=";
@@ -298,6 +302,9 @@ struct RouterInfoTraits
 
     else if (value == GetTrait(Trait::IntroKey))
       return Trait::IntroKey;
+
+    else if (value == GetTrait(Trait::IntroExp))
+      return Trait::IntroExp;
 
     // Demarcation
     else if (value == GetTrait(Trait::Delimiter))

--- a/src/core/router/transports/impl.h
+++ b/src/core/router/transports/impl.h
@@ -233,23 +233,11 @@ class Transports {
   bool ConnectToPeer(
       const kovri::core::IdentHash& ident, Peer& peer);
 
-  bool ConnectToPeerNTCP(
-      const kovri::core::IdentHash& ident, Peer& peer);
-
+  bool ConnectToPeerNTCP(Peer& peer);
   bool ConnectToPeerSSU(Peer& peer);
 
   void HandlePeerCleanupTimer(
       const boost::system::error_code& ecode);
-
-  void NTCPResolve(
-      const std::string& addr,
-      const kovri::core::IdentHash& ident);
-
-  void HandleNTCPResolve(
-      const boost::system::error_code& ecode,
-      boost::asio::ip::tcp::resolver::iterator it,
-      kovri::core::IdentHash ident,
-      std::shared_ptr<boost::asio::ip::tcp::resolver> resolver);
 
   void UpdateBandwidth();
 


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Requires merging of #931 and https://github.com/coneiric/kovri/pull/1.

Resolves #433.