### PR TITLE
Makefile: fix doxygen target (requires CMake)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ fuzz-tests: deps
 
 # Produce Doxygen documentation
 doxygen:
-	$(eval cmake-kovri += $(cmake-doxygen))
+	$(eval cmake-kovri += $(cmake) $(cmake-doxygen))
 	$(call CMAKE,$(build),$(cmake-kovri)) && $(MAKE) -C $(build) doc
 
 # Produce available CMake build options


### PR DESCRIPTION
Because of how our nightly builds are rigged, the build will "fail" when
running `make doxygen`, so this fix can't wait until after release.

We don't need another rc when this is merged because this is only needed for buildbot and the website. We can go directly to release next week (pending any other unforeseen issues).

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

