### PR TITLE
Tunnel: shorten lock for transit tunnels

### DIFF
--- a/src/core/router/tunnel/impl.cc
+++ b/src/core/router/tunnel/impl.cc
@@ -667,10 +667,9 @@ void Tunnels::ManageInboundTunnels() {
 }
 
 void Tunnels::ManageTransitTunnels() {
-  std::unique_lock<std::mutex> l(m_TransitTunnelsMutex);
-
   const std::uint64_t ts = kovri::core::GetSecondsSinceEpoch();
   for (auto it = m_TransitTunnels.begin(); it != m_TransitTunnels.end();) {
+    std::unique_lock<std::mutex> l(m_TransitTunnelsMutex);
     if (ts > it->second->GetCreationTime() + TUNNEL_EXPIRATION_TIMEOUT) {
       LOG(debug) << "Tunnels: transit tunnel " << it->second->GetTunnelID() << " expired";
       it = m_TransitTunnels.erase(it);


### PR DESCRIPTION
Scope lock for transit tunnels to iterate correctly over the entire map.

Resolves #946

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

