### PR TITLE
SSU: Remove assert that's always true.

### DIFF
--- a/src/core/router/transports/ssu/session.cc
+++ b/src/core/router/transports/ssu/session.cc
@@ -186,9 +186,6 @@ void SSUSession::ProcessNextMessage(
       // Update total received bytes during router run
       core::transports.UpdateReceivedBytes(len);
 
-      // TODO(anonimal): this particular state design is bad design
-      assert(
-          m_State != SessionState::Closed || m_State != SessionState::Failed);
       switch (m_State)
         {
           case SessionState::Introduced:


### PR DESCRIPTION
Maybe there should be `&&` instead of `||`. But it doesn't really matter, because this situation is handled by the `default` branch of the following switch statement.

Coverity #183013


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

