### PR TITLE
Client: allow more hash types for server tunnel ACL

### DIFF
--- a/pkg/config/tunnels.conf
+++ b/pkg/config/tunnels.conf
@@ -97,30 +97,41 @@ dest_port = 110
 ;
 ;                  Examples:
 ;
-;                  - To only allow a certain address:
+;                  - To only allow a certain address, you can use the base32 address (with or without .b32.i2p domain) or base64 hash:
 ;
-;                      white_list = az33gdq36azgihuy6xvn4cqoqi5c4jwkmowqvk7doh7mjtqazpra
+;                      white_list = az33gdq36azgihuy6xvn4cqoqi5c4jwkmowqvk7doh7mjtqazpra.b32.i2p
+;
+;                          or
+;
+;                      white_list = hd7qflc64cul74t3s74ps2um45nbj5x43p3xh5bxaj2bzvtwu76a
+;
+;                          or
+;
+;                      white_list = 2nlfAJ8WhMoQc297OhMz0v4MzDPc8XBzIDoFPurbUpg=
 ;
 ;                  - To deny an address:
 ;
-;                      black_list = az33gdq36azgihuy6xvn4cqoqi5c4jwkmowqvk7doh7mjtqazpra
+;                      black_list = az33gdq36azgihuy6xvn4cqoqi5c4jwkmowqvk7doh7mjtqazpra.b32.i2p
 ;
+;                          or
+;
+;                      black_list = hd7qflc64cul74t3s74ps2um45nbj5x43p3xh5bxaj2bzvtwu76a
+;
+;                          or
+;
+;                      black_list = 2nlfAJ8WhMoQc297OhMz0v4MzDPc8XBzIDoFPurbUpg=
 ;
 ;                   Details:
 ;
-;                    - To allow white list access, have the known peer visit:
+;                    - To allow white list access, have the known peer do the following:
 ;
-;                        http://stats.i2p/cgi-bin/mydest
+;                       1. Visit http://check.kovri.i2p
+;                       2. Have them copy and paste either the given base64 hash or the base32 address
+;                       3. Have them privately send you *one* of these hashes
 ;
-;                    - and then have them privately send you the line:
+;                  - For multiple addresses, use comma-separated I2P addresses:
 ;
-;                       "Your Destination B32 is: <insert long base32 address>.b32.i2p"
-;
-;                    - then, remove '.b32.i2p' and replace <b32> in the white list
-;
-;                  For multiple address, use comma-separated I2P addresses (without '.b32.i2p', like above):
-;
-;                  white_list (or black_list) = address1,address2,address3,etc.
+;                      white_list (or black_list) = address1,address2,address3,etc.
 ;
 ;--------------------------------------------------------------------------------------
 

--- a/src/client/util/parse.h
+++ b/src/client/util/parse.h
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2013-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -44,7 +44,7 @@ namespace client {
 /// @brief Parses an ACL
 /// @param record String record of CSV
 /// @return Returns a std::set of the b32 of each value from the list
-const std::set<kovri::core::IdentHash> ParseACL(const std::string list);
+std::set<kovri::core::IdentHash> ParseACL(const std::string list);
 
 /// @brief Parse for multiple CSV destination(s) and also dest:port
 /// @details Free function used solely for configuration which shows that we

--- a/tests/unit_tests/client/util/parse.cc
+++ b/tests/unit_tests/client/util/parse.cc
@@ -74,6 +74,12 @@ BOOST_AUTO_TEST_CASE(Base32)
     acl += ident.ToBase32() + ",";
 }
 
+BOOST_AUTO_TEST_CASE(Base64)
+{
+  for (const auto& ident : idents)
+    acl += ident.ToBase64() + ",";
+}
+
 BOOST_AUTO_TEST_CASE(InvalidList)
 {
   std::uint8_t count(0);

--- a/tests/unit_tests/client/util/parse.cc
+++ b/tests/unit_tests/client/util/parse.cc
@@ -68,6 +68,12 @@ struct ParseACLFixture
 
 BOOST_FIXTURE_TEST_SUITE(ParseACL, ParseACLFixture)
 
+BOOST_AUTO_TEST_CASE(Base32)
+{
+  for (const auto& ident : idents)
+    acl += ident.ToBase32() + ",";
+}
+
 BOOST_AUTO_TEST_CASE(InvalidList)
 {
   std::uint8_t count(0);

--- a/tests/unit_tests/client/util/parse.cc
+++ b/tests/unit_tests/client/util/parse.cc
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(ParseACL)
 
       // Log valid b32
       const std::string b32 = hash.ToBase32();
-      LOG(debug) << "ParseACL: " << b32;
+      BOOST_TEST_MESSAGE(b32);
 
       // Construct malformed ACL delimiters
       // TODO(unassigned): extend test for malformed ACLs?
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(ParseACL)
     }
 
   // Log our malformed ACL
-  LOG(debug) << "ParseACL: " << acl;
+  BOOST_TEST_MESSAGE(acl);
 
   // Parse our malformed ACL
   auto const& parsed_idents = kovri::client::ParseACL(acl);

--- a/tests/unit_tests/client/util/parse.cc
+++ b/tests/unit_tests/client/util/parse.cc
@@ -74,6 +74,12 @@ BOOST_AUTO_TEST_CASE(Base32)
     acl += ident.ToBase32() + ",";
 }
 
+BOOST_AUTO_TEST_CASE(Base32Domain)
+{
+  for (const auto& ident : idents)
+    acl += ident.ToBase32() + ".b32.i2p,";
+}
+
 BOOST_AUTO_TEST_CASE(Base64)
 {
   for (const auto& ident : idents)

--- a/tests/unit_tests/client/util/parse.cc
+++ b/tests/unit_tests/client/util/parse.cc
@@ -80,6 +80,19 @@ BOOST_AUTO_TEST_CASE(Base64)
     acl += ident.ToBase64() + ",";
 }
 
+BOOST_AUTO_TEST_CASE(MixedRadix)
+{
+  std::size_t count(0);
+
+  for (const auto& ident : idents)
+    {
+      if (!count)
+        acl += ident.ToBase32() + ",";
+      acl += ident.ToBase64() + ",";
+      count++;
+    }
+}
+
 BOOST_AUTO_TEST_CASE(InvalidList)
 {
   std::uint8_t count(0);

--- a/tests/unit_tests/client/util/parse.cc
+++ b/tests/unit_tests/client/util/parse.cc
@@ -1,5 +1,5 @@
 /**                                                                                           //
- * Copyright (c) 2013-2017, The Kovri I2P Router Project                                      //
+ * Copyright (c) 2015-2018, The Kovri I2P Router Project                                      //
  *                                                                                            //
  * All rights reserved.                                                                       //
  *                                                                                            //
@@ -26,8 +26,6 @@
  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,          //
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF    //
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               //
- *                                                                                            //
- * Parts of the project are originally copyright (c) 2013-2015 The PurpleI2P Project          //
  */
 
 #include <boost/test/unit_test.hpp>


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Referencing #959.