### PR TITLE
Util: report router status

### DIFF
--- a/src/client/api/i2p_control/session.cc
+++ b/src/client/api/i2p_control/session.cc
@@ -241,8 +241,9 @@ void I2PControlSession::HandleRouterInfo(
     {
       switch (pair.first)
         {
-          case RouterInfo::Status:  // TODO(unassigned): implement
-            response->SetParam(pair.first, std::string("???"));
+          case RouterInfo::Status:
+            response->SetParam(
+                pair.first, core::context.GetState(core::context.GetState()));
             break;
 
           case RouterInfo::Uptime:

--- a/src/core/router/context.h
+++ b/src/core/router/context.h
@@ -103,6 +103,22 @@ class RouterContext : public RouterInfoTraits, public GarlicDestination {
     return m_State;
   }
 
+  /// @return Router state
+  std::string GetState(RouterState state) const noexcept
+  {
+    switch (state)
+      {
+        case RouterState::OK:
+          return "OK";
+        case RouterState::Testing:
+          return "Testing";
+        case RouterState::Firewalled:
+          return "Firewalled";
+        default:
+          return "Unknown";
+      }
+  }
+
   /// @brief Set context state
   // @param status the new state this context will have
   void SetState(RouterState state) noexcept


### PR DESCRIPTION
Uses kovri-util to report current router status.

Resolves implementation TODO.

---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

