### PR TITLE
Installer: Fix building package on Linux.

### DIFF
--- a/pkg/installers/kovri-install.sh
+++ b/pkg/installers/kovri-install.sh
@@ -296,7 +296,7 @@ CreatePackage()
         rsync -avR $_resource $staging_path 1>/dev/null
       done
     else
-      cp -R --parents $resources $staging_path
+      cp -R --parents ${resources[@]} $staging_path
     fi
     catch "could not copy resources for packaging"
 


### PR DESCRIPTION
Fixed invocation of the cp command. The Linux nightly package was almost empty,
it only contained pkg/client/, INSTALL.txt, and kovri-install.sh.

Signed-off-by: Tadeas Moravec <moravec.tadeas@gmail.com>


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

