### PR TITLE
AddressBook: move subscription saving to storage

### DIFF
--- a/src/client/address_book/impl.h
+++ b/src/client/address_book/impl.h
@@ -174,12 +174,10 @@ class AddressBook : public AddressBookDefaults {
   /// @brief Saves subscription to address book
   /// @details Saves to subscription file if file does not exist or we have fresh download
   /// @param stream Reference to file stream of hosts (subscription)
-  /// @param file_name Optional filename to write to (used for multiple subscriptions)
+  /// @param sub Subscription type for where to store addresses
   /// @return True if subscription was successfully loaded
   /// @warning Must validate before saving
-  bool SaveSubscription(
-      std::istream& stream,
-      std::string file_name = "");
+  bool SaveSubscription(std::istream& stream, SubscriptionType sub);
 
   /// @brief Validates subscription, saves hosts to file
   /// @param stream Stream to process

--- a/src/client/address_book/storage.cc
+++ b/src/client/address_book/storage.cc
@@ -146,5 +146,31 @@ std::size_t AddressBookStorage::Save(const AddressMap& addresses)
   return num;
 }
 
+std::size_t AddressBookStorage::SaveSubscription(
+    const std::map<std::string, kovri::core::IdentityEx>& addresses,
+    SubscriptionType sub)
+{
+  std::size_t num = 0;
+  auto filename = core::GetPath(core::Path::AddressBook)/ GetSubscriptionFilename(sub);
+  LOG(debug) << "AddressBookStorage: opening subscription file " << filename;
+  std::ofstream file(filename.string(), std::ofstream::out);
+  if (!file)
+    {
+      LOG(error) << "AddressBookStorage: can't open subscription " << filename;
+    }
+  else
+    {
+      for (auto const& it : addresses)
+        {
+          file << it.first << "=" << it.second.ToBase64() << std::endl;
+          num++;
+        }
+      LOG(info) << "AddressBookStorage: " << num << " addresses saved";
+    }
+  // Flush subscription file
+  file << std::flush;
+  return num;
+}
+
 }  // namespace client
 }  // namespace kovri

--- a/src/client/address_book/storage.h
+++ b/src/client/address_book/storage.h
@@ -115,6 +115,21 @@ struct AddressBookDefaults {
     return "hosts.txt";
   }
 
+  std::string GetSubscriptionFilename(const SubscriptionType sub) const {
+    switch(sub)
+    {
+      case SubscriptionType::Default:
+        return "hosts.txt";
+      case SubscriptionType::User:
+        return "user_hosts.txt";
+      case SubscriptionType::Private:
+        return "private_hosts.txt";
+      default:
+        LOG(error) << __func__ << ": unknown subscription type";
+        return "";
+    }
+  }
+
   /// @brief Gets addresses file (file list of saved addresses)
   /// @return Default addresses filename
   /// @notes Currently only used to verify that addresses have indeed been saved
@@ -161,6 +176,13 @@ class AddressBookStorage : public AddressBookDefaults {
   /// @return Number of addresses saved
   /// @param addresses Const reference to map of human-readable address to b32 hashes of address
   std::size_t Save(const AddressMap& addresses);
+
+  /// @brief Saves subscriptions to file in hosts.txt format
+  /// @return Number of addresses saved
+  /// @param addresses Const reference to map of human-readable address to full router identity
+  std::size_t SaveSubscription(
+      const std::map<std::string, kovri::core::IdentityEx>& addresses,
+      SubscriptionType sub);
 
  private:
   /// @return Address book path with appended addresses location


### PR DESCRIPTION
Save subscriptions based on type, and move I/O to AddressBookStorage. ~~~Makes the default `hosts.txt` read-only.~~~

Resolves #1006

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

