### PR TITLE
SSU: use index for processing data packets

### DIFF
--- a/src/core/router/transports/ssu/data.cc
+++ b/src/core/router/transports/ssu/data.cc
@@ -148,31 +148,33 @@ void SSUData::ProcessSentMessageACK(
 
 void SSUData::ProcessACKs(
     std::uint8_t*& buf,
-    std::uint8_t flag) {
+    std::uint8_t flag,
+    std::atomic<std::size_t>& idx)
+{
   LOG(debug)
     << "SSUData:" << m_Session.GetFormattedSessionInfo() << "processing ACKs";
   if (flag & SSUFlag::DataExplicitACKsIncluded) {
     // explicit ACKs
-    auto num_ACKs = *buf;
-    buf++;
+    auto num_ACKs = buf[idx];
+    idx++;
     for (auto i = 0; i < num_ACKs; i++)
       ProcessSentMessageACK(
-          core::InputByteStream::Read<std::uint32_t>(buf + i * 4));
-    buf += num_ACKs * 4;
+          core::InputByteStream::Read<std::uint32_t>(&buf[idx + i * 4]));
+    idx += num_ACKs * 4;
   }
   if (flag & SSUFlag::DataACKBitfieldsIncluded) {
     // explicit ACK bitfields
-    auto num_bitfields = *buf;
-    buf++;
+    auto num_bitfields = buf[idx];
+    idx++;
     for (auto i = 0; i < num_bitfields; i++) {
-      auto const msg_id = core::InputByteStream::Read<std::uint32_t>(buf);
-      buf += 4;  // message ID
+      auto const msg_id = core::InputByteStream::Read<std::uint32_t>(&buf[idx]);
+      idx += 4;  // message ID
       auto it = m_SentMessages.find(msg_id);
       // process individual ACK bitfields
       bool is_not_last = false;
       std::size_t fragment = 0;
       do {
-        auto bitfield = *buf;
+        auto bitfield = buf[idx];
         is_not_last = bitfield & 0x80;
         bitfield &= 0x7F;  // clear MSB
         if (bitfield && it != m_SentMessages.end()) {
@@ -188,27 +190,27 @@ void SSUData::ProcessACKs(
             mask <<= 1;
           }
         }
-        buf++;
+        idx++;
       }
       while (is_not_last);
     }
   }
 }
 
-void SSUData::ProcessFragments(
-    std::uint8_t* buf) {
+void SSUData::ProcessFragments(std::uint8_t* buf, std::atomic<std::size_t>& idx)
+{
   LOG(debug)
     << "SSUData:" << m_Session.GetFormattedSessionInfo()
     << "processing fragments";
-  auto num_fragments = *buf;  // number of fragments
-  buf++;
+  auto num_fragments = buf[idx];  // number of fragments
+  idx++;
   for (auto i = 0; i < num_fragments; i++) {
-    auto const msg_id = core::InputByteStream::Read<std::uint32_t>(buf);
-    buf += 4;
+    auto const msg_id = core::InputByteStream::Read<std::uint32_t>(&buf[idx]);
+    idx += 4;
     std::array<std::uint8_t, 4> frag;
     frag.at(0) = 0;
-    memcpy(frag.data() + 1, buf, 3);
-    buf += 3;
+    memcpy(frag.data() + 1, &buf[idx], 3);
+    idx += 3;
     auto const fragment_info =
         core::InputByteStream::Read<std::uint32_t>(frag.data());
     auto fragment_size = fragment_info & 0x3FFF;  // bits 0 - 13
@@ -332,7 +334,7 @@ void SSUData::ProcessFragments(
     } else {
       SendFragmentACK(msg_id, fragment_num);
     }
-    buf += fragment_size;
+    idx += fragment_size;
   }
 }
 
@@ -347,8 +349,9 @@ void SSUData::ProcessMessage(
     std::uint8_t* buf,
     std::size_t len) {
   // std::uint8_t* start = buf;
-  std::uint8_t flag = *buf;
-  buf++;
+  std::atomic<std::size_t> idx(0);
+  std::uint8_t flag = buf[idx];
+  idx++;
   LOG(debug)
     << "SSUData:" << m_Session.GetFormattedSessionInfo()
     << "processing message: flags=" << static_cast<std::size_t>(flag)
@@ -357,19 +360,19 @@ void SSUData::ProcessMessage(
   if (flag &
       (SSUFlag::DataACKBitfieldsIncluded |
        SSUFlag::DataExplicitACKsIncluded))
-    ProcessACKs(buf, flag);
+    ProcessACKs(buf, flag, idx);
   // extended data if presented
   if (flag & SSUFlag::DataExtendedIncluded) {
-    std::uint8_t extended_data_size = *buf;
-    buf++;  // size
+    std::uint8_t extended_data_size = buf[idx];
+    idx++;  // size
     LOG(debug)
       << "SSUData:" << m_Session.GetFormattedSessionInfo()
       << "SSU extended data of "
       << static_cast<int>(extended_data_size) << " bytes presented";
-    buf += extended_data_size;
+    idx += extended_data_size;
   }
   // process data
-  ProcessFragments(buf);
+  ProcessFragments(buf, idx);
 }
 
 // TODO(anonimal): bytestream refactor

--- a/src/core/router/transports/ssu/data.cc
+++ b/src/core/router/transports/ssu/data.cc
@@ -147,7 +147,7 @@ void SSUData::ProcessSentMessageACK(
 }
 
 void SSUData::ProcessACKs(
-    std::uint8_t*& buf,
+    const std::uint8_t* const buf,
     std::uint8_t flag,
     std::atomic<std::size_t>& idx)
 {
@@ -197,7 +197,9 @@ void SSUData::ProcessACKs(
   }
 }
 
-void SSUData::ProcessFragments(std::uint8_t* buf, std::atomic<std::size_t>& idx)
+void SSUData::ProcessFragments(
+    const std::uint8_t* const buf,
+    std::atomic<std::size_t>& idx)
 {
   LOG(debug)
     << "SSUData:" << m_Session.GetFormattedSessionInfo()
@@ -346,7 +348,7 @@ void SSUData::FlushReceivedMessage() {
 }
 
 void SSUData::ProcessMessage(
-    std::uint8_t* buf,
+    const std::uint8_t* const buf,
     std::size_t len) {
   // std::uint8_t* start = buf;
   std::atomic<std::size_t> idx(0);

--- a/src/core/router/transports/ssu/data.h
+++ b/src/core/router/transports/ssu/data.h
@@ -129,7 +129,7 @@ class SSUData {
   void Stop();
 
   void ProcessMessage(
-      std::uint8_t* buf,
+      const std::uint8_t* const buf,
       std::size_t len);
 
   void FlushReceivedMessage();
@@ -148,9 +148,14 @@ class SSUData {
       std::uint32_t msg_id,
       std::size_t fragment_num);
 
-  void ProcessACKs(std::uint8_t*& buf, std::uint8_t flag, std::size_t& idx);
+  void ProcessACKs(
+      const std::uint8_t* const buf,
+      std::uint8_t flag,
+      std::atomic<std::size_t>& idx);
 
-  void ProcessFragments(std::uint8_t* buf, std::size_t& idx);
+  void ProcessFragments(
+      const std::uint8_t* const buf,
+      std::atomic<std::size_t>& idx);
 
   void ProcessSentMessageACK(
       std::uint32_t msg_id);

--- a/src/core/router/transports/ssu/data.h
+++ b/src/core/router/transports/ssu/data.h
@@ -148,12 +148,9 @@ class SSUData {
       std::uint32_t msg_id,
       std::size_t fragment_num);
 
-  void ProcessACKs(
-      std::uint8_t*& buf,
-      std::uint8_t flag);
+  void ProcessACKs(std::uint8_t*& buf, std::uint8_t flag, std::size_t& idx);
 
-  void ProcessFragments(
-      std::uint8_t * buf);
+  void ProcessFragments(std::uint8_t* buf, std::size_t& idx);
 
   void ProcessSentMessageACK(
       std::uint32_t msg_id);


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Instead of incrementing the packet buffer directly, increments an index used to access to packet buffer.