### PR TITLE
Tests: NetDb: update parameters when adding RI

### DIFF
--- a/tests/unit_tests/core/router/net_db/impl.cc
+++ b/tests/unit_tests/core/router/net_db/impl.cc
@@ -66,8 +66,8 @@ struct NetDbFixture : public IdentityExFixture
         std::make_pair(true, false),
         cap);
 
-    m_NetDb->AddRouterInfo(
-        ri->GetIdentHash(), ri->GetBuffer(), ri->GetBufferLen());
+    BOOST_CHECK_NO_THROW(
+        m_NetDb->AddRouterInfo(ri->GetIdentHash(), ri->data(), ri->size()));
 
     return ri;
   }


### PR DESCRIPTION
Was not rebased after the buffer refactor in #926


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

