### PR TITLE
SSUSession: get either IPv4/6 intro key from remote

### DIFF
--- a/src/core/router/transports/ssu/session.cc
+++ b/src/core/router/transports/ssu/session.cc
@@ -1655,7 +1655,7 @@ const std::uint8_t* SSUSession::GetIntroKey() const
     {
       LOG(debug) << "SSUSession: " << __func__ << ": using remote's key";
       auto* const address =
-          m_RemoteRouter->GetAddress(m_RemoteRouter->HasV6(), Transport::SSU);
+          m_RemoteRouter->GetAnyAddress(m_RemoteRouter->HasV6(), Transport::SSU);
       assert(address);  // TODO(anonimal): SSU should be guaranteed
       return address->key;
     }


### PR DESCRIPTION
---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---


Resolves #997 (should).

As for the need to throw for all null deference checks, I'll provide a better solution when I return so we don't have to litter the code with throws for every pointer.