### PR TITLE
Build: remove aggressive optimizations for clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,8 @@ endif()
 #   The issue is not reproducible with Debug build type. See #993.
 #   Absolutely resolve this hack when are out of out Alpha, or no later than Beta.
 if (CLANG)
-  set(CMAKE_BUILD_TYPE Debug)
+  # Remove aggressive optimizations from release builds. Referencing #993
+  string(REPLACE "-O3" "-O1" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 endif()
 
 # Require C++14 support (minimum version compilers guarantee this)


### PR DESCRIPTION
Clang release builds are too aggressive with `-O3` optimizations, and cause runtime errors.
Allows for Clang release builds, referencing #993.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

