### PR TITLE
Router ssu session: Fix potential null dereference

### DIFF
--- a/src/core/router/transports/ssu/session.cc
+++ b/src/core/router/transports/ssu/session.cc
@@ -565,6 +565,7 @@ void SSUSession::SendSessionCreated(const std::uint8_t* dh_x)
 
       // Compute exchanged session dataset size
       // TODO(anonimal): at this point, why would we allow mix-and-match IPv6 to send to IPv4 - or vice versa...
+      assert(address);
       bool const is_IPv6 = address->host.is_v6();
       std::uint16_t const data_size =
           get_signed_data_size(alice_ip.size() + (is_IPv6 ? 16 : 4));


### PR DESCRIPTION
Address is checked in GetIntroKey so the chances of running into the new
assert are negligible. But Coverity is right, the potential is nonzero.

Silences Coverity #183014.


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

