### PR TITLE
Build: set make shell to bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@
 
 # Get custom Kovri data path + set appropriate CMake generator.
 # If no path is given, set default path
+SHELL := $(shell which bash)
 system := $(shell uname)
 ifeq ($(KOVRI_DATA_PATH),)
   ifeq ($(system), Linux)


### PR DESCRIPTION
Fixes build on systems with default non-bash shells.


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

