### PR TITLE
Crypto: remove ed25519 assertions

### DIFF
--- a/src/core/crypto/impl/cryptopp/signature.cc
+++ b/src/core/crypto/impl/cryptopp/signature.cc
@@ -45,7 +45,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <cstdint>
 #include <cstring>
 #include <memory>
@@ -844,8 +843,6 @@ class Ed25519Verifier::Ed25519VerifierImpl
     int const ret(CryptoPP::NaCl::crypto_sign_open(
         rm, &rmlen, sm.data(), sm.size(), m_Pk.data()));
 
-    assert(rmlen == mlen);
-
     return !ret;
   }
 
@@ -905,7 +902,6 @@ class Ed25519Signer::Ed25519SignerImpl
           CryptoPP::Exception::OTHER_ERROR, "could not ed25519 sign message");
 
     // We only want the signature
-    assert(sm.size() == smlen);
     std::copy(sm.begin(), sm.end() - mlen, signature);
   }
 


### PR DESCRIPTION
The verifier assertion won't allow the verifier to simply return, from
which we then throw accordingly. The signer assertion should be removed
because we throw on bad signing anyway.

Closes #981.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

