### PR TITLE
Stream: default construct current remote lease

### DIFF
--- a/src/client/api/streaming.cc
+++ b/src/client/api/streaming.cc
@@ -105,7 +105,7 @@ Stream::Stream(
       m_Status(eStreamStatusNew),
       m_IsAckSendScheduled(false),
       m_LocalDestination(local),
-      m_CurrentRemoteLease {0, 0, 0},
+      m_CurrentRemoteLease{},
       m_ReceiveTimer(m_Service),
       m_ResendTimer(m_Service),
       m_AckSendTimer(m_Service),

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(kovri-tests
   client/address_book/storage.cc
   client/api/i2p_control/data.cc
   client/api/i2p_control/parser.cc
+  client/api/streaming.cc
   client/reseed.cc
   client/proxy/http.cc
   client/util/http.cc

--- a/tests/unit_tests/client/api/streaming.cc
+++ b/tests/unit_tests/client/api/streaming.cc
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2015-2018, The Kovri I2P Router Project
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ *    conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *    of conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include "src/client/api/streaming.h"
+#include "src/client/destination.h"
+
+#include "src/core/router/identity.h"
+
+namespace core = kovri::core;
+namespace client = kovri::client;
+
+struct StreamingFixture
+{
+  std::unique_ptr<client::Stream> CreateStream()
+  {
+    client::ClientDestination cd(
+        core::PrivateKeys::CreateRandomKeys(
+            core::DEFAULT_ROUTER_SIGNING_KEY_TYPE),
+        {});
+    client::StreamingDestination sd(cd);
+    boost::asio::io_service svc;
+    return std::make_unique<client::Stream>(svc, sd);
+  }
+
+  std::unique_ptr<client::Stream> stream;
+};
+
+BOOST_FIXTURE_TEST_SUITE(StreamingTests, StreamingFixture)
+
+BOOST_AUTO_TEST_CASE(DefaultStream)
+{
+  BOOST_CHECK_NO_THROW(stream = CreateStream());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Use empty brace-initialization to default construct the current remote lease, and prevent a null buffer assertion firing.

Resolves #948.