### PR TITLE
Readme updated with French Link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This page is also available in the following languages
 + [Italian](https://github.com/monero-project/kovri-docs/blob/master/i18n/it/README.md)
 + Spanish
 + Russian
-+ French
++ [French](https://github.com/monero-project/kovri-docs/blob/master/i18n/fr/README.md)
 + German
 + Danishs
 


### PR DESCRIPTION
This come along with ~~monero-project/kovri-docs#55 and should perhaps not be merge before~~ monero-project/kovri-docs#58 and should be merge at the same moment.