### PR TITLE
Core: use IPv6 address object when expected + add test cases

### DIFF
--- a/src/core/router/context.cc
+++ b/src/core/router/context.cc
@@ -140,7 +140,7 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
           const auto& address = boost::asio::ip::address::from_string(host);
 
           // NTCP
-          if (has_ntcp && !router.GetNTCPAddress(address.is_v6()))
+          if (has_ntcp && !router.GetAddress(address.is_v6(), Transport::NTCP))
             {
               LOG(debug)
                   << "RouterContext: NTCP was expected but no transport "
@@ -149,7 +149,7 @@ void RouterContext::Initialize(const boost::program_options::variables_map& map)
               router.AddAddress(std::make_tuple(Transport::NTCP, host, port));
             }
           // SSU
-          if (has_ssu && !router.GetSSUAddress(address.is_v6()))
+          if (has_ssu && !router.GetAddress(address.is_v6(), Transport::SSU))
             {
               LOG(debug)
                   << "RouterContext: SSU was expected but no transport "
@@ -278,7 +278,7 @@ bool RouterContext::AddIntroducer(
     const kovri::core::RouterInfo& routerInfo,
     std::uint32_t tag) {
   bool ret = false;
-  auto address = routerInfo.GetSSUAddress();
+  const auto* address = routerInfo.GetV4Address(Transport::SSU);
   if (address) {
     ret = m_RouterInfo.AddIntroducer(address, tag);
     if (ret)

--- a/src/core/router/info.h
+++ b/src/core/router/info.h
@@ -546,13 +546,27 @@ class RouterInfo : public RouterInfoTraits, public RoutingDestination
 
   // TODO(anonimal): template address getter
 
-  /// @return Address object capable of NTCP
-  /// @param has_v6 Address should have v6 capability
-  const Address* GetNTCPAddress(bool has_v6 = false) const;
+  /// @return V6-only address object
+  /// @param transport Given transport (NTCP or SSU)
+  const Address* GetV6Address(const Transport transport) const;
 
-  /// @return Address object capable of SSU
-  /// @param has_v6 Address should have v6 capability
-  const Address* GetSSUAddress(bool has_v6 = false) const;
+  /// @return V4-only address object
+  /// @param transport Given transport (NTCP or SSU)
+  const Address* GetV4Address(const Transport transport) const;
+
+  /// @return Any available address object
+  /// @param prefer_v6 Give preference to IPv6 object but return IPv4 if IPv6 is unavailable
+  /// @param transport Given transport (NTCP or SSU)
+  const Address* GetAnyAddress(
+      const bool prefer_v6,
+      const Transport transport) const;
+
+  /// @return Address object, IPv4 only unless otherwise specified
+  /// @param require_v6 Require that an IPv6-only object is returned
+  /// @param transport Given transport (NTCP or SSU)
+  const Address* GetAddress(
+      const bool require_v6,
+      const Transport transport) const;
 
  public:
   /// @return Pointer to RI buffer

--- a/src/core/router/transports/impl.cc
+++ b/src/core/router/transports/impl.cc
@@ -366,13 +366,15 @@ bool Transports::ConnectToPeerNTCP(Peer& peer)
   LOG(debug)
     << "Transports: attempting NTCP for peer"
     << GetFormattedSessionInfo(peer.router);
-  const auto* address = peer.router->GetNTCPAddress(context.SupportsV6());
-  // No NTCP address found
-  if (!address)
-    return false;
 
-  // TODO(anonimal): We should expect to have an address specified when NTCP is enabled/allowed
-  assert(!address->host.is_unspecified());
+  const auto* address =
+      peer.router->GetAnyAddress(context.SupportsV6(), Transport::NTCP);
+
+  if (!address)
+    {
+      LOG(warning) << "Transports: no NTCP address found";
+      return false;
+    }
 
   if (!address->host.is_unspecified()) {
     if (!peer.router->UsesIntroducer() && !peer.router->IsUnreachable()) {

--- a/src/core/router/transports/impl.h
+++ b/src/core/router/transports/impl.h
@@ -115,7 +115,7 @@ const std::uint32_t LOW_BANDWIDTH_LIMIT = 32 * 1024;  // 32KBps
 /// @class Transports
 /// @brief Provides functions to pass messages to a given peer.
 ///        Manages the SSU and NTCP transports.
-class Transports {
+class Transports : public core::RouterInfoTraits {
  public:
   Transports();
 

--- a/src/core/router/transports/ssu/data.cc
+++ b/src/core/router/transports/ssu/data.cc
@@ -35,6 +35,7 @@
 #include <boost/bind.hpp>
 #include <boost/endian/conversion.hpp>
 
+#include "core/router/info.h"
 #include "core/router/net_db/impl.h"
 #include "core/router/transports/ssu/server.h"
 
@@ -94,7 +95,10 @@ void SSUData::Stop() {
 void SSUData::AdjustPacketSize(
     const kovri::core::RouterInfo& remote_router) {
   LOG(debug) << "SSUData: adjusting packet size";
-  auto ssu_address = remote_router.GetSSUAddress();
+
+  const auto* ssu_address =
+      remote_router.GetAddress(m_Session.IsV6(), Transport::SSU);
+
   if (ssu_address && ssu_address->mtu) {
     if (m_Session.IsV6 ())
       m_PacketSize =

--- a/src/core/router/transports/ssu/data.h
+++ b/src/core/router/transports/ssu/data.h
@@ -117,7 +117,7 @@ struct SentMessage {
 };
 
 class SSUSession;
-class SSUData {
+class SSUData : public RouterInfoTraits {
  public:
   SSUData(
       SSUSession& session);

--- a/src/core/router/transports/ssu/server.cc
+++ b/src/core/router/transports/ssu/server.cc
@@ -388,7 +388,7 @@ std::shared_ptr<SSUSession> SSUServer::FindSession(
   LOG(debug) << "SSUServer: finding session from RI";
   if (!router)
     return nullptr;
-  auto address = router->GetSSUAddress();  // v4 only
+  auto* address = router->GetV4Address(Transport::SSU);
   if (!address)
     return nullptr;
   auto session =
@@ -396,7 +396,7 @@ std::shared_ptr<SSUSession> SSUServer::FindSession(
   if (session || !context.SupportsV6())
     return session;
   // try v6
-  address = router->GetSSUAddress(true);
+  address = router->GetV6Address(Transport::SSU);
   if (!address)
     return nullptr;
   return FindSession(boost::asio::ip::udp::endpoint(address->host, address->port));
@@ -419,7 +419,7 @@ std::shared_ptr<SSUSession> SSUServer::GetSession(
   LOG(debug) << "SSUServer: getting session";
   std::shared_ptr<SSUSession> session;
   if (router) {
-    auto address = router->GetSSUAddress(context.SupportsV6());
+    const auto* address = router->GetAnyAddress(context.SupportsV6(), Transport::SSU);
     if (address) {
       boost::asio::ip::udp::endpoint remote_endpoint(
           address->host,

--- a/src/core/router/transports/ssu/server.h
+++ b/src/core/router/transports/ssu/server.h
@@ -63,7 +63,7 @@ struct RawSSUPacket {
   std::size_t len{};
 };
 
-class SSUServer {
+class SSUServer : public core::RouterInfoTraits {
  public:
   SSUServer(boost::asio::io_service& service, const std::size_t port);
 

--- a/src/core/router/transports/ssu/session.h
+++ b/src/core/router/transports/ssu/session.h
@@ -127,9 +127,10 @@ struct SSUSessionPacket  // TODO(unassigned): finish
 };
 
 class SSUServer;
-class SSUSession
-    : public TransportSession,
-      public std::enable_shared_from_this<SSUSession> {
+class SSUSession : public RouterInfoTraits,
+                   public TransportSession,
+                   public std::enable_shared_from_this<SSUSession>
+{
  public:
   SSUSession(
       SSUServer& server,

--- a/tests/unit_tests/core/router/info.cc
+++ b/tests/unit_tests/core/router/info.cc
@@ -31,8 +31,9 @@
 #include "tests/unit_tests/main.h"
 
 #include "core/router/identity.h"
+#include "core/router/info.h"
 
-struct RouterInfoFixture
+struct RouterInfoFixture : public core::RouterInfoTraits
 {
   core::PrivateKeys keys = core::PrivateKeys::CreateRandomKeys(
       core::SIGNING_KEY_TYPE_EDDSA_SHA512_ED25519);
@@ -52,5 +53,108 @@ BOOST_AUTO_TEST_CASE(InvalidSignature)
   BOOST_CHECK_THROW(router.Verify(), std::exception);
   BOOST_CHECK_THROW(router.CreateBuffer(keys), std::exception);
 }
+
+BOOST_AUTO_TEST_CASE(IPv4)
+{
+  core::RouterInfo ri(keys, {{"127.0.0.1", 12345}}, {true, true});
+
+  // Yes ipv4
+  BOOST_CHECK_EQUAL(ri.HasNTCP(), true);
+  BOOST_CHECK_EQUAL(ri.HasSSU(), true);
+
+  // No ipv6
+  // TODO(unassigned): logic would dictate that we only allow true for ipv6 capable
+  //   but our current implementation doesn't allow this (these should return false)
+  BOOST_CHECK_EQUAL(ri.HasNTCP(true), true);
+  BOOST_CHECK_EQUAL(ri.HasSSU(true), true);
+  //
+  BOOST_CHECK_EQUAL(ri.HasV6(), false);
+}
+
+BOOST_AUTO_TEST_CASE(IPv6)
+{
+  core::RouterInfo ri(keys, {{"::1", 12345}}, {true, true});
+
+  // No ipv4
+  BOOST_CHECK_EQUAL(ri.HasNTCP(), false);
+  BOOST_CHECK_EQUAL(ri.HasSSU(), false);
+
+  // Yes ipv6
+  BOOST_CHECK_EQUAL(ri.HasNTCP(true), true);
+  BOOST_CHECK_EQUAL(ri.HasSSU(true), true);
+  BOOST_CHECK_EQUAL(ri.HasV6(), true);
+}
+
+BOOST_AUTO_TEST_CASE(GetAddress)
+{
+  core::RouterInfo ri(
+      keys, {{"127.0.0.1", 54321}, {"::1", 12345}}, {true, true});
+
+  // Yes ipv4
+  BOOST_CHECK_NE(ri.GetV4Address(Transport::NTCP), nullptr);
+  BOOST_CHECK_NE(ri.GetV4Address(Transport::SSU), nullptr);
+
+  // Yes ipv6
+  BOOST_CHECK_NE(ri.GetV6Address(Transport::NTCP), nullptr);
+  BOOST_CHECK_NE(ri.GetV6Address(Transport::SSU), nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(GetAddressIPv4only)
+{
+  core::RouterInfo ri(keys, {{"127.0.0.1", 54321}}, {true, true});
+
+  // Yes ipv4
+  BOOST_CHECK_NE(ri.GetV4Address(Transport::NTCP), nullptr);
+  BOOST_CHECK_NE(ri.GetV4Address(Transport::SSU), nullptr);
+
+  BOOST_CHECK_NE(ri.GetAddress(false, Transport::NTCP), nullptr);
+  BOOST_CHECK_NE(ri.GetAddress(false, Transport::SSU), nullptr);
+
+  BOOST_CHECK_NE(ri.GetAnyAddress(false, Transport::NTCP), nullptr);
+  BOOST_CHECK_NE(ri.GetAnyAddress(false, Transport::SSU), nullptr);
+
+  // No ipv6
+  BOOST_CHECK_EQUAL(ri.GetV6Address(Transport::NTCP), nullptr);
+  BOOST_CHECK_EQUAL(ri.GetV6Address(Transport::SSU), nullptr);
+
+  BOOST_CHECK_EQUAL(ri.GetAddress(true, Transport::NTCP), nullptr);
+  BOOST_CHECK_EQUAL(ri.GetAddress(true, Transport::SSU), nullptr);
+
+  BOOST_CHECK_NE(ri.GetAnyAddress(true, Transport::NTCP), nullptr);
+  BOOST_CHECK_NE(ri.GetAnyAddress(true, Transport::SSU), nullptr);
+
+  BOOST_CHECK_EQUAL(ri.GetAnyAddress(true, Transport::NTCP)->host.is_v6(), false);
+  BOOST_CHECK_EQUAL(ri.GetAnyAddress(true, Transport::SSU)->host.is_v6(), false);
+}
+
+BOOST_AUTO_TEST_CASE(GetAddressIPv6only)
+{
+  core::RouterInfo ri(keys, {{"::1", 54321}}, {true, true});
+
+  // No ipv4
+  BOOST_CHECK_EQUAL(ri.GetV4Address(Transport::NTCP), nullptr);
+  BOOST_CHECK_EQUAL(ri.GetV4Address(Transport::SSU), nullptr);
+
+  BOOST_CHECK_EQUAL(ri.GetAddress(false, Transport::NTCP), nullptr);
+  BOOST_CHECK_EQUAL(ri.GetAddress(false, Transport::SSU), nullptr);
+
+  BOOST_CHECK_EQUAL(ri.GetAnyAddress(false, Transport::NTCP), nullptr);
+  BOOST_CHECK_EQUAL(ri.GetAnyAddress(false, Transport::SSU), nullptr);
+
+  // Yes ipv6
+  BOOST_CHECK_NE(ri.GetV6Address(Transport::NTCP), nullptr);
+  BOOST_CHECK_NE(ri.GetV6Address(Transport::SSU), nullptr);
+
+  BOOST_CHECK_NE(ri.GetAddress(true, Transport::NTCP), nullptr);
+  BOOST_CHECK_NE(ri.GetAddress(true, Transport::SSU), nullptr);
+
+  BOOST_CHECK_NE(ri.GetAnyAddress(true, Transport::NTCP), nullptr);
+  BOOST_CHECK_NE(ri.GetAnyAddress(true, Transport::SSU), nullptr);
+
+  BOOST_CHECK_EQUAL(ri.GetAnyAddress(true, Transport::NTCP)->host.is_v6(), true);
+  BOOST_CHECK_EQUAL(ri.GetAnyAddress(true, Transport::SSU)->host.is_v6(), true);
+}
+
+// TODO(unassigned): expand test cases
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

Resolves #840.

Note: this PR decided to side-step most of the pre-fork issues mentioned in https://github.com/monero-project/kovri/issues/840#issuecomment-406165876 in favor of resolving a few immediate ones (including the adjusting of appropriate SSU packet size).