### PR TITLE
 Bytestream: data pointer refactor, add tellp + related SSU refactor

### DIFF
--- a/src/client/destination.cc
+++ b/src/client/destination.cc
@@ -515,7 +515,7 @@ void ClientDestination::HandleDataMessage(const std::uint8_t* buf, std::size_t)
       // streaming protocol
       auto dest = GetStreamingDestination(dest_port);
       if (dest)
-        dest->HandleDataMessagePayload(payload.Data(), payload.Size());
+        dest->HandleDataMessagePayload(payload.data(), payload.size());
       else
         LOG(warning) << "ClientDestination: missing streaming destination";
     }
@@ -526,8 +526,8 @@ void ClientDestination::HandleDataMessage(const std::uint8_t* buf, std::size_t)
         m_DatagramDestination->HandleDataMessagePayload(
             source_port,
             dest_port,
-            payload.Data(),
-            payload.Size());
+            payload.data(),
+            payload.size());
       else
         LOG(warning) << "ClientDestination: missing streaming destination";
     break;

--- a/src/core/router/transports/ssu/packet.cc
+++ b/src/core/router/transports/ssu/packet.cc
@@ -713,7 +713,7 @@ SSUFragment SSUPacketParser::ParseFragment() {
   fragment.SetIsLast(fragment_info & 0x010000);  // bit 16
   fragment.SetNumber(fragment_info >> 17);  // bits 23 - 17
   // End session if fragmented size is greater than buffer size
-  if (fragment.GetSize() > Size())
+  if (fragment.GetSize() > size())
     {
       // TODO(anonimal): invalid size could be an implementation issue rather
       //   than an attack. Reconsider how we mitigate invalid fragment size.
@@ -975,7 +975,7 @@ void SSUPacketBuilder::WriteSessionCreated(SSUSessionCreatedPacket* packet) {
 
 void SSUPacketBuilder::WriteSessionConfirmed(
     SSUSessionConfirmedPacket* packet) {
-  const std::uint8_t* const begin = Tellp();
+  const std::uint8_t* const begin = tellp();
   Write<std::uint8_t>(0x01);  // 1 byte info, with 1 fragment
   const std::size_t identity_size = packet->GetRemoteRouterIdentity().GetFullLen();
   Write<std::uint16_t>(identity_size);
@@ -988,7 +988,7 @@ void SSUPacketBuilder::WriteSessionConfirmed(
   // message
   const std::size_t signature_size = packet->GetRemoteRouterIdentity().GetSignatureLen();
   const std::size_t padding_size = GetPaddingSize(
-      packet->GetHeader()->GetSize() + Tellp() - begin + signature_size);
+      packet->GetHeader()->GetSize() + tellp() - begin + signature_size);
   std::uint8_t* const padding = m_DataPtr;
   SkipBytes(padding_size);
   kovri::core::RandBytes(padding, padding_size);

--- a/src/core/router/transports/ssu/packet.cc
+++ b/src/core/router/transports/ssu/packet.cc
@@ -975,7 +975,7 @@ void SSUPacketBuilder::WriteSessionCreated(SSUSessionCreatedPacket* packet) {
 
 void SSUPacketBuilder::WriteSessionConfirmed(
     SSUSessionConfirmedPacket* packet) {
-  std::uint8_t* const begin = m_DataPtr;
+  const std::uint8_t* const begin = Tellp();
   Write<std::uint8_t>(0x01);  // 1 byte info, with 1 fragment
   const std::size_t identity_size = packet->GetRemoteRouterIdentity().GetFullLen();
   Write<std::uint16_t>(identity_size);
@@ -988,7 +988,7 @@ void SSUPacketBuilder::WriteSessionConfirmed(
   // message
   const std::size_t signature_size = packet->GetRemoteRouterIdentity().GetSignatureLen();
   const std::size_t padding_size = GetPaddingSize(
-      packet->GetHeader()->GetSize() + m_DataPtr - begin + signature_size);
+      packet->GetHeader()->GetSize() + Tellp() - begin + signature_size);
   std::uint8_t* const padding = m_DataPtr;
   SkipBytes(padding_size);
   kovri::core::RandBytes(padding, padding_size);

--- a/src/core/router/tunnel/config.cc
+++ b/src/core/router/tunnel/config.cc
@@ -216,8 +216,8 @@ void TunnelHopConfig::CreateBuildRequestRecord(
   try {
     // ElGamal encrypt with the hop's public encryption key
     GetCurrentRouter()->GetElGamalEncryption()->Encrypt(
-        stream->Data(),
-        stream->Size(),
+        stream->data(),
+        stream->size(),
         // TODO(unassigned): Passing pointer argument interferes with more needed refactor work.
         // Pointing to record argument appears to only lead to more spaghetti code
         record + BUILD_REQUEST_RECORD_ENCRYPTED_OFFSET);

--- a/src/core/util/byte_stream.h
+++ b/src/core/util/byte_stream.h
@@ -71,27 +71,27 @@ class ByteStream
 
   /// @brief Get the first unconsumed/unwritten byte in the stream
   /// @return Pointer to the first byte
-  const std::uint8_t* Data() const noexcept
+  const std::uint8_t* data() const noexcept
   {
     return m_DataPtr - m_Counter;
   }
 
   /// @brief Total size of stream given at initialization
   /// @return Total size
-  std::size_t Size() const noexcept
+  std::size_t size() const noexcept
   {
     return m_Length + m_Counter;
   }
 
   /// @brief Get the current position in the stream
   /// @return Pointer to current byte position
-  const std::uint8_t* Tellp() const noexcept
+  const std::uint8_t* tellp() const noexcept
   {
     return m_DataPtr;
   }
 
   /// @brief Remaining length of the stream after advancement
-  std::size_t Gcount() const noexcept
+  std::size_t gcount() const noexcept
   {
     return m_Length;
   }
@@ -184,7 +184,7 @@ class OutputByteStream : public ByteStream
 
   /// @brief Allows writing the first byte in the stream
   /// @return Pointer to the first byte
-  std::uint8_t* Data() noexcept
+  std::uint8_t* data() noexcept
   {
     return m_DataPtr - m_Counter;
   }

--- a/tests/unit_tests/core/util/byte_stream.cc
+++ b/tests/unit_tests/core/util/byte_stream.cc
@@ -88,8 +88,8 @@ BOOST_AUTO_TEST_CASE(InputByteStream)
   BOOST_CHECK_THROW(input.SkipBytes(1), std::length_error);
 
   BOOST_CHECK_EQUAL_COLLECTIONS(
-      input.Data(),
-      input.Data() + input.Size(),
+      input.data(),
+      input.data() + input.size(),
       m_IPv4Array.begin(),
       m_IPv4Array.end());
 }
@@ -101,11 +101,11 @@ BOOST_AUTO_TEST_CASE(OutputByteStream)
   BOOST_CHECK_THROW(output.WriteData(nullptr, 0), std::invalid_argument);
   BOOST_CHECK_THROW(output.WriteData(buffer.data(), 0), std::length_error);
   BOOST_CHECK_NO_THROW(output.Write<std::uint8_t>(m_IPv4Array.at(0)));
-  BOOST_CHECK_EQUAL(output.Size(), buffer.size());
-  BOOST_CHECK_EQUAL(output.Data(), buffer.data());
-  BOOST_CHECK_EQUAL(output.Tellp(), &buffer.at(1));
+  BOOST_CHECK_EQUAL(output.size(), buffer.size());
+  BOOST_CHECK_EQUAL(output.data(), buffer.data());
+  BOOST_CHECK_EQUAL(output.tellp(), &buffer.at(1));
   BOOST_CHECK_NO_THROW(output.WriteData(&m_IPv4Array.at(1), 3));
-  BOOST_CHECK_EQUAL(output.Tellp(), buffer.end());
+  BOOST_CHECK_EQUAL(output.tellp(), buffer.end());
   BOOST_CHECK_THROW(output.Write<std::uint8_t>(1), std::length_error);
   BOOST_CHECK_EQUAL_COLLECTIONS(
       buffer.begin(),
@@ -124,17 +124,17 @@ BOOST_AUTO_TEST_CASE(NoBufferOutputByteStream)
  BOOST_CHECK_NO_THROW(output.Write<std::uint8_t>(255));
  BOOST_CHECK_THROW(output.Write<std::uint8_t>(1), std::length_error);
  BOOST_CHECK_THROW(output.SkipBytes(1), std::length_error);
- BOOST_CHECK_EQUAL(output.Size(), 4);
+ BOOST_CHECK_EQUAL(output.size(), 4);
 
  // Test output
- core::InputByteStream input(output.Data(), output.Size());
+ core::InputByteStream input(output.data(), output.size());
  BOOST_CHECK_EQUAL(input.Read<std::uint16_t>(), 65535);
  BOOST_CHECK_EQUAL(input.Read<std::uint8_t>(), 0);
  BOOST_CHECK_EQUAL(input.Read<std::uint8_t>(), 255);
  BOOST_CHECK_THROW(input.ReadBytes(1), std::length_error);
- BOOST_CHECK_EQUAL(input.Size(), 4);
+ BOOST_CHECK_EQUAL(input.size(), 4);
 
- BOOST_CHECK_EQUAL(std::memcmp(input.Data(), output.Data(), output.Size()), 0);
+ BOOST_CHECK_EQUAL(std::memcmp(input.data(), output.data(), output.size()), 0);
 }
 
 BOOST_AUTO_TEST_CASE(OutputByteStreamNonConstData)
@@ -142,9 +142,9 @@ BOOST_AUTO_TEST_CASE(OutputByteStreamNonConstData)
   core::OutputByteStream output(1);
   output.Write<std::uint8_t>(254);
   std::uint8_t const buf[1]{0xFF};
-  std::memcpy(output.Data(), buf, sizeof(buf));
+  std::memcpy(output.data(), buf, sizeof(buf));
   BOOST_CHECK_EQUAL(
-      core::InputByteStream::Read<std::uint8_t>(output.Data()), 255);
+      core::InputByteStream::Read<std::uint8_t>(output.data()), 255);
 }
 
 BOOST_AUTO_TEST_CASE(Bits16Test)

--- a/tests/unit_tests/core/util/byte_stream.cc
+++ b/tests/unit_tests/core/util/byte_stream.cc
@@ -90,8 +90,8 @@ BOOST_AUTO_TEST_CASE(InputByteStream)
   BOOST_CHECK_EQUAL_COLLECTIONS(
       input.Data(),
       input.Data() + input.Size(),
-      m_IPv4Array.data(),
-      m_IPv4Array.data() + m_IPv4Array.size());
+      m_IPv4Array.begin(),
+      m_IPv4Array.end());
 }
 
 BOOST_AUTO_TEST_CASE(OutputByteStream)
@@ -103,15 +103,15 @@ BOOST_AUTO_TEST_CASE(OutputByteStream)
   BOOST_CHECK_NO_THROW(output.Write<std::uint8_t>(m_IPv4Array.at(0)));
   BOOST_CHECK_EQUAL(output.Size(), buffer.size());
   BOOST_CHECK_EQUAL(output.Data(), buffer.data());
-  BOOST_CHECK_EQUAL(output.Tellp(), buffer.data() + 1);
+  BOOST_CHECK_EQUAL(output.Tellp(), &buffer.at(1));
   BOOST_CHECK_NO_THROW(output.WriteData(&m_IPv4Array.at(1), 3));
-  BOOST_CHECK_EQUAL(output.Tellp(), buffer.data() + buffer.size());
+  BOOST_CHECK_EQUAL(output.Tellp(), buffer.end());
   BOOST_CHECK_THROW(output.Write<std::uint8_t>(1), std::length_error);
   BOOST_CHECK_EQUAL_COLLECTIONS(
-      buffer.data(),
-      buffer.data() + buffer.size(),
-      m_IPv4Array.data(),
-      m_IPv4Array.data() + m_IPv4Array.size());
+      buffer.begin(),
+      buffer.end(),
+      m_IPv4Array.begin(),
+      m_IPv4Array.end());
 }
 
 BOOST_AUTO_TEST_CASE(NoBufferOutputByteStream)
@@ -197,10 +197,10 @@ BOOST_AUTO_TEST_CASE(AddressToByteVectorIPv4)
   auto const ip = core::AddressToByteVector(address);
   BOOST_CHECK_EQUAL(ip.size(), address.to_v4().to_bytes().size());
   BOOST_CHECK_EQUAL_COLLECTIONS(
-      ip.data(),
-      ip.data() + ip.size(),
-      m_IPv4Array.data(),
-      m_IPv4Array.data() + m_IPv4Array.size());
+      ip.begin(),
+      ip.end(),
+      m_IPv4Array.begin(),
+      m_IPv4Array.end());
   // Reconstruct a new address and check with original
   boost::asio::ip::address_v4::bytes_type bytes;
   std::memcpy(bytes.data(), ip.data(), address.to_v4().to_bytes().size());
@@ -215,10 +215,10 @@ BOOST_AUTO_TEST_CASE(AddressToByteVectorIPv6)
   auto const ip = core::AddressToByteVector(address);
   BOOST_CHECK_EQUAL(ip.size(), address.to_v6().to_bytes().size());
   BOOST_CHECK_EQUAL_COLLECTIONS(
-      ip.data(),
-      ip.data() + ip.size(),
-      m_IPv6Array.data(),
-      m_IPv6Array.data() + m_IPv6Array.size());
+      ip.begin(),
+      ip.end(),
+      m_IPv6Array.begin(),
+      m_IPv6Array.end());
   // Reconstruct a new address and check with original
   boost::asio::ip::address_v6::bytes_type bytes;
   std::memcpy(bytes.data(), ip.data(), address.to_v6().to_bytes().size());


### PR DESCRIPTION
Use counter as index into the internal stream buffer, and use member functions for access.

References #823

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

