### PR TITLE
Kovri: add ident base32 conversions + base32/64 tests, implement HTTP server tunnel X-I2P headers

### DIFF
--- a/src/client/tunnel.h
+++ b/src/client/tunnel.h
@@ -126,6 +126,11 @@ class I2PTunnelConnection
 
   void StreamReceive();
 
+  const auto& get_stream() const noexcept
+  {
+    return m_Stream;
+  }
+
   void HandleStreamReceive(
       const boost::system::error_code& ecode,
       std::size_t bytes_transferred);

--- a/src/core/router/identity.cc
+++ b/src/core/router/identity.cc
@@ -317,6 +317,17 @@ void IdentityEx::FromBase64(const std::string& encoded)
     throw std::runtime_error("IdentityEx: could not decode from base64");
 }
 
+std::string IdentityEx::ToBase32() const
+{
+  // TODO(anonimal): this max size is arbitrary. Realistically,
+  //   we'll only need a max with 387 + 4 for EdDSA-Ed25519 routers
+  //   which is a majority of the network. Note: do not set that size
+  //   until we remove implementing other signatures.
+  core::Buffer<core::DEFAULT_IDENTITY_SIZE, 1024> buf;
+  buf(ToBuffer(buf.data(), buf.size()));
+  return core::Base32::Encode(buf.data(), buf.size());
+}
+
 std::string IdentityEx::ToBase64() const
 {
   std::array<std::uint8_t, 1024> buf{{}};

--- a/src/core/router/identity.cc
+++ b/src/core/router/identity.cc
@@ -308,6 +308,13 @@ std::size_t IdentityEx::ToBuffer(
   return GetFullLen();
 }
 
+void IdentityEx::FromBase32(const std::string& encoded)
+{
+  auto const decoded = core::Base32::Decode(encoded.c_str(), encoded.length());
+  if (!FromBuffer(decoded.data(), decoded.size()))
+    throw std::runtime_error("IdentityEx: could not decode from base32");
+}
+
 void IdentityEx::FromBase64(const std::string& encoded)
 {
   auto const decoded = core::Base64::Decode(encoded.c_str(), encoded.length());

--- a/src/core/router/identity.h
+++ b/src/core/router/identity.h
@@ -158,6 +158,7 @@ class IdentityEx {
       std::uint8_t* buf,
       std::size_t len) const;
 
+  void FromBase32(const std::string& encoded);
   void FromBase64(const std::string& s);
 
   std::string ToBase32() const;

--- a/src/core/router/identity.h
+++ b/src/core/router/identity.h
@@ -160,6 +160,7 @@ class IdentityEx {
 
   void FromBase64(const std::string& s);
 
+  std::string ToBase32() const;
   std::string ToBase64() const;
 
   /// @brief Human readable description of this struct

--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -724,7 +724,10 @@ void RouterInfo::CreateRouterInfo(
   LOG(debug) << "RouterInfo: " << __func__;
 
   // Write ident
-  // TODO(anonimal): review the following arbitrary size (must be >= 387)
+  // TODO(anonimal): this max size is arbitrary. Realistically,
+  //   we'll only need a max with 387 + 4 for EdDSA-Ed25519 routers
+  //   which is a majority of the network. Note: do not set that size
+  //   until we remove implementing other signatures.
   std::array<std::uint8_t, 1024> ident {{}};
   auto ident_len =
       private_keys.GetPublic().ToBuffer(ident.data(), ident.size());

--- a/tests/unit_tests/core/router/identity.cc
+++ b/tests/unit_tests/core/router/identity.cc
@@ -51,15 +51,15 @@ BOOST_AUTO_TEST_CASE(ParseIdentity)
   // Parse
   core::IdentityEx identity;
   BOOST_CHECK(
-      identity.FromBuffer(m_AliceIdentity.data(), m_AliceIdentity.size()));
+      identity.FromBuffer(raw_ident.data(), raw_ident.size()));
   // Check that FromBuffer + ToBuffer == original buffer
   std::array<std::uint8_t, core::DEFAULT_IDENTITY_SIZE + 4> output{{}};
   auto len = identity.ToBuffer(output.data(), output.size());
   BOOST_CHECK_EQUAL_COLLECTIONS(
       output.data(),
       output.data() + len,
-      m_AliceIdentity.data(),
-      m_AliceIdentity.data() + m_AliceIdentity.size());
+      raw_ident.data(),
+      raw_ident.data() + raw_ident.size());
   // Check key types
   BOOST_CHECK_EQUAL(
       identity.GetSigningKeyType(),
@@ -79,17 +79,17 @@ BOOST_AUTO_TEST_CASE(ParseIdentityFailure)
   // Change for invalid length
   core::IdentityEx identity;
   for (std::size_t i(1);
-       i <= m_AliceIdentity.size() - core::DEFAULT_IDENTITY_SIZE;
+       i <= raw_ident.size() - core::DEFAULT_IDENTITY_SIZE;
        i++)
     BOOST_CHECK_EQUAL(
-        identity.FromBuffer(m_AliceIdentity.data(), m_AliceIdentity.size() - i),
+        identity.FromBuffer(raw_ident.data(), raw_ident.size() - i),
         0);
 }
 
 BOOST_AUTO_TEST_CASE(ValidRoutingKey)
 {
   core::IdentityEx ident;
-  BOOST_CHECK(ident.FromBuffer(m_AliceIdentity.data(), m_AliceIdentity.size()));
+  BOOST_CHECK(ident.FromBuffer(raw_ident.data(), raw_ident.size()));
   BOOST_CHECK_NO_THROW(core::CreateRoutingKey(ident.GetIdentHash()));
 }
 

--- a/tests/unit_tests/core/router/identity.cc
+++ b/tests/unit_tests/core/router/identity.cc
@@ -105,4 +105,9 @@ BOOST_AUTO_TEST_CASE(ValidDateFormat)
   BOOST_CHECK(std::regex_search(core::GetFormattedDate(), regex));
 }
 
+BOOST_AUTO_TEST_CASE(Base32Conversion)
+{
+  BOOST_CHECK_NO_THROW(ident.FromBase32(ident.ToBase32()));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/unit_tests/core/router/identity.cc
+++ b/tests/unit_tests/core/router/identity.cc
@@ -48,30 +48,31 @@ BOOST_FIXTURE_TEST_SUITE(IdentityExTests, IdentityExFixture)
 
 BOOST_AUTO_TEST_CASE(ParseIdentity)
 {
-  // Parse
-  core::IdentityEx identity;
-  BOOST_CHECK(
-      identity.FromBuffer(raw_ident.data(), raw_ident.size()));
-  // Check that FromBuffer + ToBuffer == original buffer
+  // Verify integrity of buffer conversion
   std::array<std::uint8_t, core::DEFAULT_IDENTITY_SIZE + 4> output{{}};
-  auto len = identity.ToBuffer(output.data(), output.size());
+  auto const len = ident.ToBuffer(output.data(), output.size());
   BOOST_CHECK_EQUAL_COLLECTIONS(
       output.data(),
       output.data() + len,
       raw_ident.data(),
       raw_ident.data() + raw_ident.size());
+
   // Check key types
   BOOST_CHECK_EQUAL(
-      identity.GetSigningKeyType(),
+      ident.GetSigningKeyType(),
       core::SIGNING_KEY_TYPE_EDDSA_SHA512_ED25519);
-  BOOST_CHECK_EQUAL(identity.GetCryptoKeyType(), core::CRYPTO_KEY_TYPE_ELGAMAL);
+
+  BOOST_CHECK_EQUAL(ident.GetCryptoKeyType(), core::CRYPTO_KEY_TYPE_ELGAMAL);
+
   // Check sig lengths
   BOOST_CHECK_EQUAL(
-      identity.GetSigningPublicKeyLen(), core::EDDSA25519_PUBLIC_KEY_LENGTH);
+      ident.GetSigningPublicKeyLen(), core::EDDSA25519_PUBLIC_KEY_LENGTH);
+
   BOOST_CHECK_EQUAL(
-      identity.GetSigningPrivateKeyLen(), core::EDDSA25519_PRIVATE_KEY_LENGTH);
+      ident.GetSigningPrivateKeyLen(), core::EDDSA25519_PRIVATE_KEY_LENGTH);
+
   BOOST_CHECK_EQUAL(
-      identity.GetSignatureLen(), core::EDDSA25519_SIGNATURE_LENGTH);
+      ident.GetSignatureLen(), core::EDDSA25519_SIGNATURE_LENGTH);
 }
 
 BOOST_AUTO_TEST_CASE(ParseIdentityFailure)
@@ -88,16 +89,14 @@ BOOST_AUTO_TEST_CASE(ParseIdentityFailure)
 
 BOOST_AUTO_TEST_CASE(ValidRoutingKey)
 {
-  core::IdentityEx ident;
-  BOOST_CHECK(ident.FromBuffer(raw_ident.data(), raw_ident.size()));
   BOOST_CHECK_NO_THROW(core::CreateRoutingKey(ident.GetIdentHash()));
 }
 
 BOOST_AUTO_TEST_CASE(InvalidRoutingKey)
 {
   kovri::core::IdentHash hash;
-  BOOST_CHECK_THROW(core::CreateRoutingKey(nullptr), std::invalid_argument);
   BOOST_CHECK_THROW(core::CreateRoutingKey(hash), std::invalid_argument);
+  BOOST_CHECK_THROW(core::CreateRoutingKey(nullptr), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(ValidDateFormat)

--- a/tests/unit_tests/core/router/identity.cc
+++ b/tests/unit_tests/core/router/identity.cc
@@ -53,8 +53,7 @@ BOOST_AUTO_TEST_CASE(ParseIdentity)
   BOOST_CHECK(
       identity.FromBuffer(m_AliceIdentity.data(), m_AliceIdentity.size()));
   // Check that FromBuffer + ToBuffer == original buffer
-  // TODO(anonimal): review the following arbitrary size (must be >= 387)
-  std::array<std::uint8_t, 1024> output{{}};
+  std::array<std::uint8_t, core::DEFAULT_IDENTITY_SIZE + 4> output{{}};
   auto len = identity.ToBuffer(output.data(), output.size());
   BOOST_CHECK_EQUAL_COLLECTIONS(
       output.data(),

--- a/tests/unit_tests/core/router/identity.cc
+++ b/tests/unit_tests/core/router/identity.cc
@@ -110,4 +110,9 @@ BOOST_AUTO_TEST_CASE(Base32Conversion)
   BOOST_CHECK_NO_THROW(ident.FromBase32(ident.ToBase32()));
 }
 
+BOOST_AUTO_TEST_CASE(Base64Conversion)
+{
+  BOOST_CHECK_NO_THROW(ident.FromBase64(ident.ToBase64()));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/unit_tests/core/router/identity.h
+++ b/tests/unit_tests/core/router/identity.h
@@ -41,6 +41,11 @@ namespace core = kovri::core;
 
 struct IdentityExFixture
 {
+  IdentityExFixture()
+  {
+    BOOST_CHECK(ident.FromBuffer(raw_ident.data(), raw_ident.size()));
+  }
+
   std::array<std::uint8_t, core::DEFAULT_IDENTITY_SIZE + 4> raw_ident
   {{
     // 256 bytes Public key
@@ -102,6 +107,8 @@ struct IdentityExFixture
     // 2 bytes crypto key : CRYPTO_KEY_TYPE_ELGAMAL
     0x00, 0x00,
   }};
+
+  core::IdentityEx ident;
 };
 
 #endif  // TESTS_UNIT_TESTS_CORE_ROUTER_IDENTITY_H_

--- a/tests/unit_tests/core/router/identity.h
+++ b/tests/unit_tests/core/router/identity.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2017, The Kovri I2P Router Project
+ * Copyright (c) 2015-2018, The Kovri I2P Router Project
  *
  * All rights reserved.
  *
@@ -41,7 +41,7 @@ namespace core = kovri::core;
 
 struct IdentityExFixture
 {
-  std::array<std::uint8_t, core::DEFAULT_IDENTITY_SIZE + 4> m_AliceIdentity
+  std::array<std::uint8_t, core::DEFAULT_IDENTITY_SIZE + 4> raw_ident
   {{
     // 256 bytes Public key
     0x6c, 0xdb, 0x94, 0xcb, 0xce, 0x27, 0x7a, 0xef,

--- a/tests/unit_tests/core/router/net_db/impl.cc
+++ b/tests/unit_tests/core/router/net_db/impl.cc
@@ -53,7 +53,7 @@ struct NetDbFixture : public IdentityExFixture
   {
     // Use Alice's data from IdentityEx fixture
     core::IdentityEx m_Ident;
-    m_Ident.FromBuffer(m_AliceIdentity.data(), m_AliceIdentity.size());
+    m_Ident.FromBuffer(raw_ident.data(), raw_ident.size());
     m_Hash = m_Ident.GetIdentHash();
   }
 

--- a/tests/unit_tests/core/router/transports/ssu/packet.cc
+++ b/tests/unit_tests/core/router/transports/ssu/packet.cc
@@ -62,9 +62,9 @@ struct SSUTestVectorsFixture : public IdentityExFixture
     // 1 byte info
     output.Write<std::uint8_t>(0x01);
     // 2 byte identity size (0x01, 0x87)
-    output.Write<std::uint16_t>(m_AliceIdentity.size());
+    output.Write<std::uint16_t>(raw_ident.size());
     // Append identity
-    output.WriteData(m_AliceIdentity.data(), m_AliceIdentity.size());
+    output.WriteData(raw_ident.data(), raw_ident.size());
     // Signed on time (0x57, 0x69, 0x04, 0xAA)
     output.Write<std::uint32_t>(m_SignedOnTime);
     // Padding to reach multiple of 16 bytes
@@ -461,7 +461,7 @@ BOOST_AUTO_TEST_CASE(SessionConfirmedPlain)
   // Construct IdentityEx
   core::IdentityEx identity;
   BOOST_CHECK(
-      identity.FromBuffer(m_AliceIdentity.data(), m_AliceIdentity.size()));
+      identity.FromBuffer(raw_ident.data(), raw_ident.size()));
   std::unique_ptr<core::SSUSessionConfirmedPacket> packet;
   // Parse
   core::SSUPacketParser parser(session_confirmed.data(), session_confirmed.size());
@@ -679,7 +679,7 @@ BOOST_AUTO_TEST_CASE(SessionConfirmedPlain)
   // Construct IdentityEx
   core::IdentityEx identity;
   BOOST_CHECK(
-      identity.FromBuffer(m_AliceIdentity.data(), m_AliceIdentity.size()));
+      identity.FromBuffer(raw_ident.data(), raw_ident.size()));
   // Build initial packet : need header
   core::SSUPacketParser parser(header_plain.data(), header_plain.size());
   std::unique_ptr<core::SSUHeader> header;
@@ -701,7 +701,7 @@ BOOST_AUTO_TEST_CASE(SessionConfirmedPlain)
   // Padding is randomized, so check everything before and after
   const std::size_t padding_position = header_plain.size() + 1  // Info
                                        + 2  // Identity size
-                                       + m_AliceIdentity.size()  // Identity
+                                       + raw_ident.size()  // Identity
                                        + 4;  // SignedOnTime size
   BOOST_CHECK_EQUAL_COLLECTIONS(
       buffer.get(),


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Resolves #952.