### PR TITLE
CMake: fix the MinGW-w64 static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,11 @@ endif()
 # This error appear for cotired build
 if (MINGW)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj")
+  # TODO(unassigned): remove once a better solution is found (we don't want to force optimization)
+  #   Referencing https://github.com/monero-project/meta/issues/238
+  if (WITH_STATIC AND ARCH_WIDTH EQUAL "64")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+  endif()
 endif()
 
 # Directly link IPHLPAPI.lib instead of using `#pragma comment()`


### PR DESCRIPTION
Credit to iDunk. Referencing monero-project/meta#238


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

