### PR TITLE
Socks: Catch a potential exception in destructor.

### DIFF
--- a/src/client/proxy/socks.cc
+++ b/src/client/proxy/socks.cc
@@ -42,6 +42,7 @@
 #include "client/tunnel.h"
 
 #include "core/router/identity.h"
+#include "core/util/exception.h"
 
 
 namespace kovri {
@@ -376,7 +377,15 @@ void SOCKSHandler::Terminate() {
     LOG(debug) << "SOCKSHandler: close stream";
     m_Stream.reset();
   }
-  Done(shared_from_this());
+  try
+    {
+      Done(shared_from_this());
+    }
+  catch (...)
+    {
+      core::Exception ex;
+      ex.Dispatch(__func__);
+    }
 }
 
 // TODO(anonimal): bytestream refactor


### PR DESCRIPTION
shared_from_this() can throw std::bad_weak_ptr if called on an
object that has never been shared in a shared_ptr. Throwing an exception
in a destructor crashes the program.

Not using SOCKSHandler with shared pointers is a serious bug and
the program probably should crash, but in a more controlled manner and
with an error message.

But in mainly silences Coverity #175240.

Same situation as in PR #923 . I just haven't noticed that while working on
that one.

Signed-off-by: Tadeas Moravec <moravec.tadeas@gmail.com>


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

