### PR TITLE
NetDB: correct floodfill context option

### DIFF
--- a/src/core/router/context.h
+++ b/src/core/router/context.h
@@ -147,7 +147,7 @@ class RouterContext : public RouterInfoTraits, public GarlicDestination {
   // @return true if we are a floodfill router otherwise false
   bool IsFloodfill() const
   {
-    return m_Opts["floodfill"].as<bool>();
+    return m_Opts["enable-floodfill"].as<bool>();
   }
 
   // @return true if we are going to accept tunnels right now.


### PR DESCRIPTION
Prevents boost::bad_any_cast by using the correct variable_map entry.
Resolves #990

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

