### PR TITLE
Unit Tests: Fix build errors due to namespace issues

### DIFF
--- a/tests/unit_tests/client/proxy/http.cc
+++ b/tests/unit_tests/client/proxy/http.cc
@@ -253,6 +253,8 @@ BOOST_AUTO_TEST_CASE(ValidResponse)
 
 BOOST_AUTO_TEST_CASE(InvalidResponse)
 {
+  namespace client = kovri::client;
+
   client::HTTPResponse response(client::HTTPResponse::ok);
   BOOST_CHECK_THROW(
       response.set(static_cast<client::HTTPResponse::status_t>(12345)),

--- a/tests/unit_tests/core/router/info.cc
+++ b/tests/unit_tests/core/router/info.cc
@@ -33,6 +33,9 @@
 #include <boost/test/unit_test.hpp>
 
 #include "core/router/identity.h"
+#include "core/router/info.h"
+
+namespace core = kovri::core;
 
 struct RouterInfoFixture
 {

--- a/tests/unit_tests/core/util/buffer.cc
+++ b/tests/unit_tests/core/util/buffer.cc
@@ -34,6 +34,8 @@
 
 #include "core/util/buffer.h"
 
+namespace core = kovri::core;
+
 struct BufferFixture
 {
   core::Buffer<> buf;


### PR DESCRIPTION
Fix namespace resolution errors found after an initial clone and build with -DWITH_TESTS=ON. All unit tests now build and pass.


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

